### PR TITLE
fix(config): read duration as seconds from file

### DIFF
--- a/config/src/config/partial.rs
+++ b/config/src/config/partial.rs
@@ -56,9 +56,15 @@ pub struct Connections {
     pub known_peers: HashSet<SocketAddr>,
 
     /// Period of the bootstrap peers task
+    #[serde(default)]
+    #[serde(deserialize_with = "from_secs")]
+    #[serde(rename = "bootstrap_peers_period_seconds")]
     pub bootstrap_peers_period: Option<Duration>,
 
     /// Period of the persist peers task
+    #[serde(default)]
+    #[serde(deserialize_with = "from_secs")]
+    #[serde(rename = "bootstrap_peers_period_seconds")]
     pub storage_peers_period: Option<Duration>,
 }
 
@@ -82,4 +88,17 @@ impl Config {
         default.environment = Environment::Mainnet;
         default
     }
+}
+
+use serde::{Deserialize, Deserializer};
+
+// Create a duration type from a u64 representing seconds
+fn from_secs<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(match u64::deserialize(deserializer) {
+        Ok(secs) => Some(Duration::from_secs(secs)),
+        Err(_) => None,
+    })
 }

--- a/config/src/loaders/toml.rs
+++ b/config/src/loaders/toml.rs
@@ -147,4 +147,27 @@ db_path = 'dbfiles'
         assert_eq!(empty_config.storage, Storage::default());
         assert_eq!(config.storage.db_path, Some(PathBuf::from("dbfiles")));
     }
+
+    #[test]
+    fn test_load_duration() {
+        use std::time::Duration;
+
+        let empty_config = super::from_str("[storage]").unwrap();
+        let config = super::from_str(
+            r"
+[connections]
+bootstrap_peers_period_seconds = 10
+",
+        )
+        .unwrap();
+
+        assert_eq!(
+            empty_config.connections.bootstrap_peers_period,
+            Connections::default().bootstrap_peers_period
+        );
+        assert_eq!(
+            config.connections.bootstrap_peers_period,
+            Some(Duration::from_secs(10))
+        );
+    }
 }


### PR DESCRIPTION
Allow to set

```toml
[connections]
bootstrap_peers_period_seconds = 10
```