### PR TITLE
feat(handshake): add handshake timeout to config and move session creation to SessionsManager

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -235,6 +235,10 @@ mod tests {
             config.discovery_peers_period,
             Testnet1.connections_discovery_peers_period()
         );
+        assert_eq!(
+            config.handshake_timeout,
+            Testnet1.connections_handshake_timeout()
+        );
     }
 
     #[test]
@@ -249,6 +253,7 @@ mod tests {
             bootstrap_peers_period: Some(Duration::from_secs(10)),
             storage_peers_period: Some(Duration::from_secs(60)),
             discovery_peers_period: Some(Duration::from_secs(100)),
+            handshake_timeout: Some(Duration::from_secs(3)),
         };
         let config = Connections::from_partial(&partial_config, &*defaults);
 
@@ -259,6 +264,7 @@ mod tests {
         assert_eq!(config.bootstrap_peers_period, Duration::from_secs(10));
         assert_eq!(config.storage_peers_period, Duration::from_secs(60));
         assert_eq!(config.discovery_peers_period, Duration::from_secs(100));
+        assert_eq!(config.handshake_timeout, Duration::from_secs(3));
     }
 
     #[test]
@@ -266,6 +272,7 @@ mod tests {
         let partial_config = partial::Config::default();
         let config = Config::from_partial(&partial_config);
 
+        assert_eq!(config.environment, Environment::Testnet1);
         assert_eq!(
             config.connections.server_addr,
             Testnet1.connections_server_addr()
@@ -294,5 +301,10 @@ mod tests {
             config.connections.discovery_peers_period,
             Testnet1.connections_discovery_peers_period()
         );
+        assert_eq!(
+            config.connections.handshake_timeout,
+            Testnet1.connections_handshake_timeout()
+        );
+        assert_eq!(config.storage.db_path, Testnet1.storage_db_path());
     }
 }

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -93,6 +93,9 @@ pub struct Connections {
 
     /// Period of the peers discovery task
     pub discovery_peers_period: Duration,
+
+    /// Handshake timeout
+    pub handshake_timeout: Duration,
 }
 
 /// Storage-specific configuration
@@ -168,6 +171,9 @@ impl Connections {
                 .discovery_peers_period
                 .to_owned()
                 .unwrap_or_else(|| defaults.connections_discovery_peers_period()),
+            handshake_timeout: config
+                .handshake_timeout
+                .unwrap_or_else(|| defaults.connections_handshake_timeout()),
         }
     }
 }

--- a/config/src/config/partial.rs
+++ b/config/src/config/partial.rs
@@ -64,11 +64,20 @@ pub struct Connections {
     /// Period of the persist peers task
     #[serde(default)]
     #[serde(deserialize_with = "from_secs")]
-    #[serde(rename = "bootstrap_peers_period_seconds")]
+    #[serde(rename = "storage_peers_period_seconds")]
     pub storage_peers_period: Option<Duration>,
 
     /// Period of the peers discovery task
+    #[serde(default)]
+    #[serde(deserialize_with = "from_secs")]
+    #[serde(rename = "discovery_peers_period_seconds")]
     pub discovery_peers_period: Option<Duration>,
+
+    /// Handshake timeout
+    #[serde(default)]
+    #[serde(deserialize_with = "from_secs")]
+    #[serde(rename = "handshake_timeout_seconds")]
+    pub handshake_timeout: Option<Duration>,
 }
 
 /// Storage-specific configuration

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -46,6 +46,11 @@ pub trait Defaults {
     fn connections_discovery_peers_period(&self) -> Duration {
         Duration::from_secs(30)
     }
+
+    /// Default handshake timeout
+    fn connections_handshake_timeout(&self) -> Duration {
+        Duration::from_secs(5)
+    }
 }
 
 /// Struct that will implement all the mainnet defaults

--- a/config/src/loaders/toml.rs
+++ b/config/src/loaders/toml.rs
@@ -149,25 +149,46 @@ db_path = 'dbfiles'
     }
 
     #[test]
