### PR TITLE
feat(config): add jsonrpc section and server_address under it

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -66,6 +66,9 @@ pub struct Config {
 
     /// Consensus-critical configuration
     pub consensus_constants: ConsensusConstants,
+
+    /// JSON-RPC API configuration
+    pub jsonrpc: JsonRPC,
 }
 
 /// Connection-specific configuration.
@@ -119,6 +122,14 @@ pub struct ConsensusConstants {
     pub checkpoints_period: u16,
 }
 
+/// JsonRPC API configuration
+#[derive(Debug, Clone, PartialEq)]
+pub struct JsonRPC {
+    /// JSON-RPC server address, that is, the socket address (interface ip and
+    /// port) for the JSON-RPC server
+    pub server_address: SocketAddr,
+}
+
 /// Possible values for the "environment" configuration param.
 #[derive(Deserialize, Clone, Debug, PartialEq)]
 pub enum Environment {
@@ -162,6 +173,7 @@ impl Config {
             connections: Connections::from_partial(&config.connections, &*defaults),
             storage: Storage::from_partial(&config.storage, &*defaults),
             consensus_constants,
+            jsonrpc: JsonRPC::from_partial(&config.jsonrpc, &*defaults),
         }
     }
 }
@@ -233,6 +245,17 @@ impl ConsensusConstants {
                 .checkpoint_period
                 .to_owned()
                 .unwrap_or_else(|| defaults.consensus_constants_checkpoints_period()),
+        }
+    }
+}
+
+impl JsonRPC {
+    pub fn from_partial(config: &partial::JsonRPC, defaults: &dyn Defaults) -> Self {
+        JsonRPC {
+            server_address: config
+                .server_address
+                .to_owned()
+                .unwrap_or_else(|| defaults.jsonrpc_server_address()),
         }
     }
 }

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -339,6 +339,27 @@ mod tests {
     }
 
     #[test]
+    fn test_jsonrpc_default_from_partial() {
+        let defaults: Box<Defaults> = Box::new(Testnet1);
+        let partial_config = partial::JsonRPC::default();
+        let config = JsonRPC::from_partial(&partial_config, &*defaults);
+
+        assert_eq!(config.server_address, Testnet1.jsonrpc_server_address());
+    }
+
+    #[test]
+    fn test_jsonrpc_from_partial() {
+        let defaults: Box<Defaults> = Box::new(Testnet1);
+        let addr: SocketAddr = "127.0.0.1:4000".parse().unwrap();
+        let partial_config = partial::JsonRPC {
+            server_address: Some(addr),
+        };
+        let config = JsonRPC::from_partial(&partial_config, &*defaults);
+
+        assert_eq!(config.server_address, addr);
+    }
+
+    #[test]
     fn test_config_default_from_partial() {
         let partial_config = partial::Config::default();
         let config = Config::from_partial(&partial_config);
@@ -377,5 +398,9 @@ mod tests {
             Testnet1.connections_handshake_timeout()
         );
         assert_eq!(config.storage.db_path, Testnet1.storage_db_path());
+        assert_eq!(
+            config.jsonrpc.server_address,
+            Testnet1.jsonrpc_server_address()
+        );
     }
 }

--- a/config/src/config/partial.rs
+++ b/config/src/config/partial.rs
@@ -35,6 +35,10 @@ pub struct Config {
     /// Consensus-critical configuration
     #[serde(default)]
     pub consensus_constants: ConsensusConstants,
+
+    /// JSON-RPC API configuration
+    #[serde(default)]
+    pub jsonrpc: JsonRPC,
 }
 
 /// Connection-specific partial configuration.
@@ -102,6 +106,14 @@ pub struct ConsensusConstants {
     #[serde(default)]
     #[serde(rename = "checkpoint_period_seconds")]
     pub checkpoint_period: Option<u16>,
+}
+
+/// JSON-RPC API configuration
+#[derive(Deserialize, Default, Debug, Clone, PartialEq)]
+pub struct JsonRPC {
+    /// JSON-RPC server address, that is, the socket address (interface ip and
+    /// port) for the JSON-RPC server
+    pub server_address: Option<SocketAddr>,
 }
 
 impl Default for Environment {

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -63,6 +63,9 @@ pub trait Defaults {
     fn consensus_constants_checkpoints_period(&self) -> u16 {
         90
     }
+
+    /// Default JSON-RPC server addr
+    fn jsonrpc_server_address(&self) -> SocketAddr;
 }
 
 /// Struct that will implement all the mainnet defaults
@@ -76,9 +79,14 @@ impl Defaults for Mainnet {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 11337)
     }
 
