### PR TITLE
feat(storage): create Storable trait

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -153,7 +153,90 @@ These are the specific types for this implementor:
 
 The full source code of the `Storage` implementor for `RocksStorage` can be found at [`rocks.rs`][rocks].
 
+## `Storable` trait
+
+The `Storable` trait defines a conversion from any type to bytes.
+It is useful because the storage backends expect keys and values to be raw bytes,
+so the data needs to be serialized and deserialized.
+
+The simplest way to implement this trait is to add
+`#[derive(Serialize, Deserialize)]` from `serde` to the type definition:
+
+```rust
+#[derive(Serialize, Deserialize)]
+struct Foo {
+    data: Vec<String>
+}
+```
+
+The default implementation uses [MessagePack][msgpack], but the implementor is free to choose
+a different encoding for their custom types.
+
+The preferred way to work with this trait is using the `StorageHelper`,
+described below:
+
+## `StorageHelper` trait
+
+To enable better ergonomics when working with the storage, users can
+import the `StorageHelper` trait which adds two additional methods to
+the `Storage`:
+
+```rust
+pub trait StorageHelper {
+    /// Insert an element into the storage
+    fn put_t<T: Storable>(&mut self, key: &[u8], value: T) -> StorageResult<()>;
+    /// Get an element from the storage
+    fn get_t<T: Storable>(&mut self, key: &[u8]) -> StorageResult<Option<T>>;
+}
+```
+
+This trait is implemented by default for all the storage backends which
+work with raw bytes.
+
+It allows for inserting and removing typed values, as long as the types
+implement the `Storable` trait.
+
+### Example
+
+```rust
+use witnet_storage::storage::{Storage, StorageHelper};
+use witnet_storage::error::StorageResult;
+use witnet_storage::backends::in_memory::InMemoryStorage;
+
+fn main() -> StorageResult<()> {
+    // Create an InMemoryStorage for testing
+    let mut s = InMemoryStorage::new(())?;
+
+    // Insert a String
+    let v1: String = "hello!".to_string();
+    s.put_t(b"str", v1.clone())?;
+
+    // Get that String back
+    let v2: String = s.get_t(b"str")?.unwrap();
+    assert_eq!(v1, v2);
+
+    // Insert a i32
+    let x1: i32 = 54;
+    s.put_t(b"int", x1.clone())?;
+
+    // Get that i32 back
+    let x2 = s.get_t::<i32>(b"int")?.unwrap();
+    assert_eq!(x1, x2);
+
+    Ok(())
+}
+```
+
+### Safety
+
+This trait allows for inserting and removing typed values, although there is no type
+safety, the user is responsible to make sure the `get_t` method
+specifies the correct type. In most cases the conversion will fail and
+the `get_t` method will return an error. But it is possible to get a
+valid result from a different type.
+
 [#21]: https://github.com/witnet/witnet-rust/pull/21
 [storage]: https://github.com/witnet/witnet-rust/blob/master/storage/src/storage.rs
 [rocks]: https://github.com/witnet/witnet-rust/blob/master/storage/src/backends/rocks.rs
 [in_memory]: https://github.com/witnet/witnet-rust/blob/master/storage/src/backends/in_memory.rs
+[msgpack]: https://msgpack.org/

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -10,7 +10,9 @@ description = "Witnet storage module that conveniently abstracts a key/value API
 env_logger = "0.5.13"
 failure = "0.1.2"
 log = "0.4.5"
+rmp-serde = "0.13"
 rocksdb = { version = "0.10.1", optional = true }
+serde = "1.0"
 witnet_util = { path = "../util" }
 
 [features]

--- a/storage/src/error.rs
+++ b/storage/src/error.rs
@@ -34,6 +34,10 @@ pub enum StorageErrorKind {
     Get,
     /// Errors when deleting a key/value pair
     Delete,
+    /// Errors when converting a value into bytes
+    Encode,
+    /// Errors when creating a value from bytes
+    Decode,
 }
 
 impl fmt::Display for StorageErrorKind {

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -107,7 +107,7 @@ pub trait StorageHelper<'a, ConnData: Debug>: Storage<ConnData, &'a [u8], Vec<u8
         }
     }
     /// Get an element from the storage
