### PR TITLE
feat(managers): periodically persist peers into storage 

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -43,6 +43,7 @@ use crate::defaults::{Defaults, Testnet1};
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// Module containing the partial configuration struct that is
 /// returned by the loaders.
@@ -83,6 +84,12 @@ pub struct Connections {
     /// used as a bootstrap mechanism to gain access to the P2P
     /// network
     pub known_peers: HashSet<SocketAddr>,
+
+    /// Period of the bootstrap peers task
+    pub bootstrap_peers_period: Duration,
+
+    /// Period of the persist peers task
+    pub storage_peers_period: Duration,
 }
 
 /// Storage-specific configuration
@@ -146,6 +153,14 @@ impl Connections {
                 .union(&defaults.connections_known_peers())
                 .cloned()
                 .collect(),
+            bootstrap_peers_period: config
+                .bootstrap_peers_period
+                .to_owned()
+                .unwrap_or_else(|| defaults.connections_bootstrap_peers_period()),
+            storage_peers_period: config
+                .storage_peers_period
+                .to_owned()
+                .unwrap_or_else(|| defaults.connections_storage_peers_period()),
         }
     }
 }
@@ -195,6 +210,14 @@ mod tests {
         assert_eq!(config.inbound_limit, Testnet1.connections_inbound_limit());
         assert_eq!(config.outbound_limit, Testnet1.connections_outbound_limit());
         assert_eq!(config.known_peers, Testnet1.connections_known_peers());
+        assert_eq!(
+            config.bootstrap_peers_period,
+            Testnet1.connections_bootstrap_peers_period()
+        );
+        assert_eq!(
+            config.storage_peers_period,
+            Testnet1.connections_storage_peers_period()
+        );
     }
 
     #[test]
@@ -206,6 +229,8 @@ mod tests {
             inbound_limit: Some(3),
             outbound_limit: Some(4),
             known_peers: [addr].iter().cloned().collect(),
+            bootstrap_peers_period: Some(Duration::from_secs(10)),
+            storage_peers_period: Some(Duration::from_secs(60)),
         };
         let config = Connections::from_partial(&partial_config, &*defaults);
 
@@ -213,6 +238,8 @@ mod tests {
         assert_eq!(config.inbound_limit, 3);
         assert_eq!(config.outbound_limit, 4);
         assert!(config.known_peers.contains(&addr));
+        assert_eq!(config.bootstrap_peers_period, Duration::from_secs(10));
+        assert_eq!(config.storage_peers_period, Duration::from_secs(60));
     }
 
     #[test]
@@ -235,6 +262,14 @@ mod tests {
         assert_eq!(
             config.connections.known_peers,
             Testnet1.connections_known_peers()
+        );
+        assert_eq!(
+            config.connections.bootstrap_peers_period,
+            Testnet1.connections_bootstrap_peers_period()
+        );
+        assert_eq!(
+            config.connections.storage_peers_period,
+            Testnet1.connections_storage_peers_period()
         );
     }
 }

--- a/config/src/config/partial.rs
+++ b/config/src/config/partial.rs
@@ -13,6 +13,7 @@ use std::collections::HashSet;
 use std::default::Default;
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// The partial configuration object that contains all other, more
 /// specific, configuration objects (connections, storage, etc).
@@ -53,6 +54,12 @@ pub struct Connections {
     /// network
     #[serde(default)]
     pub known_peers: HashSet<SocketAddr>,
+
+    /// Period of the bootstrap peers task
+    pub bootstrap_peers_period: Option<Duration>,
+
+    /// Period of the persist peers task
+    pub storage_peers_period: Option<Duration>,
 }
 
 /// Storage-specific configuration

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -5,6 +5,7 @@
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// Trait defining all the configuration params that have a suitable
 /// default value depending on the environment (mainnet, testnet,
@@ -30,6 +31,16 @@ pub trait Defaults {
 
     /// Default path for the database
     fn storage_db_path(&self) -> PathBuf;
+
+    /// Default period for bootstrap peers
+    fn connections_bootstrap_peers_period(&self) -> Duration {
+        Duration::from_secs(5)
+    }
+
+    /// Default period for persist peers into storage
+    fn connections_storage_peers_period(&self) -> Duration {
+        Duration::from_secs(30)
+    }
 }
 
 /// Struct that will implement all the mainnet defaults

