### PR TITLE
feat(managers): implement algorithm for peer discovery in SessionManager

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -90,6 +90,9 @@ pub struct Connections {
 
     /// Period of the persist peers task
     pub storage_peers_period: Duration,
+
+    /// Period of the peers discovery task
+    pub discovery_peers_period: Duration,
 }
 
 /// Storage-specific configuration
@@ -161,6 +164,10 @@ impl Connections {
                 .storage_peers_period
                 .to_owned()
                 .unwrap_or_else(|| defaults.connections_storage_peers_period()),
+            discovery_peers_period: config
+                .discovery_peers_period
+                .to_owned()
+                .unwrap_or_else(|| defaults.connections_discovery_peers_period()),
         }
     }
 }
@@ -218,6 +225,10 @@ mod tests {
             config.storage_peers_period,
             Testnet1.connections_storage_peers_period()
         );
+        assert_eq!(
+            config.discovery_peers_period,
+            Testnet1.connections_discovery_peers_period()
+        );
     }
 
     #[test]
@@ -231,6 +242,7 @@ mod tests {
             known_peers: [addr].iter().cloned().collect(),
             bootstrap_peers_period: Some(Duration::from_secs(10)),
             storage_peers_period: Some(Duration::from_secs(60)),
+            discovery_peers_period: Some(Duration::from_secs(100)),
         };
         let config = Connections::from_partial(&partial_config, &*defaults);
 
@@ -240,6 +252,7 @@ mod tests {
         assert!(config.known_peers.contains(&addr));
         assert_eq!(config.bootstrap_peers_period, Duration::from_secs(10));
         assert_eq!(config.storage_peers_period, Duration::from_secs(60));
+        assert_eq!(config.discovery_peers_period, Duration::from_secs(100));
     }
 
     #[test]
@@ -270,6 +283,10 @@ mod tests {
         assert_eq!(
             config.connections.storage_peers_period,
             Testnet1.connections_storage_peers_period()
+        );
+        assert_eq!(
+            config.connections.discovery_peers_period,
+            Testnet1.connections_discovery_peers_period()
         );
     }
 }

--- a/config/src/config/partial.rs
+++ b/config/src/config/partial.rs
@@ -66,6 +66,9 @@ pub struct Connections {
     #[serde(deserialize_with = "from_secs")]
     #[serde(rename = "bootstrap_peers_period_seconds")]
     pub storage_peers_period: Option<Duration>,
+
+    /// Period of the peers discovery task
+    pub discovery_peers_period: Option<Duration>,
 }
 
 /// Storage-specific configuration

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -41,6 +41,11 @@ pub trait Defaults {
     fn connections_storage_peers_period(&self) -> Duration {
         Duration::from_secs(30)
     }
+
+    /// Default period for discovering peers
+    fn connections_discovery_peers_period(&self) -> Duration {
+        Duration::from_secs(30)
+    }
 }
 
 /// Struct that will implement all the mainnet defaults

--- a/docs/architecture/session.md
+++ b/docs/architecture/session.md
@@ -28,6 +28,19 @@ Session::create(move |ctx| {
 
 ## API
 
+### Incoming: Others -> Peers Manager
+
+These are the messages supported by the peers manager handlers:
+
+| Message          | Input type            | Output type                       | Description            |
+| ---------------- | --------------------- | --------------------------------- | ---------------------- |
+| `GetPeers`       | `()`                  | `()`                              | Empty                  |
+
+#### GetPeers
+The handler of `GetPeers` message is currently empty.
+
+// TODO Update documentation when `GetPeers` gets any actual functionality.
+
 ### Outgoing messages: Sessions Manager -> Others
 
 These are the messages sent by the connections manager:


### PR DESCRIPTION
Define a new config parameter named discovery_peers_period.
Implement a function on Session Manager to call to itself with Anycast(GetPeers) (see #87).
Add documentation to SessionsManager and Sessions

Close #90