### PR TITLE
chore(config doc): Document config fields and default values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Cargo.lock
 
 # Ignore rocksdb default storage path
 .wit/
+
+# Ignore generated documentation
+site

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -28,7 +28,9 @@ pub mod loaders;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Config {
     #[serde(default = "Config::default_connections")]
+    /// Connections-specific configuration
     pub connections: ConnectionsConfig,
+    /// Storage-specific configuration
     #[serde(default = "Config::default_storage")]
     pub storage: StorageConfig,
 }
@@ -37,12 +39,25 @@ pub struct Config {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ConnectionsConfig {
     #[serde(default = "ConnectionsConfig::default_server_addr")]
+    /// Server address, that is, the socket address (interface ip and
+    /// port) to which the server accepting connections from other
+    /// peers should bind to
     pub server_addr: SocketAddr,
+
     #[serde(default = "ConnectionsConfig::default_inbound_limit")]
+    /// Maximum number of concurrent connections the server should
+    /// accept
     pub inbound_limit: u16,
+
     #[serde(default = "ConnectionsConfig::default_outbound_limit")]
+    /// Maximum number of opened connections to other peers this node
+    /// (acting as a client) should maintain
     pub outbound_limit: u16,
+
     #[serde(default = "ConnectionsConfig::default_known_peers")]
+    /// List of other peer addresses this node knows at start, it is
+    /// used as a bootstrap mechanism to gain access to the P2P
+    /// network
     pub known_peers: Vec<SocketAddr>,
 }
 
@@ -50,15 +65,18 @@ pub struct ConnectionsConfig {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct StorageConfig {
     #[serde(default = "StorageConfig::default_db_path")]
+    /// Path to the directory that will contain the storage-database files
     pub db_path: PathBuf,
 }
 
 impl Config {
-    fn default_connections() -> ConnectionsConfig {
+    /// Default connections-specific configuration
+    pub fn default_connections() -> ConnectionsConfig {
         ConnectionsConfig::default()
     }
 
-    fn default_storage() -> StorageConfig {
+    /// Default storage-specific configuration
+    pub fn default_storage() -> StorageConfig {
         StorageConfig::default()
     }
 }
@@ -73,19 +91,23 @@ impl Default for Config {
 }
 
 impl ConnectionsConfig {
-    fn default_server_addr() -> SocketAddr {
+    /// Default `server_addr` value (`127.0.0.1:21337`)
+    pub fn default_server_addr() -> SocketAddr {
         "127.0.0.1:21337".parse().unwrap()
     }
 
-    fn default_inbound_limit() -> u16 {
+    /// Default `inbound_limit` value (`128`)
+    pub fn default_inbound_limit() -> u16 {
         128
     }
 
-    fn default_outbound_limit() -> u16 {
+    /// Default `outbound_limit` value (`8`)
+    pub fn default_outbound_limit() -> u16 {
         8
     }
 
-    fn default_known_peers() -> Vec<SocketAddr> {
+    /// Default `known_peers` value (`[]`)
+    pub fn default_known_peers() -> Vec<SocketAddr> {
         Vec::default()
     }
 }
@@ -102,7 +124,8 @@ impl Default for ConnectionsConfig {
 }
 
 impl StorageConfig {
-    fn default_db_path() -> PathBuf {
+    /// Default `db_path` value (`.wit`)
+    pub fn default_db_path() -> PathBuf {
         PathBuf::from(".wit")
     }
 }

--- a/core/src/actors/config_manager.rs
+++ b/core/src/actors/config_manager.rs
@@ -2,7 +2,7 @@ use actix::{
     fut::FutureResult, Actor, ActorFuture, AsyncContext, Context, ContextFutureSpawner, Handler,
     MailboxError, Message, Supervised, System, SystemService, WrapFuture,
 };
-use log::debug;
+use log::{debug, info};
 use std::io;
 use std::path::PathBuf;
 use witnet_config::loaders::toml;
@@ -18,7 +18,11 @@ pub const CONFIG_DEFAULT_FILENAME: &str = "witnet.toml";
 /// supports messages for giving access to the configuration it holds.
 #[derive(Debug)]
 pub struct ConfigManager {
+    /// Loaded configuration
     config: Config,
+
+    /// Configuration file from which to read the configuration when
+    /// the actor starts
     config_file: PathBuf,
 }
 
@@ -35,8 +39,12 @@ impl Actor for ConfigManager {
     type Context = Context<Self>;
 
     fn started(&mut self, _ctx: &mut Self::Context) {
-        debug!("[Config Manager] Started!");
-        self.config = toml::from_file(self.config_file.as_path()).unwrap();
+        debug!("Config Manager actor has been started!");
+        info!(
+            "Reading configuration from file: {}",
+            self.config_file.to_string_lossy()
+        );
+        self.config = toml::from_file(&self.config_file).unwrap()
     }
 }
 

--- a/docs/architecture/managers/config-manager.md
+++ b/docs/architecture/managers/config-manager.md
@@ -2,10 +2,9 @@
 
 The __config manager__ is the actor in charge of managing the configuration required by the system. Its main responsibilities are the following:
 
-- Load configuration from a file using a given format
-- Load default parameters, if they are not defined
+- Load configuration from a file (if specified when creating the actor) and merge it with the default configuration
 - Store configuration parameters on its state
-- Provide the configuration to other actors
+- Provide a deep-copy of the configuration to other actors
 
 ## State
 
@@ -14,7 +13,10 @@ The state of the `Config Manager` is defined as library code ['Config'][config],
 ```rust
 #[derive(Debug, Default)]
 pub struct ConfigManager {
+    /// Loaded configuration
     config: Config,
+    /// Configuration file from which to read the configuration when
+    /// the actor starts, if `None` the default configuration is used
     filename: Option<String>,
 }
 ```
@@ -41,18 +43,25 @@ System::current().registry().set(config_manager_addr);
 
 ### Incoming messages: Others -> Config Manager
 
-These are the messages supported by the connections manager handlers:
+These are the messages supported by the config manager actor:
 
-| Message   | Input type | Output type    | Description                         |
-| --------- | ---------- | -------------- | ----------------------------------- |
-| GetConfig | `()`       | `ConfigResult` | Request a copy of the configuration |
+| Message   | Input type | Output type    | Description                              |
+| --------- | ---------- | -------------- | -----------------------------------      |
+| GetConfig | `()`       | `ConfigResult` | Request a deep-copy of the configuration |
 
-The way other actors will communicate with the connections manager is:
+Where `ConfigResult` is just:
 
-1. Get the address of the connections manager from the registry:
+``` rust
+/// Result of the GetConfig message handling
+pub type ConfigResult = Result<Config, io::Error>;
+```
+
+The way other actors will communicate with the config manager is:
+
+1. Get the address of the config manager from the registry:
 
     ```rust
-    // Get connections manager address
+    // Get config manager address
     let config_manager_addr = System::current().registry().get::<ConfigManager>();
     ```
 

--- a/docs/configuration/cli.md
+++ b/docs/configuration/cli.md
@@ -1,0 +1,3 @@
+# Configuration params in CLI
+
+When running the node, you can specify which configuration file to load using the command line option `-c` or `--config`. See the help (`--help`) for more information.

--- a/docs/configuration/toml-file.md
+++ b/docs/configuration/toml-file.md
@@ -1,0 +1,27 @@
+# Custom TOML configuration file
+
+A custom `witnet.toml` file can be used to configure parameters of the node. In order for the node to be able to read this file, it should exist in the current working directory where the node is run. Another way is to just tell the node where the config file resides using a command line option. See the CLI reference for more info.
+
+## TOML file example
+
+``` toml
+[connections] # section for connections-related params
+server_addr = "127.0.0.1:1234"
+inbound_limit = 30
+
+[storage] # section for storage-related params
+db_path = ".wit"
+
+# ... more options
+```
+
+## Configuration params
+
+| Section     | Param          | Default Value       | Description                                                       |
+| ---------   | ----------     | --------------      | -----------------------------------                               |
+| connections | server_addr    | `"127.0.0.1:21337"` | Server socket address to which it should bind to                  |
+| connections | inbound_limit  | `128`               | Maximum number of concurrent connections the server should accept |
+| connections | outbound_limit | `8`                 | Maximum number of opened connections to other peers this node has |
+| connections | known_peers    | `[]`                | Other peer addresses this node knows about at start               |
+| storage     | db_path        | `".wit"`            | Directory containing the dabase files                             |
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Introduction: architecture/managers/managers.md
       - Sessions Manager: architecture/managers/sessions-manager.md
       - Connections Manager: architecture/managers/connections-manager.md
+      - Config Manager: architecture/managers/config-manager.md
       - Storage Manager: architecture/managers/storage-manager.md
       - Peers Manager: architecture/managers/peers-manager.md
     - Mempool Management: architecture/mempool-mgmt.md
@@ -67,6 +68,9 @@ nav:
   - Roadmap: roadmap.md
   - Contributing: contributing.md
   - Development: development.md
+  - Configuration:
+    - Custom toml file: configuration/toml-file.md
+    - Command Line Interface (CLI): configuration/cli.md
   - Glossary: glossary.md
 
 theme:


### PR DESCRIPTION
Documentation comments for the config crate.

In order to test run: `cargo doc -p witnet_config --open` and you should find all structs and their fields commented.

Also created a section in the project-level docs with the config params explained.
![image](https://user-images.githubusercontent.com/83847/48061889-adc2df00-e1c0-11e8-9172-6c21d48ad782.png)