--- a/core/src/actors/mod.rs
+++ b/core/src/actors/mod.rs
@@ -21,3 +21,6 @@ pub mod config_manager;
 
 /// Connections manager actor module
 pub mod connections_manager;
+
+/// Storage keys constants
+pub mod storage_keys;

--- a/core/src/actors/storage_keys.rs
+++ b/core/src/actors/storage_keys.rs
@@ -1,0 +1,2 @@
+/// Constant to specify the peers key for the storage
+pub static PEERS_KEY: &'static [u8] = b"peers";

--- a/docs/architecture/managers/peers-manager.md
+++ b/docs/architecture/managers/peers-manager.md
@@ -92,11 +92,10 @@ The way other actors will communicate with the storage manager is:
 
 These are the messages sent by the peers manager:
 
-| Message   | Destination   | Input type | Output type                 | Description               |
-| --------- | ------------- | ---------- | --------------------------- | ------------------------- |
-| GetConfig | ConfigManager | `()`       | `Result<Config, io::Error>` | Request the configuration |
-
-It is foreseen that in the future, the peers manager will call the `Storage Manager` to store a list of known peers.
+| Message     | Destination       | Input type                                | Output type                 | Description                               |
+| ----------- | ----------------- | ----------------------------------------- | --------------------------- | ----------------------------------------- |
+| `GetConfig` | `ConfigManager`   | `()`                                      | `Result<Config, io::Error>` | Request the configuration                 |
+| `Put`       | `StorageManager`  | `&'static [u8]`, `Vec<u8>`                | `StorageResult<()>`         | Wrapper to RocksStorage `put()` method    |
 
 #### GetConfig
 
@@ -104,9 +103,18 @@ This message is sent to the [`ConfigManager`][config_manager] actor when the pee
 
 The return value is used to initialize the list of known peers. For further information, see  [`ConfigManager`][config_manager].
 
+#### Put
+
+This message is sent to the [`StorageManager`][storage_manager] actor periodically using a period 
+obtained from [`ConfigManager`][config_manager]
+
+The return value is used to check if the storage process has been successful.
+
 ## Further information
 
 The full source code of the `PeersManager` can be found at [`peers_manager.rs`][peers_manager].
 
 [peers]: https://github.com/witnet/witnet-rust/blob/master/p2p/src/peers.rs
 [peers_manager]: https://github.com/witnet/witnet-rust/blob/master/core/src/actors/peers_manager.rs
+[config_manager]: https://github.com/witnet/witnet-rust/blob/master/core/src/actors/config_manager.rs
+[storage_manager]: https://github.com/witnet/witnet-rust/blob/master/core/src/actors/storage_manager.rs

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -9,4 +9,6 @@ edition = "2018"
 [dependencies]
 failure = "0.1.2"
 rand = "0.5.5"
+serde = "1.0"
+serde_derive = "1.0"
 witnet_util = { path = "../util" }

--- a/p2p/src/peers/mod.rs
+++ b/p2p/src/peers/mod.rs
@@ -1,5 +1,7 @@
 //! Library for managing a list of available peers
 
+use serde_derive::{Deserialize, Serialize};
+
 use std::collections::HashMap;
 use std::net::SocketAddr;
 
@@ -12,13 +14,14 @@ use crate::peers::error::PeersResult;
 pub mod error;
 
 /// Peer information being used while listing available Witnet peers
+#[derive(Serialize, Deserialize)]
 struct PeerInfo {
     address: SocketAddr,
     _timestamp: i64,
 }
 
 /// Peers TBD
-#[derive(Default)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct Peers {
     /// Server sessions
     peers: HashMap<SocketAddr, PeerInfo>,


### PR DESCRIPTION
Define a new config parameter named storage_peers_period.
Implement a function on Peers Manager to dump periodically peers into storage through sending a Put message to Storage Manager
Add documentation to peers manager doc 

Close #97 