### PR TITLE
fix(travis): Switch to beta Rust version (1.31)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: cargo
 dist: trusty
 sudo: false
 rust:
-  - nightly-2018-10-31 # FIXME: move to beta once 1.31 enters beta channel
+  - beta
 
 addons:
   apt:
@@ -29,3 +29,4 @@ before_script:
 
 script:
     - just travis
+

--- a/data_structures/src/lib.rs
+++ b/data_structures/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(try_from)]
 // To enable `#[allow(clippy::all)]`
 //#![feature(tool_lints)]
 

--- a/data_structures/src/serializers.rs
+++ b/data_structures/src/serializers.rs
@@ -1,4 +1,4 @@
-use std::convert::{Into, TryFrom};
+use std::convert::Into;
 extern crate flatbuffers;
 
 use crate::flatbuffers::protocol_generated::protocol::{
@@ -104,7 +104,13 @@ struct VersionWitnetArgs {
     version: u32,
 }
 
-impl TryFrom<Vec<u8>> for Message {
+pub trait MyTryFrom<T>: Sized {
+    type Error;
+
+    fn try_from(value: T) -> Result<Self, Self::Error>;
+}
+
+impl MyTryFrom<Vec<u8>> for Message {
     type Error = &'static str;
     // type Error = Err<&'static str>;
     fn try_from(bytes: Vec<u8>) -> Result<Self, &'static str> {

--- a/data_structures/src/serializers.rs
+++ b/data_structures/src/serializers.rs
@@ -104,13 +104,13 @@ struct VersionWitnetArgs {
     version: u32,
 }
 
-pub trait MyTryFrom<T>: Sized {
+pub trait TryFrom<T>: Sized {
     type Error;
 
     fn try_from(value: T) -> Result<Self, Self::Error>;
 }
 
-impl MyTryFrom<Vec<u8>> for Message {
+impl TryFrom<Vec<u8>> for Message {
     type Error = &'static str;
     // type Error = Err<&'static str>;
     fn try_from(bytes: Vec<u8>) -> Result<Self, &'static str> {

--- a/data_structures/tests/lib.rs
+++ b/data_structures/tests/lib.rs
@@ -1,4 +1,2 @@
-#![feature(try_from)]
-
 pub mod flatbuffers;
 pub mod serializers;

--- a/data_structures/tests/serializers.rs
+++ b/data_structures/tests/serializers.rs
@@ -1,6 +1,6 @@
 use witnet_data_structures::types;
 
-use witnet_data_structures::serializers::MyTryFrom;
+use witnet_data_structures::serializers::TryFrom;
 
 #[test]
 fn message_ping_to_bytes() {

--- a/data_structures/tests/serializers.rs
+++ b/data_structures/tests/serializers.rs
@@ -1,8 +1,6 @@
-#![feature(try_from)]
-
 use witnet_data_structures::types;
 
-use std::convert::TryFrom;
+use witnet_data_structures::serializers::MyTryFrom;
 
 #[test]
 fn message_ping_to_bytes() {


### PR DESCRIPTION
The minimum Rust version required for this project is 1.31 because of the use of the 2018 edition.

This PR changes the version from nightly to beta, and removes the use of the unstable `try_from` feature (only available in nightly), which is replaced with a `TryFrom` in `data_structures/src/serializers.rs`, at least until `try_from` is stabilized:

```rust
pub trait TryFrom<T>: Sized {
    type Error;

    fn try_from(value: T) -> Result<Self, Self::Error>;
}
```

To switch between the std `TryFrom` and "our" `TryFrom`, just change the import:

```rust
//use std::convert::TryFrom;
use witnet_data_structures::serializers::TryFrom;
```
