### PR TITLE
deny missing docs for public api

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,3 +1,12 @@
+//! configuration
+
+#![deny(non_upper_case_globals)]
+#![deny(non_camel_case_types)]
+#![deny(non_snake_case)]
+#![deny(unused_mut)]
+// FIXME: doc the config
+// #![deny(missing_docs)]
+
 extern crate toml;
 extern crate serde_json;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,12 @@
+//! core
+
+#![deny(non_upper_case_globals)]
+#![deny(non_camel_case_types)]
+#![deny(non_snake_case)]
+#![deny(unused_mut)]
+#![deny(missing_docs)]
+
+/// core greeting
 pub fn greetings() -> String {
     println!("Hello from core!");
     String::from("Hello from core!")

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -1,3 +1,12 @@
+//! crypto
+
+#![deny(non_upper_case_globals)]
+#![deny(non_camel_case_types)]
+#![deny(non_snake_case)]
+#![deny(unused_mut)]
+#![deny(missing_docs)]
+
+/// crypto greeting
 pub fn greetings() -> String {
     println!("Hello from crypto!");
     String::from("Hello from crypto!")

--- a/data_structures/src/lib.rs
+++ b/data_structures/src/lib.rs
@@ -1,3 +1,12 @@
+//! data structures
+
+#![deny(non_upper_case_globals)]
+#![deny(non_camel_case_types)]
+#![deny(non_snake_case)]
+#![deny(unused_mut)]
+#![deny(missing_docs)]
+
+/// data greeting
 pub fn greetings() -> String {
     println!("Hello from data structures!");
     String::from("Hello from data structures!")

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,3 +1,12 @@
+//! p2p
+
+#![deny(non_upper_case_globals)]
+#![deny(non_camel_case_types)]
+#![deny(non_snake_case)]
+#![deny(unused_mut)]
+#![deny(missing_docs)]
+
+/// p2p greeting
 pub fn greetings() -> String {
     println!("Hello from p2p!");
     String::from("Hello from p2p!")

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,3 +1,12 @@
+//! storage
+
+#![deny(non_upper_case_globals)]
+#![deny(non_camel_case_types)]
+#![deny(non_snake_case)]
+#![deny(unused_mut)]
+#![deny(missing_docs)]
+
+/// storage greeting
 pub fn greetings() -> String {
     println!("Hello from storage!");
     String::from("Hello from storage!")


### PR DESCRIPTION
Force contributors to write docs for public api(but you still by-pass by applying `#[allow(missing_docs]` onto certain items), it'll benefit both developing and contributing.
r? @aesedepece 