### PR TITLE
feat(core): add broadcast message to sessions manager

### DIFF
--- a/core/src/actors/sessions_manager/messages.rs
+++ b/core/src/actors/sessions_manager/messages.rs
@@ -87,3 +87,18 @@ where
 {
     type Result = ();
 }
+
+/// Message indicating a message is to be forwarded to all the consolidated outbound sessions
+pub struct Broadcast<T> {
+    /// Command to be sent to all the sessions
+    pub command: T,
+}
+
+impl<T> Message for Broadcast<T>
+where
+    T: Clone + Message + Send,
+    T::Result: Send,
+    Session: Handler<T>,
+{
+    type Result = ();
+}

--- a/docs/architecture/managers/sessions-manager.md
+++ b/docs/architecture/managers/sessions-manager.md
@@ -55,6 +55,7 @@ These are the messages supported by the sessions manager handlers:
 | `Unregister`  | `SocketAddr, SessionType, SessionStatus`  | `SessionsResult<()>`  | Request to unregister a session                   |
 | `Consolidate` | `SocketAddr, SessionType`                 | `SessionsResult<()>`  | Request to consolidate a session                  |
 | `Anycast<T>`  | `T`                                       | `()`                  | Request to send a T message to a random Session   |
+| `Broadcast<T>`| `T`                                       | `()`                  | Request to send a T message to all the consolidated outbound sesions |
 
 The handling of these messages is basically just calling the corresponding methods from the
 [`Sessions`][sessions] library. For example, the handler of the `Register` message would be
@@ -106,7 +107,9 @@ session_manager_addr
     })
     .wait(ctx);
 ```
+
 #### Anycast<T>
+
 The handler for `Anycast<T>` messages is basically just calling the method `get_random_anycast_session` from the
 [`Sessions`][sessions] library to obtain a random `Session` and forward the `T` message to it.
 
@@ -128,6 +131,15 @@ The return value of the delegated call is processed by `act.process_command_resp
         }
     }
 ```
+
+#### Broadcast<T>
+
+Similarly to the `Anycast<T>` handler, the handler for `Broadcast<T>` is just calling
+the method `get_all_consolidated_outbound_sessions` from [`Sessions`][sessions] library
+and forwards the message `T` to all the received addresses.
+
+This message does not do any error handling, the messages are all assumed to be
+successfully sent.
 
 ### Outgoing messages: Sessions Manager -> Others
 

--- a/p2p/src/sessions/mod.rs
+++ b/p2p/src/sessions/mod.rs
@@ -161,6 +161,13 @@ where
             .nth(index)
             .map(|info| info.reference.clone())
     }
+    /// Method to get all the consolidated outbound sessions
+    pub fn get_all_consolidated_outbound_sessions<'a>(&'a self) -> impl Iterator<Item = &T> + 'a {
+        self.outbound_consolidated
+            .collection
+            .values()
+            .map(|info| &info.reference)
+    }
     /// Method to insert a new session
     pub fn register_session(
         &mut self,


### PR DESCRIPTION
Similarly to the anycast message, the broadcast message forwards the wrapped message to all the consolidated outbound sessions.

In order to broadcast a message, the message needs to implement Clone.

Proof of work: sending a `Broadcast<GetPeers>`:

![broadcast_getpeers](https://user-images.githubusercontent.com/44604217/48767436-09a86000-ecb7-11e8-9427-696971837bf2.png)
