### PR TITLE
WIP: feat(service): add counter service example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ witnet_crypto = { path = "./crypto" }
 witnet_data_structures = { path = "./data_structures" }
 witnet_p2p = { path = "./p2p" }
 witnet_storage = { path = "./storage" }
+threadpool = "1.7.1"
 
 [profile.dev]
 opt-level = 0

--- a/examples/counter_service.rs
+++ b/examples/counter_service.rs
@@ -1,0 +1,12 @@
+extern crate witnet;
+
+use witnet::services::counter;
+
+fn main() {
+    let c = counter::start(0);
+
+    println!("Get count: {:?}", counter::get(&c));
+    println!("Set count to 10: {:?}", counter::set(&c, 10));
+    println!("Get count: {:?}", counter::get(&c));
+    println!("Stop counter: {:?}", counter::stop(&c));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod cli;
+pub mod server;
+pub mod services;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,9 @@ use witnet_config as config;
 
 use std::process::exit;
 
-mod cli;
-mod server;
+pub mod cli;
+pub mod server;
+pub mod services;
 
 fn main() {
     env_logger::init();

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,0 +1,77 @@
+pub mod counter {
+    use std::thread;
+    use std::sync::mpsc::{sync_channel, channel, Sender, SyncSender};
+
+    enum Command {
+        Get,
+        Set(u32),
+        Stop
+    }
+
+    #[derive(Debug, PartialEq)]
+    pub enum Answer {
+        Count(u32),
+        Nothing
+    }
+
+    pub struct CounterState {
+        count: u32
+    }
+
+    pub struct Counter {
+        sender: Sender<(SyncSender<Answer>, Command)>,
+        _handle: thread::JoinHandle<()>,
+    }
+
+    pub fn start(count: u32) -> Counter {
+        let (sender, receiver) = channel();
+        let handle = thread::spawn(move || {
+            println!("Starting counter service...");
+            let mut state = CounterState { count: count };
+
+            loop {
+                let cmd: (SyncSender<Answer>, Command) = receiver.recv().unwrap();
+
+                match cmd {
+                    (ch, Command::Get) => {
+                        ch.send(Answer::Count(state.count)).unwrap();
+                    },
+                    (ch, Command::Set(count)) => {
+                        let old_count = state.count;
+                        state.count = count;
+                        ch.send(Answer::Count(old_count)).unwrap();
+                    },
+                    (ch, Command::Stop) => {
+                        ch.send(Answer::Nothing).unwrap();
+                        break;
+                    }
+                }
+            }
+            println!("Stopping counter service...");
+        });
+
+        Counter {
+            sender: sender,
+            _handle: handle
+        }
+    }
+
+    fn query(counter: &Counter, cmd: Command) -> Answer {
+        let (sender, receiver) = sync_channel(0);
+        counter.sender.send((sender, cmd)).unwrap();
+
+        receiver.recv().unwrap()
+    }
+
+    pub fn get(counter: &Counter) -> Answer {
+        query(counter, Command::Get)
+    }
+
+    pub fn set(counter: &Counter, count: u32) -> Answer {
+        query(counter, Command::Set(count))
+    }
+
+    pub fn stop(counter: &Counter) {
+        query(counter, Command::Stop);
+    }
+}


### PR DESCRIPTION
*IMPORTANT*: Do not merge, this is just an example to show one way to structure services in the application.

add example of a counter running in its own thread. communication with
that thread occurs via message-passing. to see a demo look into
`examples/counter_service.rs` file and to run it execute:

`cargo run --example counter_service`

this is a minimal example and doesn't take into account proper error
handling, nor timeouts handling to avoid indefinitely blocks in threads.