-    fn get_t<T: Storable>(&mut self, key: &'a [u8]) -> StorageResult<Option<T>> {
+    fn get_t<T: Storable>(&self, key: &'a [u8]) -> StorageResult<Option<T>> {
         let value = self.get(key)?;
         if value.is_none() {
             return Ok(None);

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -1,8 +1,10 @@
-//! Module containing a Storage generic trait that can be implemented for different specific storage
-//! backends.
+//! Module containing a `Storage` generic trait that can be implemented for different specific storage
+//! backends, and a `Storable` trait which marks types as being convertible to bytes for storage.
 
-use crate::error::StorageResult;
+use crate::error::{StorageError, StorageErrorKind, StorageResult};
+use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
+use witnet_util::error::WitnetError;
 
 /// This is a generic trait that exposes a very simple key/value CRUD API for data storage.
 /// This trait can be easily implemented for any specific storage backend solution (databases,
@@ -21,4 +23,109 @@ pub trait Storage<ConnData: Debug, Key, Value> {
 
     /// Delete an entry from the storage, identified by its key.
     fn delete(&mut self, key: Key) -> StorageResult<()>;
+}
+
+/// Trait which marks a type as storable.
+/// The simplest way to implement this trait
+/// is to add `#[derive(Serialize, Deserialize)]` to the type definition.
+/// The storage works on raw bytes, so we need to serialize and deserialize the data.
+/// The default implementation uses MessagePack, but the implementor is free to choose
+/// a different encoding for their custom types.
+pub trait Storable: Sized {
+    /// Convert `Self` into `Vec<u8>`
+    fn to_bytes(&self) -> StorageResult<Vec<u8>>;
+    /// Convert `Vec<u8>` into `Self
+    fn from_bytes(x: &[u8]) -> StorageResult<Self>;
+}
+
+// By default, mark all the types which can be serialized and deserialized
+// using serde as `Storable`
+impl<T> Storable for T
+where
+    T: Serialize + DeserializeOwned,
+{
+    /// Convert `Self` into `Vec<u8>`
+    fn to_bytes(&self) -> StorageResult<Vec<u8>> {
+        rmp_serde::to_vec(&self).map_err(|e| {
+            WitnetError::from(StorageError::new(
+                StorageErrorKind::Encode,
+                "Error when encoding value".to_string(),
+                format!("{}", e),
+            ))
+        })
+    }
+    /// Convert `Vec<u8>` into `Self
+    fn from_bytes(x: &[u8]) -> StorageResult<Self> {
+        rmp_serde::from_slice(x).map_err(|e| {
+            WitnetError::from(StorageError::new(
+                StorageErrorKind::Decode,
+                "Error when decoding value".to_string(),
+                format!("{}", e),
+            ))
+        })
+    }
+}
+
+/// Helper trait to work on types instead of raw bytes.
+/// The type must implement the `Storable` trait.
+///
+/// Usage example:
+///
+/// ```
+/// use witnet_storage::storage::{Storage, StorageHelper};
+/// use witnet_storage::error::StorageResult;
+/// use witnet_storage::backends::in_memory::InMemoryStorage;
+///
+/// fn main() -> StorageResult<()> {
+///     let mut s = InMemoryStorage::new(())?;
+///     let v1: String = "hello!".to_string();
+///     s.put_t(b"str", v1.clone())?;
+///     let v2: String = s.get_t(b"str")?.unwrap();
+///     assert_eq!(v1, v2);
+///
+///     let x1: i32 = 54;
+///     s.put_t(b"int", x1.clone())?;
+///     let x2 = s.get_t::<i32>(b"int")?.unwrap();
+///     assert_eq!(x1, x2);
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// It is the caller's responsibility to make sure that the type signature is correct,
+/// as trying to get a value of an incorrect type may lead to unexpected behaviour.
+pub trait StorageHelper<'a, ConnData: Debug>: Storage<ConnData, &'a [u8], Vec<u8>> {
+    /// Insert an element into the storage
+    fn put_t<T: Storable>(&mut self, key: &'a [u8], value: T) -> StorageResult<()> {
+        match value.to_bytes() {
+            Ok(v) => self.put(key, v),
+            Err(e) => Err(WitnetError::from(StorageError::new(
+                StorageErrorKind::Put,
+                format!("Key: {:?}", key),
+                format!("Failed to convert value into bytes: {:?}", e),
+            ))),
+        }
+    }
+    /// Get an element from the storage
+    fn get_t<T: Storable>(&mut self, key: &'a [u8]) -> StorageResult<Option<T>> {
+        let value = self.get(key)?;
+        if value.is_none() {
+            return Ok(None);
+        }
+        let value = value.unwrap();
+        match T::from_bytes(&value) {
+            Ok(v) => Ok(Some(v)),
+            Err(e) => Err(WitnetError::from(StorageError::new(
+                StorageErrorKind::Get,
+                format!("Key: {:?}", key),
+                format!("Failed to create value from bytes: {:?}", e),
+            ))),
+        }
+    }
+}
+
+// Implement the above helper trait for all the storage backends that work on raw bytes
+impl<'a, ConnData: Debug, T> StorageHelper<'a, ConnData> for T where
+    T: Storage<ConnData, &'a [u8], Vec<u8>>
+{
 }

--- a/storage/tests/storable.rs
+++ b/storage/tests/storable.rs
@@ -1,0 +1,52 @@
+use witnet_storage::backends::in_memory::InMemoryStorage;
+use witnet_storage::error::StorageResult;
+use witnet_storage::storage::{Storable, Storage, StorageHelper};
+
+#[test]
+fn storable_types() -> StorageResult<()> {
+    // Create a new type and implement the storable trait
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    struct Foo {
+        data: u16,
+    };
+    impl Storable for Foo {
+        // Converts a u16 into a Vec<u8>
+        fn to_bytes(&self) -> StorageResult<Vec<u8>> {
+            let mut v = vec![];
+            v.push(self.data as u8);
+            v.push((self.data >> 8) as u8);
+            Ok(v)
+        }
+        fn from_bytes(x: &[u8]) -> StorageResult<Self> {
+            let data = x[0] as u16 + ((x[1] as u16) << 8);
+            Ok(Foo { data })
+        }
+    }
+
+    // Test with InMemoryStorage
+    let mut s = InMemoryStorage::new(())?;
+
+    let f = Foo { data: 10 };
+    s.put(b"a", f.to_bytes().unwrap())?;
+    assert_eq!(Foo::from_bytes(&s.get(b"a")?.unwrap()).unwrap(), f);
+
+    // Using the helper trait
+    assert_eq!(s.get_t::<Foo>(b"a")?.unwrap(), f);
+
+    let f2 = Foo { data: 2 };
+    s.put_t(b"c", f2)?;
+    let also_f2: Foo = s.get_t(b"c")?.unwrap();
+    assert_eq!(also_f2, f2);
+
+    // We can work with anything that can be serialized by serde
+    let f3 = format!("Hello, world");
+    s.put_t(b"string", f3.clone())?;
+    assert_eq!(s.get_t::<String>(b"string")?.unwrap(), f3);
+
+    // Enums and structs are supported, as long as they implement Serialize/Deserialize
+    let f4 = Some(56i32);
+    s.put_t(b"some_int", f4)?;
+    assert_eq!(s.get_t::<Option<i32>>(b"some_int")?.unwrap(), f4);
+
+    Ok(())
+}


### PR DESCRIPTION
Define a `Storable` trait which defines a conversion from a given type to raw bytes.
The default implementation uses MessagePack, but since the encoding is specific to each type, users can create their own encoders/decoders.