+    fn jsonrpc_server_address(&self) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 11338)
+    }
+
     fn storage_db_path(&self) -> PathBuf {
         PathBuf::from(".witnet-rust-mainnet")
     }
+
     fn consensus_constants_checkpoint_zero_timestamp(&self) -> i64 {
         // A point far in the future, so the `EpochManager` will return an error `EpochZeroInTheFuture`
         19_999_999_999_999
@@ -88,6 +96,10 @@ impl Defaults for Mainnet {
 impl Defaults for Testnet1 {
     fn connections_server_addr(&self) -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 21337)
+    }
+
+    fn jsonrpc_server_address(&self) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 21338)
     }
 
     fn storage_db_path(&self) -> PathBuf {

--- a/config/src/loaders/toml.rs
+++ b/config/src/loaders/toml.rs
@@ -191,4 +191,22 @@ handshake_timeout_seconds = 21
             Some(Duration::from_secs(21))
         );
     }
+
+    #[test]
+    fn test_configure_jsonrpc() {
+        let empty_config = super::from_str("[jsonrpc]").unwrap();
+        let config = super::from_str(
+            r"
+[jsonrpc]
+server_address = '127.0.0.1:1234'
+",
+        )
+        .unwrap();
+
+        assert_eq!(empty_config.jsonrpc, JsonRPC::default());
+        assert_eq!(
+            config.jsonrpc.server_address,
+            Some("127.0.0.1:1234".parse().unwrap())
+        );
+    }
 }

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -20,6 +20,7 @@ At the moment, the available environments are: `testnet-1` and `mainnet`.
 | `storage`             | `db_path`                        | `".witnet-rust-testnet-1"` | Directory containing the database files                             |
 | `consensus_constants` | `checkpoint_zero_timestamp`      | `9_999_999_999_999`        | Timestamp at checkpoint 0 (the start of epoch 0)                    |
 | `consensus_constants` | `checkpoints_period_seconds`     | `90`                       | Seconds between the start of an epoch and the start of the next one |
+| `jsonrpc`             | `server_address`                 | `"127.0.0.1:21338"`        | JSON-RPC server socket address                                      |
 
 ## Defaults for Mainnet
 
@@ -35,3 +36,4 @@ At the moment, the available environments are: `testnet-1` and `mainnet`.
 | `storage`             | `db_path`                        | `".witnet-rust-mainnet"`   | Directory containing the database files                             |
 | `consensus_constants` | `checkpoint_zero_timestamp`      | `19_999_999_999_999`       | Timestamp at checkpoint 0 (the start of epoch 0)                    |
 | `consensus_constants` | `checkpoints_period_seconds`     | `90`                       | Seconds between the start of an epoch and the start of the next one |
+| `jsonrpc`             | `server_address`                 | `"127.0.0.1:11338"`        | JSON-RPC server socket address                                      |

--- a/docs/configuration/toml-file.md
+++ b/docs/configuration/toml-file.md
@@ -23,6 +23,9 @@ db_path = ".wit"
 checkpoint_zero_timestamp = 1542203073
 checkpoints_period_seconds = 90
 
+[jsonrpc] # section for params related to JSON-RPC API
+server_address = "127.0.0.1:4321"
+
 # ... more options
 ```
 
@@ -40,6 +43,7 @@ checkpoints_period_seconds = 90
 | `storage`             | `db_path`                        | `".witnet-rust-testnet-1"` | Directory containing the database files                             |
 | `consensus_constants` | `checkpoint_zero_timestamp`      | `9_999_999_999_999`        | Timestamp at checkpoint 0 (the start of epoch 0)                    |
 | `consensus_constants` | `checkpoints_period_seconds`     | `90`                       | Seconds between the start of an epoch and the start of the next one |
+| `jsonrpc`             | `server_address`                 | `"127.0.0.1:21338"`        | JSON-RPC server socket address                                      |                
 
 These are the defaults for `testnet-1`.
 See [environment][environment] for the specific values for all the environments.


### PR DESCRIPTION
This PR implements the first three actionables of #152 :

- Add a new `[jsonrpc]` section in configuration and a `server_address` param under it.
- Add tests for it
- Add documentation for this new section and parameter

`ConfigManager` already reads the whole configuration, no change was required for that.

This PR does not close the issue #152 , as more work is required.
