### PR TITLE
fix(actors): rename new to from_value in order to fix clippy warnings

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -13,6 +13,12 @@ install-setup:
     just install-clippy
     just install-rustfmt
 
+# print tool versions
+versions:
+    rustc --version
+    cargo fmt -- --version
+    cargo clippy -- --version
+
 # run clippy
 clippy:
     cargo clippy --all-targets --all-features -- -D warnings
@@ -40,6 +46,7 @@ docs-deploy:
 # run travis
 travis:
     just install-setup
+    just versions
     cargo fmt --all -- --check
     just clippy
     cargo test --all --verbose

--- a/core/src/actors/storage_manager.rs
+++ b/core/src/actors/storage_manager.rs
@@ -45,8 +45,12 @@ pub struct Put {
 }
 
 impl Put {
+    /// Create a `Put` message from raw bytes
+    pub fn new(key: &'static [u8], value: Vec<u8>) -> Self {
+        Put { key, value }
+    }
     /// Create a `Put` message by converting the value into bytes
-    pub fn new<T: Storable>(key: &'static [u8], value: &T) -> StorageResult<Self> {
+    pub fn from_value<T: Storable>(key: &'static [u8], value: &T) -> StorageResult<Self> {
         let value = value.to_bytes()?;
         Ok(Put { key, value })
     }


### PR DESCRIPTION
* Add version information to the Justfile to prevent similar issues in the future.

* `Put` now has a `new` method which takes raw bytes, and `from_value` which takes a `Storable` type.