### PR TITLE
feat(blocks manager): Create a bare-bones version of Blocks Manager

### DIFF
--- a/core/src/actors/blocks_manager.rs
+++ b/core/src/actors/blocks_manager.rs
@@ -1,0 +1,31 @@
+//! # Blocks Manager actor
+//!
+//! This module contains the Blocks Manager actor which is in charge
+//! of managing the blocks of the Witnet blockchain received through
+//! the protocol. Among its responsabilities lie the following:
+//!
+//! * Initializing the chain info upon running the node for the first time and persisting it into storage [StorageManager](actors::storage_manager::StorageManager)
+//! * Recovering the chain info from storage and keeping it in its state.
+//! * Validating block candidates as they come from a session
+//! * Consolidating multiple block candidates for the same checkpoint into a single valid block.
+//! * Putting valid blocks into storage by sending them to the storage manager actor.
+//! * Having a method for letting other components to get blocks by *hash* or *checkpoint*.
+//! * Having a method for letting other components to get the epoch of the current tip of the blockchain (e.g. last epoch field required for the handshake in the Witnet network protocol)
+
+use actix;
+use log::debug;
+
+#[derive(Debug, Default)]
+/// Blocks manager actor: manages the blocks of the Witnet blockchain
+pub struct BlocksManager;
+
+impl actix::Supervised for BlocksManager {}
+impl actix::SystemService for BlocksManager {}
+
+impl actix::Actor for BlocksManager {
+    type Context = actix::Context<Self>;
+
+    fn started(&mut self, _ctx: &mut Self::Context) {
+        debug!("Blocks Manager actor has been started!");
+    }
+}

--- a/core/src/actors/mod.rs
+++ b/core/src/actors/mod.rs
@@ -27,3 +27,6 @@ pub mod storage_keys;
 
 /// Epoch manager actor module
 pub mod epoch_manager;
+
+/// Blocks manager actor module
+pub mod blocks_manager;

--- a/core/src/actors/node.rs
+++ b/core/src/actors/node.rs
@@ -12,6 +12,7 @@ use crate::actors::epoch_manager::EpochManager;
 use crate::actors::peers_manager::PeersManager;
 use crate::actors::sessions_manager::SessionsManager;
 use crate::actors::storage_manager::StorageManager;
+use crate::actors::blocks_manager::BlocksManager;
 
 /// Function to run the main system
 pub fn run(config: Option<PathBuf>, callback: fn()) -> Result<(), io::Error> {
@@ -44,6 +45,10 @@ pub fn run(config: Option<PathBuf>, callback: fn()) -> Result<(), io::Error> {
     // Start epoch manager actor
     let epoch_manager_addr = EpochManager::default().start();
     System::current().registry().set(epoch_manager_addr);
+
+    // Start blocks manager actor
+    let blocks_manager_addr = BlocksManager::default().start();
+    System::current().registry().set(blocks_manager_addr);
 
     // Run system
     system.run();

--- a/docs/architecture/managers/blocks-manager.md
+++ b/docs/architecture/managers/blocks-manager.md
@@ -1,0 +1,11 @@
+# Blocks Manager
+
+The __blocks manager__ is the actor in charge of managing the blocks of the Witnet blockchain. Among its responsabilities lie the following:
+
+* Initializing the chain info upon running the node for the first time and persisting it into storage (see **Storage Manager**).
+* Recovering the chain info from storage and keeping it in its state.
+* Validating block candidates as they come from a session (see **Sessions Manager**).
+* Consolidating multiple block candidates for the same checkpoint into a single valid block.
+* Putting valid blocks into storage by sending them to the storage manager actor.
+* Having a method for letting other components to get blocks by *hash* or *checkpoint*.
+* Having a method for letting other components to get the epoch of the current tip of the blockchain (e.g. last epoch field required for the handshake in the Witnet network protocol)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,12 +63,13 @@ nav:
     - Persistent Storage: architecture/storage.md
     - Managers:
       - Introduction: architecture/managers/managers.md
-      - Sessions Manager: architecture/managers/sessions-manager.md
-      - Connections Manager: architecture/managers/connections-manager.md
+      - Blocks Manager: architecture/managers/blocks-manager.md
       - Config Manager: architecture/managers/config-manager.md
+      - Connections Manager: architecture/managers/connections-manager.md
       - Epoch Manager: architecture/managers/epoch-manager.md
-      - Storage Manager: architecture/managers/storage-manager.md
       - Peers Manager: architecture/managers/peers-manager.md
+      - Sessions Manager: architecture/managers/sessions-manager.md
+      - Storage Manager: architecture/managers/storage-manager.md
     - Session: architecture/session.md 
     - Mempool Management: architecture/mempool-mgmt.md
     - Block Management: architecture/block-mgmt.md


### PR DESCRIPTION
This PR includes:

- [x] Creating the scaffold for the `BlocksManager` actor without adding any particular feature to it (no handlers).
- [x] Starting up `BlocksManager` from `core/actors/node.rs`
- [x] Create basic documentation page for `BlocksManager`
