### PR TITLE
feat(p2p): add `GetPeers`, replace `AddPeer` with `AddPeers`

### DIFF
--- a/core/src/actors/sessions_manager.rs
+++ b/core/src/actors/sessions_manager.rs
@@ -13,7 +13,7 @@ use crate::actors::config_manager::send_get_config_request;
 use crate::actors::connections_manager::{ConnectionsManager, OutboundTcpConnect};
 use crate::actors::session::Session;
 
-use crate::actors::peers_manager::{GetPeer, PeersManager, PeersSocketAddrResult};
+use crate::actors::peers_manager::{GetRandomPeer, PeersManager, PeersSocketAddrResult};
 use witnet_p2p::sessions::{error::SessionsResult, SessionStatus, SessionType, Sessions};
 
 /// Period of the bootstrap peers task (in seconds)
@@ -50,7 +50,7 @@ impl SessionsManager {
                 peers_manager_addr
                     // Send GetPeer message to peers manager actor
                     // This returns a Request Future, representing an asynchronous message sending process
-                    .send(GetPeer)
+                    .send(GetRandomPeer)
                     // Convert a normal future into an ActorFuture
                     .into_actor(act)
                     // Process the response from the peers manager

--- a/docs/architecture/managers/sessions-manager.md
+++ b/docs/architecture/managers/sessions-manager.md
@@ -112,7 +112,7 @@ These are the messages sent by the connections manager:
 |-----------------------|-----------------------|---------------|-----------------------------------|---------------------------------------|
 | GetServerAddress      | ConfigManager         | `()`          | `Option<SocketAddr>`              | Request the config server address     |
 | GetConnLimits         | ConfigManager         | `()`          | `Option<(u16, u16)>`              | Request the config connections limits |
-| GetPeer               | PeersManager          | `()`          | `PeersResult<Option<SocketAddr>>` | Request the address of a peer         | 
+| GetRandomPeer         | PeersManager          | `()`          | `PeersResult<Option<SocketAddr>>` | Request the address of a peer         |
 | OutboundTcpConnect    | ConnectionsManager    | `SocketAddr`  | `()`                              | Request a TCP conn to an address      | 
 
 #### GetServerAddress
@@ -136,7 +136,7 @@ reached.
 
 For further information, see [`ConfigManager`][config_manager].
 
-#### GetPeer
+#### GetRandomPeer
 
 This message is sent to the [`PeersManager`][peers_manager] actor when the sessions manager actor
 detects that the number of outbound sessions registered is less than the configured limit. This


### PR DESCRIPTION
Rename some `peers` methods and the corresponding messages to accept a `Vec<SocketAddr>` instead of a `SocketAddr` allowing to process multiple peers per message:
`AddPeer` -> `AddPeers`
`RemovePeer` -> `RemovePeers`

Rename for clarification:
`GetPeer` -> `GetRandomPeer`

Implement `GetPeers` which returns all the known peers.

Update tests and documentation.