### PR TITLE
feat(core): add subscribe and notify functionality in EpochManager

### DIFF
--- a/core/src/actors/blocks_manager/actor.rs
+++ b/core/src/actors/blocks_manager/actor.rs
@@ -1,0 +1,65 @@
+use actix::{Actor, ActorFuture, AsyncContext, Context, ContextFutureSpawner, System, WrapFuture};
+
+use crate::actors::epoch_manager::{
+    messages::{GetEpoch, Subscribe},
+    Epoch, EpochManager,
+};
+
+use crate::actors::blocks_manager::{
+    handlers::{EpochMessage, PeriodicMessage},
+    BlocksManager,
+};
+
+use log::{debug, error};
+
+/// Make actor from `BlocksManager`
+impl Actor for BlocksManager {
+    /// Every actor has to provide execution `Context` in which it can run
+    type Context = Context<Self>;
+
+    /// Method to be executed when the actor is started
+    fn started(&mut self, ctx: &mut Self::Context) {
+        debug!("Blocks Manager actor has been started!");
+
+        // TODO begin remove this once blocks manager real functionality is implemented
+        // Get EpochManager address from registry
+        let epoch_manager_addr = System::current().registry().get::<EpochManager>();
+
+        // Start chain of actions
+        epoch_manager_addr
+            // Send GetEpoch message to epoch manager actor
+            // This returns a Request Future, representing an asynchronous message sending process
+            .send(GetEpoch)
+            // Convert a normal future into an ActorFuture
+            .into_actor(self)
+            // Process the response from the epoch manager
+            // This returns a FutureResult containing the socket address if present
+            .then(move |res, _act, ctx| {
+                // Get blocks manager address
+                let blocks_manager_addr = ctx.address();
+
+                // Check GetEpoch result
+                match res {
+                    Ok(Ok(epoch)) => {
+                        // Subscribe to the next epoch with a EpochMessage
+                        epoch_manager_addr.do_send(Subscribe::to_epoch(
+                            Epoch(epoch.0 + 1),
+                            blocks_manager_addr.clone(),
+                            EpochMessage,
+                        ));
+
+                        // Subscribe to all epochs with a PeriodicMessage
+                        epoch_manager_addr
+                            .do_send(Subscribe::to_all(blocks_manager_addr, PeriodicMessage));
+                    }
+                    _ => {
+                        error!("Current epoch could not be retrieved from EpochManager");
+                    }
+                }
+
+                actix::fut::ok(())
+            })
+            .wait(ctx);
+        // TODO end remove this once blocks manager real functionality is implemented
+    }
+}

--- a/core/src/actors/blocks_manager/handlers.rs
+++ b/core/src/actors/blocks_manager/handlers.rs
@@ -1,0 +1,34 @@
+use actix::{Context, Handler};
+
+use crate::actors::blocks_manager::BlocksManager;
+use crate::actors::epoch_manager::messages::EpochNotification;
+
+use log::debug;
+
+////////////////////////////////////////////////////////////////////////////////////////
+// ACTOR MESSAGE HANDLERS
+////////////////////////////////////////////////////////////////////////////////////////
+/// Payload for the notification for a specific epoch
+pub struct EpochMessage;
+
+/// Payload for the notification for all epochs
+#[derive(Clone)]
+pub struct PeriodicMessage;
+
+/// Handler for EpochNotification<EpochMessage>
+impl Handler<EpochNotification<EpochMessage>> for BlocksManager {
+    type Result = ();
+
+    fn handle(&mut self, msg: EpochNotification<EpochMessage>, _ctx: &mut Context<Self>) {
+        debug!("Epoch notification received {:?}", msg.checkpoint);
+    }
+}
+
+/// Handler for EpochNotification<PeriodicMessage>
+impl Handler<EpochNotification<PeriodicMessage>> for BlocksManager {
+    type Result = ();
+
+    fn handle(&mut self, msg: EpochNotification<PeriodicMessage>, _ctx: &mut Context<Self>) {
+        debug!("Periodic epoch notification received {:?}", msg.checkpoint);
+    }
+}

