### PR TITLE
ci(travis): run clippy only in nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
 
 script:
     - rustup update
-    - rustup component add clippy-preview
-    - cargo clippy --all-targets --all-features -- -D warnings
+    - if [[ $TRAVIS_RUST_VERSION == "nightly" ]];
+        then rustup component add clippy-preview && cargo clippy --all-targets --all-features -- -D warnings;
+      fi #FIXME: remove after next beta release
     - cargo test --all --verbose


### PR DESCRIPTION
This PR is a workaround it is not possible to `#[allow(clippy)]` in both beta and nightly versions.

In the nightly version, the following works
```
#![feature(tool_lints)]
#![allow(clippy::all)]
```
However, in the beta version, `features` are not supported and the allow does not work.

In the near future, once the nightly becomes a beta, then this workaround should be removed.

More info can be found [here](https://github.com/rust-lang/rust/pull/54358).