-    fn test_load_duration() {
+    fn test_load_durations() {
         use std::time::Duration;
 
         let empty_config = super::from_str("[storage]").unwrap();
         let config = super::from_str(
             r"
 [connections]
-bootstrap_peers_period_seconds = 10
+bootstrap_peers_period_seconds = 11
+storage_peers_period_seconds = 7
+handshake_timeout_seconds = 21
 ",
         )
         .unwrap();
 
+        // Check default values in empty config
         assert_eq!(
             empty_config.connections.bootstrap_peers_period,
             Connections::default().bootstrap_peers_period
         );
         assert_eq!(
+            empty_config.connections.storage_peers_period,
+            Connections::default().storage_peers_period
+        );
+        assert_eq!(
+            empty_config.connections.handshake_timeout,
+            Connections::default().handshake_timeout
+        );
+
+        // Check values in initialized config
+        assert_eq!(
             config.connections.bootstrap_peers_period,
-            Some(Duration::from_secs(10))
+            Some(Duration::from_secs(11))
+        );
+        assert_eq!(
+            config.connections.storage_peers_period,
+            Some(Duration::from_secs(7))
+        );
+        assert_eq!(
+            config.connections.handshake_timeout,
+            Some(Duration::from_secs(21))
         );
     }
 }

--- a/core/src/actors/session.rs
+++ b/core/src/actors/session.rs
@@ -1,5 +1,6 @@
 use std::io::Error;
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use actix::io::{FramedWrite, WriteHandler};
 use actix::{
@@ -35,6 +36,9 @@ pub struct Session {
 
     /// Framed wrapper to send messages through the TCP connection
     _framed: FramedWrite<WriteHalf<TcpStream>, P2PCodec>,
+
+    /// Handshake timeout
+    _handshake_timeout: Duration,
 }
 
 /// Session helper methods
@@ -45,6 +49,7 @@ impl Session {
         remote_addr: SocketAddr,
         session_type: SessionType,
         _framed: FramedWrite<WriteHalf<TcpStream>, P2PCodec>,
+        _handshake_timeout: Duration,
     ) -> Session {
         Session {
             _local_addr,
@@ -52,6 +57,7 @@ impl Session {
             session_type,
             status: SessionStatus::Unconsolidated,
             _framed,
+            _handshake_timeout,
         }
     }
 }

--- a/core/src/actors/sessions_manager.rs
+++ b/core/src/actors/sessions_manager.rs
@@ -188,7 +188,7 @@ impl SystemService for SessionsManager {}
 pub type SessionsUnitResult = SessionsResult<()>;
 
 /// Message to indicate that a new session needs to be created
-pub struct CreateSession {
+pub struct Create {
     /// TCP stream
     pub stream: TcpStream,
 
@@ -196,7 +196,7 @@ pub struct CreateSession {
     pub session_type: SessionType,
 }
 
-impl Message for CreateSession {
+impl Message for Create {
     type Result = ();
 }
 
@@ -264,11 +264,11 @@ where
 // ACTOR MESSAGE HANDLERS
 ////////////////////////////////////////////////////////////////////////////////////////
 
-/// Handler for CreateSession message.
-impl Handler<CreateSession> for SessionsManager {
+/// Handler for Create message.
+impl Handler<Create> for SessionsManager {
     type Result = ();
 
-    fn handle(&mut self, msg: CreateSession, _ctx: &mut Context<Self>) {
+    fn handle(&mut self, msg: Create, _ctx: &mut Context<Self>) {
         // Get handshake timeout
         let handshake_timeout = self.sessions.handshake_timeout;
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -8,22 +8,27 @@ At the moment, the available environments are: `testnet-1` and `mainnet`.
 
 ## Defaults for Testnet-1
 
-| Section     | Param          | Default Value       | Description                                                       |
-| ---------   | ----------     | --------------      | -----------------------------------                               |
-| connections | server_addr    | `"127.0.0.1:21337"` | Server socket address to which it should bind to                  |
-| connections | inbound_limit  | `128`               | Maximum number of concurrent connections the server should accept |
-| connections | outbound_limit | `8`                 | Maximum number of opened connections to other peers this node has |
-| connections | known_peers    | `[]`                | Other peer addresses this node knows about at start               |
-| storage     | db_path        | `".wit"`            | Directory containing the dabase files                             |
+| Section     | Param                           | Default Value                 | Description                                                           |
+|-------------|---------------------------------|-------------------------------|-----------------------------------------------------------------------|
+| connections | server_addr                     | `"127.0.0.1:21337"`           | Server socket address to which it should bind to                      |
+| connections | inbound_limit                   | `128`                         | Maximum number of concurrent connections the server should accept     |
+| connections | outbound_limit                  | `8`                           | Maximum number of opened connections to other peers this node has     |
+| connections | known_peers                     | `[]`                          | Other peer addresses this node knows about at start                   |
+| connections | bootstrap_peers_period_seconds  | `5`                           | Period of the outbound peer bootstrapping process (in seconds)        |
+| connections | storage_peers_period_seconds    | `30`                          | Period of the known peers backup into storage process (in seconds)    |
+| connections | handshake_timeout_seconds       | `5`                           | Timeout for the handshake process (in seconds)                        |
+| storage     | db_path                         | `".witnet-rust-testnet-1"`    | Directory containing the database files                               |
 
 
 ## Defaults for Mainnet
 
-| Section     | Param          | Default Value       | Description                                                       |
-| ---------   | ----------     | --------------      | -----------------------------------                               |
-| connections | server_addr    | `"127.0.0.1:11337"` | Server socket address to which it should bind to                  |
-| connections | inbound_limit  | `128`               | Maximum number of concurrent connections the server should accept |
-| connections | outbound_limit | `8`                 | Maximum number of opened connections to other peers this node has |
-| connections | known_peers    | `[]`                | Other peer addresses this node knows about at start               |
-| storage     | db_path        | `".wit"`            | Directory containing the dabase files                             |
-
+| Section     | Param                           | Default Value                 | Description                                                           |
+|-------------|---------------------------------|-------------------------------|-----------------------------------------------------------------------|
+| connections | server_addr                     | `"127.0.0.1:11337"`           | Server socket address to which it should bind to                      |
+| connections | inbound_limit                   | `128`                         | Maximum number of concurrent connections the server should accept     |
+| connections | outbound_limit                  | `8`                           | Maximum number of opened connections to other peers this node has     |
+| connections | known_peers                     | `[]`                          | Other peer addresses this node knows about at start                   |
+| connections | bootstrap_peers_period_seconds  | `5`                           | Period of the outbound peer bootstrapping process (in seconds)        |
+| connections | storage_peers_period_seconds    | `30`                          | Period of the known peers backup into storage process (in seconds)    |
+| connections | handshake_timeout_seconds       | `5`                           | Timeout for the handshake process (in seconds)                        |
+| storage     | db_path                         | `".witnet-rust-mainnet"`      | Directory containing the database files                               |

--- a/docs/configuration/toml-file.md
+++ b/docs/configuration/toml-file.md
@@ -10,6 +10,11 @@ environment = "testnet-1" # or "mainnet"
 [connections] # section for connections-related params
 server_addr = "127.0.0.1:1234"
 inbound_limit = 30
+outbound_limit = 27
+known_peers = ["127.0.0.1:20000", "127.0.0.1:20001"]
+bootstrap_peers_period_seconds = 3
+storage_peers_period_seconds = 60
+handshake_timeout_seconds = 10
 
 [storage] # section for storage-related params
 db_path = ".wit"
@@ -19,12 +24,14 @@ db_path = ".wit"
 
 ## Configuration params
 
-| Section     | Param          | Default Value       | Description                                                       |
-| ---------   | ----------     | --------------      | -----------------------------------                               |
-|             | environment    | `"testnet-1"`       | Environment in which the Witnet protocol will run                 |
-| connections | server_addr    | `"127.0.0.1:21337"` | Server socket address to which it should bind to                  |
-| connections | inbound_limit  | `128`               | Maximum number of concurrent connections the server should accept |
-| connections | outbound_limit | `8`                 | Maximum number of opened connections to other peers this node has |
-| connections | known_peers    | `[]`                | Other peer addresses this node knows about at start               |
-| storage     | db_path        | `".wit"`            | Directory containing the dabase files                             |
-
+| Section     | Param                           | Default Value in testnet-1  | Description                                                         |
+|-------------|---------------------------------|-----------------------------|---------------------------------------------------------------------|
+|             | environment                     | `"testnet-1"`               | Environment in which the Witnet protocol will run                   |
+| connections | server_addr                     | `"127.0.0.1:21337"`         | Server socket address to which it should bind to                    |
+| connections | inbound_limit                   | `128`                       | Maximum number of concurrent connections the server should accept   |
+| connections | outbound_limit                  | `8`                         | Maximum number of opened connections to other peers this node has   |
+| connections | known_peers                     | `[]`                        | Other peer addresses this node knows about at start                 |
+| connections | bootstrap_peers_period_seconds  | `5`                         | Period of the outbound peer bootstrapping process (in seconds)      |
+| connections | storage_peers_period_seconds    | `30`                        | Period of the known peers backup into storage process (in seconds)  |
+| connections | handshake_timeout_seconds       | `5`                         | Timeout for the handshake process (in seconds)                      |
+| storage     | db_path                         | `".witnet-rust-testnet-1"`  | Directory containing the database files                             |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Config Manager: architecture/managers/config-manager.md
       - Storage Manager: architecture/managers/storage-manager.md
       - Peers Manager: architecture/managers/peers-manager.md
+    - Session: architecture/session.md 
     - Mempool Management: architecture/mempool-mgmt.md
     - Block Management: architecture/block-mgmt.md
     - UTXO Management: architecture/utxo-mgmt.md

--- a/p2p/src/sessions/mod.rs
+++ b/p2p/src/sessions/mod.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod bounded_sessions;
 
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use rand::{thread_rng, Rng};
 
@@ -50,6 +51,8 @@ where
     /// Outbound unconsolidated sessions: __known__ peer sessions that the node is connected to
     /// (in unconsolidated status)
     pub outbound_unconsolidated: BoundedSessions<T>,
+    /// Handshake timeout
+    pub handshake_timeout: Duration,
 }
 
 /// Default trait implementation
@@ -63,6 +66,7 @@ where
             inbound: BoundedSessions::default(),
             outbound_consolidated: BoundedSessions::default(),
             outbound_unconsolidated: BoundedSessions::default(),
+            handshake_timeout: Duration::default(),
         }
     }
 }
@@ -94,6 +98,10 @@ where
         self.inbound.set_limit(inbound_limit);
         self.outbound_consolidated
             .set_limit(outbound_consolidated_limit);
+    }
+    /// Method to set the handshake timeout
+    pub fn set_handshake_timeout(&mut self, handshake_timeout: Duration) {
+        self.handshake_timeout = handshake_timeout;
     }
     /// Method to check if a socket address is eligible as outbound peer
     pub fn is_outbound_address_eligible(&self, candidate_addr: SocketAddr) -> bool {

--- a/p2p/tests/sessions.rs
+++ b/p2p/tests/sessions.rs
@@ -1,4 +1,5 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Duration;
 
 use witnet_p2p::sessions::*;
 
@@ -60,6 +61,20 @@ fn p2p_sessions_set_limits() {
         limit_outbound_consolidated
     );
     assert!(sessions.outbound_unconsolidated.limit.is_none());
+}
+
+/// Check setting the handshake timeout
+#[test]
+fn p2p_sessions_set_handshake_timeout() {
+    // Create sessions struct
+    let mut sessions = Sessions::<String>::default();
+
+    // Set handshake timeout
+    let handshake_timeout = Duration::from_secs(17);
+    sessions.set_handshake_timeout(handshake_timeout);
+
+    // Check handshake timeout is now set
+    assert_eq!(sessions.handshake_timeout, handshake_timeout);
 }
 
 /// Check if addresses are eligible as outbound addresses


### PR DESCRIPTION
This PR adds the handshake timeout parameter to the configuration. It is placed under the `[connections]` section and given the name `handshake_timeout_seconds`. Tests are included and documentation is updated with this and other missing configuration parameters.

This PR also moves the creation of the `Session` actor from the `ConnectionsManager` to the `SessionsManager`. When a TCP connection is established, the `ConnectionsManager` will send a `Create` message to the `SessionsManager` and the `SessionsManager` will create the session.

Additionally, the handshake timeout becomes part of the state of the `Session` actor. This handshake timeout is given by the `SessionsManager`, which in turn obtains it from the `ConfigManager`.

The local address of the TCP connection is also added to the state of the `Session` actor (will be required to fill the `sender_addr` field of the `Version` message).

This PR relates to issue #93 , but does not close it.