--- a/core/src/actors/blocks_manager/handlers.rs
+++ b/core/src/actors/blocks_manager/handlers.rs
@@ -9,26 +9,27 @@ use log::debug;
 // ACTOR MESSAGE HANDLERS
 ////////////////////////////////////////////////////////////////////////////////////////
 /// Payload for the notification for a specific epoch
-pub struct EpochMessage;
+#[derive(Debug)]
+pub struct EpochPayload;
 
 /// Payload for the notification for all epochs
-#[derive(Clone)]
-pub struct PeriodicMessage;
+#[derive(Clone, Debug)]
+pub struct EveryEpochPayload;
 
-/// Handler for EpochNotification<EpochMessage>
-impl Handler<EpochNotification<EpochMessage>> for BlocksManager {
+/// Handler for EpochNotification<EpochPayload>
+impl Handler<EpochNotification<EpochPayload>> for BlocksManager {
     type Result = ();
 
-    fn handle(&mut self, msg: EpochNotification<EpochMessage>, _ctx: &mut Context<Self>) {
+    fn handle(&mut self, msg: EpochNotification<EpochPayload>, _ctx: &mut Context<Self>) {
         debug!("Epoch notification received {:?}", msg.checkpoint);
     }
 }
 
-/// Handler for EpochNotification<PeriodicMessage>
-impl Handler<EpochNotification<PeriodicMessage>> for BlocksManager {
+/// Handler for EpochNotification<EveryEpochPayload>
+impl Handler<EpochNotification<EveryEpochPayload>> for BlocksManager {
     type Result = ();
 
-    fn handle(&mut self, msg: EpochNotification<PeriodicMessage>, _ctx: &mut Context<Self>) {
+    fn handle(&mut self, msg: EpochNotification<EveryEpochPayload>, _ctx: &mut Context<Self>) {
         debug!("Periodic epoch notification received {:?}", msg.checkpoint);
     }
 }

--- a/core/src/actors/blocks_manager/mod.rs
+++ b/core/src/actors/blocks_manager/mod.rs
@@ -1,3 +1,17 @@
+//! # Blocks Manager actor
+//!
+//! This module contains the Blocks Manager actor which is in charge
+//! of managing the blocks of the Witnet blockchain received through
+//! the protocol. Among its responsabilities lie the following:
+//!
+//! * Initializing the chain info upon running the node for the first time and persisting it into storage [StorageManager](actors::storage_manager::StorageManager)
+//! * Recovering the chain info from storage and keeping it in its state.
+//! * Validating block candidates as they come from a session
+//! * Consolidating multiple block candidates for the same checkpoint into a single valid block.
+//! * Putting valid blocks into storage by sending them to the storage manager actor.
+//! * Having a method for letting other components to get blocks by *hash* or *checkpoint*.
+//! * Having a method for letting other components to get the epoch of the current tip of the blockchain (e.g. last epoch field required for the handshake in the Witnet network protocol)
+
 use actix::{Supervised, SystemService};
 
 mod actor;

--- a/core/src/actors/blocks_manager/mod.rs
+++ b/core/src/actors/blocks_manager/mod.rs
@@ -1,0 +1,17 @@
+use actix::{Supervised, SystemService};
+
+mod actor;
+mod handlers;
+
+////////////////////////////////////////////////////////////////////////////////////////
+// ACTOR BASIC STRUCTURE
+////////////////////////////////////////////////////////////////////////////////////////
+/// Block manager actor
+#[derive(Default)]
+pub struct BlocksManager {}
+
+/// Required trait for being able to retrieve BlocksManager address from registry
+impl Supervised for BlocksManager {}
+
+/// Required trait for being able to retrieve BlocksManager address from registry
+impl SystemService for BlocksManager {}

--- a/core/src/actors/blocks_manager/mod.rs
+++ b/core/src/actors/blocks_manager/mod.rs
@@ -1,16 +1,18 @@
-//! # Blocks Manager actor
+//! # BlocksManager actor
 //!
-//! This module contains the Blocks Manager actor which is in charge
+//! This module contains the BlocksManager actor which is in charge
 //! of managing the blocks of the Witnet blockchain received through
-//! the protocol. Among its responsabilities lie the following:
+//! the protocol. Among its responsabilities are the following:
 //!
 //! * Initializing the chain info upon running the node for the first time and persisting it into storage [StorageManager](actors::storage_manager::StorageManager)
 //! * Recovering the chain info from storage and keeping it in its state.
-//! * Validating block candidates as they come from a session
+//! * Validating block candidates as they come from a session.
 //! * Consolidating multiple block candidates for the same checkpoint into a single valid block.
 //! * Putting valid blocks into storage by sending them to the storage manager actor.
-//! * Having a method for letting other components to get blocks by *hash* or *checkpoint*.
-//! * Having a method for letting other components to get the epoch of the current tip of the blockchain (e.g. last epoch field required for the handshake in the Witnet network protocol)
+//! * Having a method for letting other components get blocks by *hash* or *checkpoint*.
+//! * Having a method for letting other components get the epoch of the current tip of the
+//! blockchain (e.g. the last epoch field required for the handshake in the Witnet network
+//! protocol).
 
 use actix::{Supervised, SystemService};
 
@@ -20,7 +22,7 @@ mod handlers;
 ////////////////////////////////////////////////////////////////////////////////////////
 // ACTOR BASIC STRUCTURE
 ////////////////////////////////////////////////////////////////////////////////////////
-/// Block manager actor
+/// BlocksManager actor
 #[derive(Default)]
 pub struct BlocksManager {}
 

--- a/core/src/actors/epoch_manager/handlers.rs
+++ b/core/src/actors/epoch_manager/handlers.rs
@@ -1,6 +1,6 @@
 use actix::Handler;
 
-use log::{debug, info};
+use log::debug;
 
 use super::{
     messages::{EpochResult, GetEpoch, SubscribeAll, SubscribeEpoch},
@@ -27,7 +27,7 @@ impl Handler<SubscribeEpoch> for EpochManager {
 
     /// Method to handle SubscribeEpoch messages
     fn handle(&mut self, msg: SubscribeEpoch, _ctx: &mut Self::Context) {
-        info!("Subscription received to checkpoint {:?}", msg.checkpoint);
+        debug!("New subscription to checkpoint {:?}", msg.checkpoint);
 
         // Store subscription to target checkpoint
         self.subscriptions_epoch
@@ -42,7 +42,7 @@ impl Handler<SubscribeAll> for EpochManager {
 
     /// Method to handle SubscribeAll messages
     fn handle(&mut self, msg: SubscribeAll, _ctx: &mut Self::Context) {
-        info!("Subscription received to all checkpoints");
+        debug!("New subscription to every checkpoint");
 
         // Store subscription to all checkpoints
         self.subscriptions_all.push(msg.notification);

--- a/core/src/actors/epoch_manager/handlers.rs
+++ b/core/src/actors/epoch_manager/handlers.rs
@@ -1,9 +1,9 @@
 use actix::Handler;
 
-use log::debug;
+use log::{debug, info};
 
 use super::{
-    messages::{EpochResult, GetEpoch},
+    messages::{EpochResult, GetEpoch, SubscribeAll, SubscribeEpoch},
     Epoch, EpochManager,
 };
 
@@ -15,8 +15,36 @@ impl Handler<GetEpoch> for EpochManager {
 
     /// Method to get the last checkpoint (current epoch)
     fn handle(&mut self, _msg: GetEpoch, _ctx: &mut Self::Context) -> EpochResult<Epoch> {
-        let r = self.current_epoch();
-        debug!("Current epoch: {:?}", r);
-        r
+        // Get the last checkpoint (current epoch)
+        let checkpoint = self.current_epoch();
+        debug!("Current epoch: {:?}", checkpoint);
+        checkpoint
+    }
+}
+
+impl Handler<SubscribeEpoch> for EpochManager {
+    type Result = ();
+
+    /// Method to handle SubscribeEpoch messages
+    fn handle(&mut self, msg: SubscribeEpoch, _ctx: &mut Self::Context) {
+        info!("Subscription received to checkpoint {:?}", msg.checkpoint);
+
+        // Store subscription to target checkpoint
+        self.subscriptions_epoch
+            .entry(msg.checkpoint)
+            .or_insert_with(|| vec![])
+            .push(msg.notification);
+    }
+}
+
+impl Handler<SubscribeAll> for EpochManager {
+    type Result = ();
+
+    /// Method to handle SubscribeAll messages
+    fn handle(&mut self, msg: SubscribeAll, _ctx: &mut Self::Context) {
+        info!("Subscription received to all checkpoints");
+
+        // Store subscription to all checkpoints
+        self.subscriptions_all.push(msg.notification);
     }
 }

--- a/core/src/actors/epoch_manager/messages.rs
+++ b/core/src/actors/epoch_manager/messages.rs
@@ -1,6 +1,8 @@
-use actix::Message;
+use actix::dev::ToEnvelope;
+use actix::{Actor, Addr, Handler, Message};
 
-use super::{Epoch, EpochManagerError};
+use super::{Epoch, EpochManagerError, NotificationAll, NotificationEpoch, NotificationSender};
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // ACTOR MESSAGES
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -12,4 +14,79 @@ pub type EpochResult<T> = Result<T, EpochManagerError>;
 
 impl Message for GetEpoch {
     type Result = EpochResult<Epoch>;
+}
+
+/// Subscribe
+pub struct Subscribe;
+
+/// Subscribe to a single checkpoint
+#[derive(Message)]
+pub struct SubscribeEpoch {
+    /// Checkpoint to be subscribed to
+    pub checkpoint: Epoch,
+
+    /// Notification to be sent when the checkpoint is reached
+    pub notification: Box<dyn NotificationSender>,
+}
+
+/// Subscribe to all new checkpoints
+#[derive(Message)]
+pub struct SubscribeAll {
+    /// Notification
+    pub notification: Box<dyn NotificationSender>,
+}
+
+impl Subscribe {
+    /// Subscribe to a specific checkpoint to get an `EpochNotification`
+    // TODO: rename to to_checkpoint?
+    // TODO: add helper Subscribe::to_next_epoch?
+    // TODO: helper to subscribe to nth epoch in the future
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_epoch<T, U>(checkpoint: Epoch, addr: Addr<U>, payload: T) -> SubscribeEpoch
+    where
+        T: 'static,
+        T: Send,
+        U: Actor,
+        U: Handler<EpochNotification<T>>,
+        U::Context: ToEnvelope<U, EpochNotification<T>>,
+    {
+        SubscribeEpoch {
+            checkpoint,
+            notification: Box::new(NotificationEpoch {
+                recipient: addr.recipient(),
+                payload: Some(payload),
+            }),
+        }
+    }
+    /// Subscribe to all checkpoints to get an `EpochNotification` on every new epoch
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_all<T, U>(addr: Addr<U>, payload: T) -> SubscribeAll
+    where
+        T: 'static,
+        T: Send,
+        T: Clone,
+        U: Actor,
+        U: Handler<EpochNotification<T>>,
+        U::Context: ToEnvelope<U, EpochNotification<T>>,
+    {
+        SubscribeAll {
+            notification: Box::new(NotificationAll {
+                recipient: addr.recipient(),
+                payload,
+            }),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////
+// MESSAGE FROM EPOCH MANAGER TO OTHER ACTORS
+////////////////////////////////////////////////////////////////////////////////////////
+/// Message that the EpochManager sends to subscriber actors to notify a new epoch
+#[derive(Message)]
+pub struct EpochNotification<T: Send> {
+    /// Epoch that has just started
+    pub checkpoint: Epoch,
+
+    /// Payload for the epoch notification
+    pub payload: T,
 }

--- a/core/src/actors/mod.rs
+++ b/core/src/actors/mod.rs
@@ -27,3 +27,6 @@ pub mod storage_keys;
 
 /// Epoch manager actor module
 pub mod epoch_manager;
+
+/// Blocks manager actor module
+pub mod blocks_manager;

--- a/core/src/actors/mod.rs
+++ b/core/src/actors/mod.rs
@@ -25,8 +25,8 @@ pub mod connections_manager;
 /// Storage keys constants
 pub mod storage_keys;
 
-/// Epoch manager actor module
+/// EpochManager actor module
 pub mod epoch_manager;
 
-/// Blocks manager actor module
+/// BlocksManager actor module
 pub mod blocks_manager;

--- a/core/src/actors/node.rs
+++ b/core/src/actors/node.rs
@@ -6,6 +6,7 @@ use std::result::Result;
 use actix::{Actor, System};
 use log::info;
 
+use crate::actors::blocks_manager::BlocksManager;
 use crate::actors::config_manager::ConfigManager;
 use crate::actors::connections_manager::ConnectionsManager;
 use crate::actors::epoch_manager::EpochManager;
@@ -44,6 +45,10 @@ pub fn run(config: Option<PathBuf>, callback: fn()) -> Result<(), io::Error> {
     // Start epoch manager actor
     let epoch_manager_addr = EpochManager::default().start();
     System::current().registry().set(epoch_manager_addr);
+
+    // Start blocks manager actor
+    let blocks_manager_addr = BlocksManager::default().start();
+    System::current().registry().set(blocks_manager_addr);
 
     // Run system
     system.run();

--- a/core/src/actors/peers_manager/mod.rs
+++ b/core/src/actors/peers_manager/mod.rs
@@ -1,12 +1,12 @@
 use std::time::Duration;
 
-use actix::{
-    ActorFuture, AsyncContext, Context, ContextFutureSpawner, Supervised, System, SystemService,
-    WrapFuture,
-};
 use crate::actors::{
     storage_keys::PEERS_KEY,
     storage_manager::{messages::Put, StorageManager},
+};
+use actix::{
+    ActorFuture, AsyncContext, Context, ContextFutureSpawner, Supervised, System, SystemService,
+    WrapFuture,
 };
 use log::{error, info};
 

--- a/docs/architecture/managers/blocks-manager.md
+++ b/docs/architecture/managers/blocks-manager.md
@@ -1,7 +1,14 @@
 # Blocks Manager
 
-The __blocks manager__ is the actor in charge of managing the blocks of Witnet blockchain in the
-node.
+The __blocks manager__ is the actor in charge of managing the blocks of the Witnet blockchain. Among its responsabilities lie the following:
+
+* Initializing the chain info upon running the node for the first time and persisting it into storage (see **Storage Manager**).
+* Recovering the chain info from storage and keeping it in its state.
+* Validating block candidates as they come from a session (see **Sessions Manager**).
+* Consolidating multiple block candidates for the same checkpoint into a single valid block.
+* Putting valid blocks into storage by sending them to the storage manager actor.
+* Having a method for letting other components to get blocks by *hash* or *checkpoint*.
+* Having a method for letting other components to get the epoch of the current tip of the blockchain (e.g. last epoch field required for the handshake in the Witnet network protocol)
 
 ## State
 

--- a/docs/architecture/managers/blocks-manager.md
+++ b/docs/architecture/managers/blocks-manager.md
@@ -1,0 +1,80 @@
+# Blocks Manager
+
+The __blocks manager__ is the actor in charge of managing the blocks of Witnet blockchain in the
+node.
+
+## State
+
+The blocks manager has no state for the time being.
+
+```rust
+/// Blocks manager actor
+pub struct BlocksManager {}
+```
+
+## Actor creation and registration
+
+The creation of the blocks manager actor and its registration into the system registry are
+performed directly by the main process [`node.rs`][noders]:
+
+```rust
+let blocks_manager_addr = BlocksManager::default().start();
+System::current().registry().set(blocks_manager_addr);
+```
+
+## API
+
+### Outgoing messages: Blocks Manager -> Others
+
+These are the messages sent by the blocks manager:
+
+| Message           | Destination       | Input type                                    | Output type   | Description                       |
+|-------------------|-------------------|-----------------------------------------------|---------------|-----------------------------------| 
+| `SubscribeEpoch`  | `EpochManager`    | `Epoch`, `Addr<BlocksManager>, EpochMessage`  | `()`          | Subscribe to a particular epoch   |  
+| `SubscribeAll`    | `EpochManager`    | `Addr<BlocksManager>, PeriodicMessage`        | `()`          | Subscribe to all epochs           |
+
+#### SubscribeEpoch
+
+This message is sent to the [`EpochManager`][epoch_manager] actor when the blocks manager actor is
+started, in order to subscribe to the next epoch (test functionality).
+
+Subscribing to the next epoch means that the [`EpochManager`][epoch_manager] will send an
+`EpochNotification<EpochMessage>` back to the `BlocksManager` when the epoch is reached.
+
+For further information, see [`EpochManager`][epoch_manager].
+
+#### SubscribeAll
+
+This message is sent to the [`EpochManager`][epoch_manager] actor when the blocks manager actor is
+started, in order to subscribe to the all epochs (test functionality).
+
+Subscribing to all epochs means that the [`EpochManager`][epoch_manager] will send an
+`EpochNotification<PeriodicMessage>` back to the `BlocksManager` when every epoch is reached.
+
+For further information, see [`EpochManager`][epoch_manager].
+
+### Incoming: Others -> Blocks Manager
+
+These are the messages supported by the blocks manager handlers:
+
+| Message                               | Input type                    | Output type   | Description                           |
+|---------------------------------------|-------------------------------|---------------| --------------------------------------|
+| `EpochNotification<EpochMessage>`     | `Epoch`, `EpochMessage`       | `()`          | The requested epoch has been reached  | 
+| `EpochNotification<PeriodicMessage>`  | `Epoch`, `PeriodicMessage`    | `()`          | A new epoch has been reached          |
+
+For the time being, the handlers for those message just print a debug message with the notified
+checkpoint. 
+
+```rust
+fn handle(&mut self, msg: EpochNotification<EpochMessage>, _ctx: &mut Context<Self>) {
+    debug!("Epoch notification received {:?}", msg.checkpoint);
+}
+```
+
+## Further information
+
+The full source code of the `BlocksManager` can be found at [`blocks_manager.rs`][blocks_manager].
+
+[blocks_manager]: https://github.com/witnet/witnet-rust/blob/master/core/src/actors/blocks_manager.rs
+[epoch_manager]: https://github.com/witnet/witnet-rust/blob/master/core/src/actors/epoch_manager.rs
+[noders]: https://github.com/witnet/witnet-rust/blob/master/core/src/actors/node.rs

--- a/docs/architecture/managers/blocks-manager.md
+++ b/docs/architecture/managers/blocks-manager.md
@@ -1,6 +1,6 @@
 # Blocks Manager
 
-The __blocks manager__ is the actor in charge of managing the blocks of the Witnet blockchain. Among its responsabilities lie the following:
+The __blocks manager__ is the actor in charge of managing the blocks of the Witnet blockchain. Among its responsabilities are the following:
 
 * Initializing the chain info upon running the node for the first time and persisting it into storage (see **Storage Manager**).
 * Recovering the chain info from storage and keeping it in its state.
@@ -8,14 +8,14 @@ The __blocks manager__ is the actor in charge of managing the blocks of the Witn
 * Consolidating multiple block candidates for the same checkpoint into a single valid block.
 * Putting valid blocks into storage by sending them to the storage manager actor.
 * Having a method for letting other components to get blocks by *hash* or *checkpoint*.
-* Having a method for letting other components to get the epoch of the current tip of the blockchain (e.g. last epoch field required for the handshake in the Witnet network protocol)
+* Having a method for letting other components get the epoch of the current tip of the blockchain (e.g. last epoch field required for the handshake in the Witnet network protocol).
 
 ## State
 
 The blocks manager has no state for the time being.
 
 ```rust
-/// Blocks manager actor
+/// BlocksManager actor
 pub struct BlocksManager {}
 ```
 
@@ -31,22 +31,22 @@ System::current().registry().set(blocks_manager_addr);
 
 ## API
 
-### Outgoing messages: Blocks Manager -> Others
+### Outgoing messages: BlocksManager -> Others
 
 These are the messages sent by the blocks manager:
 
 | Message           | Destination       | Input type                                    | Output type   | Description                       |
 |-------------------|-------------------|-----------------------------------------------|---------------|-----------------------------------| 
-| `SubscribeEpoch`  | `EpochManager`    | `Epoch`, `Addr<BlocksManager>, EpochMessage`  | `()`          | Subscribe to a particular epoch   |  
-| `SubscribeAll`    | `EpochManager`    | `Addr<BlocksManager>, PeriodicMessage`        | `()`          | Subscribe to all epochs           |
+| `SubscribeEpoch`  | `EpochManager`    | `Epoch`, `Addr<BlocksManager>, EpochPayload`  | `()`          | Subscribe to a particular epoch   |  
+| `SubscribeAll`    | `EpochManager`    | `Addr<BlocksManager>, EveryEpochPayload`      | `()`          | Subscribe to all epochs           |
 
 #### SubscribeEpoch
 
-This message is sent to the [`EpochManager`][epoch_manager] actor when the blocks manager actor is
+This message is sent to the [`EpochManager`][epoch_manager] actor when the `BlocksManager` actor is
 started, in order to subscribe to the next epoch (test functionality).
 
 Subscribing to the next epoch means that the [`EpochManager`][epoch_manager] will send an
-`EpochNotification<EpochMessage>` back to the `BlocksManager` when the epoch is reached.
+`EpochNotification<EpochPayload>` back to the `BlocksManager` when the epoch is reached.
 
 For further information, see [`EpochManager`][epoch_manager].
 
@@ -56,24 +56,24 @@ This message is sent to the [`EpochManager`][epoch_manager] actor when the block
 started, in order to subscribe to the all epochs (test functionality).
 
 Subscribing to all epochs means that the [`EpochManager`][epoch_manager] will send an
-`EpochNotification<PeriodicMessage>` back to the `BlocksManager` when every epoch is reached.
+`EpochNotification<EveryEpochPayload>` back to the `BlocksManager` when every epoch is reached.
 
 For further information, see [`EpochManager`][epoch_manager].
 
-### Incoming: Others -> Blocks Manager
+### Incoming: Others -> BlocksManager
 
-These are the messages supported by the blocks manager handlers:
+These are the messages supported by the `BlocksManager` handlers:
 
-| Message                               | Input type                    | Output type   | Description                           |
-|---------------------------------------|-------------------------------|---------------| --------------------------------------|
-| `EpochNotification<EpochMessage>`     | `Epoch`, `EpochMessage`       | `()`          | The requested epoch has been reached  | 
-| `EpochNotification<PeriodicMessage>`  | `Epoch`, `PeriodicMessage`    | `()`          | A new epoch has been reached          |
+| Message                                   | Input type                    | Output type   | Description                           |
+|-------------------------------------------|-------------------------------|---------------| --------------------------------------|
+| `EpochNotification<EpochPayload>`         | `Epoch`, `EpochPayload`       | `()`          | The requested epoch has been reached  | 
+| `EpochNotification<EveryEpochPayload>`    | `Epoch`, `EveryEpochPayload`  | `()`          | A new epoch has been reached          |
 
 For the time being, the handlers for those message just print a debug message with the notified
 checkpoint. 
 
 ```rust
-fn handle(&mut self, msg: EpochNotification<EpochMessage>, _ctx: &mut Context<Self>) {
+fn handle(&mut self, msg: EpochNotification<EpochPayload>, _ctx: &mut Context<Self>) {
     debug!("Epoch notification received {:?}", msg.checkpoint);
 }
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,13 +64,13 @@ nav:
     - Persistent Storage: architecture/storage.md
     - Managers:
       - Introduction: architecture/managers/managers.md
-      - Sessions Manager: architecture/managers/sessions-manager.md
-      - Connections Manager: architecture/managers/connections-manager.md
-      - Config Manager: architecture/managers/config-manager.md
-      - Epoch Manager: architecture/managers/epoch-manager.md
-      - Storage Manager: architecture/managers/storage-manager.md
-      - Peers Manager: architecture/managers/peers-manager.md
       - Blocks Manager: architecture/managers/blocks-manager.md
+      - Config Manager: architecture/managers/config-manager.md
+      - Connections Manager: architecture/managers/connections-manager.md
+      - Epoch Manager: architecture/managers/epoch-manager.md
+      - Peers Manager: architecture/managers/peers-manager.md
+      - Sessions Manager: architecture/managers/sessions-manager.md
+      - Storage Manager: architecture/managers/storage-manager.md
     - Session: architecture/session.md
     - Mempool Management: architecture/mempool-mgmt.md
     - Block Management: architecture/block-mgmt.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,8 @@ nav:
       - Epoch Manager: architecture/managers/epoch-manager.md
       - Storage Manager: architecture/managers/storage-manager.md
       - Peers Manager: architecture/managers/peers-manager.md
-    - Session: architecture/session.md 
+      - Blocks Manager: architecture/managers/blocks-manager.md
+    - Session: architecture/session.md
     - Mempool Management: architecture/mempool-mgmt.md
     - Block Management: architecture/block-mgmt.md
     - UTXO Management: architecture/utxo-mgmt.md


### PR DESCRIPTION
This PR adds the functionality described in #105 and #107 for the `EpochManager`, that is:

- Handler for the `SubscribeEpoch` message in the `EpochManager` for other actors to subscribe to a particular epoch. The `SubscribeEpoch` message contains a notification object that implements the `NotificationSender` trait and knows how to notify the subscriber actor when that epoch is reached. When the message is received at the `EpochManager`, that notification object is stored in the `EpochManager` state.

- Handler for the `SubscribeAll` message in the `EpochManager` for other actors to subscribe to all epochs. The `SubscribeAll` message contains a notification object that implements the `NotificationSender` trait and knows how to notify the subscriber actor when a new epoch is reached. When the message is received at the `EpochManager`, that notification object is stored in the `EpochManager` state.

- Periodic epoch monitoring process in the `EpochManager`. This method will try to execute always at the start of a new epoch. This method will:
  - Send a notification for subscribers that subscribe to all epochs
  - Send a notification for all subscribers that subscribed to a past epoch (if for some reason they were not notified in time at their target epoch)
  - Send a notification for all subscribers that subscribed to current epoch

- Basic blocks manager with the following functionality:
  - Subscribe to the next epoch (from its start)
  - Subscribe to all epochs

- Update documentation for `EpochManager` and for `BlocksManager`



