### PR TITLE
refactor(p2p): add separate consolidated/unconsolidated collections for outbound sessions

### DIFF
--- a/core/src/actors/connections_manager.rs
+++ b/core/src/actors/connections_manager.rs
@@ -19,7 +19,7 @@ use crate::actors::config_manager::send_get_config_request;
 use crate::actors::{codec::P2PCodec, session::Session};
 
 use witnet_config::Config;
-use witnet_p2p::sessions::SessionType;
+use witnet_p2p::sessions::{SessionStatus, SessionType};
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // ACTOR MESSAGES
@@ -99,7 +99,12 @@ impl ConnectionsManager {
             Session::add_stream(FramedRead::new(r, P2PCodec), ctx);
 
             // Create the session actor and store in its state the write part of the tcp stream
-            Session::new(address, session_type, FramedWrite::new(w, P2PCodec, ctx))
+            Session::new(
+                address,
+                session_type,
+                SessionStatus::Unconsolidated,
+                FramedWrite::new(w, P2PCodec, ctx),
+            )
         });
     }
 

--- a/core/src/actors/session.rs
+++ b/core/src/actors/session.rs
@@ -13,7 +13,7 @@ use tokio::net::TcpStream;
 use crate::actors::codec::{P2PCodec, Request};
 use crate::actors::sessions_manager::{Register, SessionsManager, Unregister};
 
-use witnet_p2p::sessions::SessionType;
+use witnet_p2p::sessions::{SessionStatus, SessionType};
 
 /// Session representing a TCP connection
 pub struct Session {
@@ -22,6 +22,9 @@ pub struct Session {
 
     /// Session type
     session_type: SessionType,
+
+    /// Session status
+    status: SessionStatus,
 
     /// Framed wrapper to send messages through the TCP connection
     _framed: FramedWrite<WriteHalf<TcpStream>, P2PCodec>,
@@ -33,11 +36,13 @@ impl Session {
     pub fn new(
         address: SocketAddr,
         session_type: SessionType,
+        status: SessionStatus,
         _framed: FramedWrite<WriteHalf<TcpStream>, P2PCodec>,
     ) -> Session {
         Session {
             address,
             session_type,
+            status,
             _framed,
         }
     }
@@ -87,6 +92,7 @@ impl Actor for Session {
         session_manager_addr.do_send(Unregister {
             address: self.address,
             session_type: self.session_type,
+            status: self.status,
         });
 
         Running::Stop

--- a/p2p/tests/bounded_sessions.rs
+++ b/p2p/tests/bounded_sessions.rs
@@ -1,7 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use witnet_p2p::sessions::bounded_sessions::*;
-use witnet_p2p::sessions::SessionStatus;
 
 /// Check if the bounded sessions default initializes empty collection and no limit
 #[test]
@@ -32,7 +31,7 @@ fn p2p_bounded_sessions_register() {
     // Check status of recently registered session
     let session_info = sessions.collection.get(&address);
     assert!(session_info.is_some());
-    assert_eq!(session_info.unwrap().status, SessionStatus::Unconsolidated);
+    assert_eq!(session_info.unwrap().reference, "reference1");
 }
 
 // Check the unregistration of a session
@@ -51,33 +50,6 @@ fn p2p_bounded_sessions_unregister() {
 
     // Expect element to be removed
     assert_eq!(sessions.collection.len(), 0);
-}
-
-// Check the update of a session
-#[test]
-fn p2p_bounded_sessions_update() {
-    // Create bounded sessions struct
-    let mut sessions = BoundedSessions::default();
-
-    // Add session
-    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-    assert!(sessions.register_session(address, "reference1").is_ok());
-    assert_eq!(sessions.collection.len(), 1);
-
-    // Check value of recently registered session
-    let session_info = sessions.collection.get(&address);
-    assert!(session_info.is_some());
-    assert_eq!(session_info.unwrap().status, SessionStatus::Unconsolidated);
-
-    // Update session status
-    assert!(sessions
-        .update_session(address, SessionStatus::Consolidated)
-        .is_ok());
-
-    // Check udpated status
-    let session_info = sessions.collection.get(&address);
-    assert!(session_info.is_some());
-    assert_eq!(session_info.unwrap().status, SessionStatus::Consolidated);
 }
 
 /// Check if the sessions limit is being used
@@ -118,17 +90,4 @@ fn p2p_bounded_sessions_unregister_unknown() {
     // Unregister non-existent session
     let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     assert!(sessions.unregister_session(address).is_err());
-}
-
-/// Check if non-existent session cannot be updated
-#[test]
-fn p2p_bounded_sessions_update_unknown() {
-    // Create bounded sessions struct
-    let mut sessions = BoundedSessions::<String>::default();
-
-    // Unregister non-existent session
-    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-    assert!(sessions
-        .update_session(address, SessionStatus::Consolidated)
-        .is_err());
 }


### PR DESCRIPTION
This PR adds separate consolidated / unconsolidated collections for outbound sessions in `p2p sessions library`. The p2p sessions library is the one that contains the state and most of the logic of the session manager. Inbound sessions are left in the same collection, no matter what their status is.

Tests for the `p2p sessions library` have been adapted to this new logic. Also, the actors that used that refactored logic in some way have been adapted.

Additionally, some extra logic that was left in the `SessionsManager` actor has been extracted from it and written in the library instead. New tests have been implemented for this new logic.
