### PR TITLE
feat(core): Create ChainInfo data structure and make BlocksManager load it from Storage

### DIFF
--- a/config/src/config/partial.rs
+++ b/config/src/config/partial.rs
@@ -8,12 +8,12 @@
 //! later, the `config` module will use this partial config object and
 //! the environment-specific defaults (see the `environment` module)
 //! to produce a __total__ (no `Option` fields) configuration object.
-use crate::config::Environment;
 use std::collections::HashSet;
 use std::default::Default;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
+use witnet_data_structures::chain::Environment;
 
 /// The partial configuration object that contains all other, more
 /// specific, configuration objects (connections, storage, etc).
@@ -102,10 +102,23 @@ pub struct ConsensusConstants {
     /// Timestamp at checkpoint 0 (the start of epoch 0)
     #[serde(default)]
     pub checkpoint_zero_timestamp: Option<i64>,
+
     /// Seconds between the start of an epoch and the start of the next one
     #[serde(default)]
-    #[serde(rename = "checkpoint_period_seconds")]
-    pub checkpoint_period: Option<u16>,
+    #[serde(rename = "checkpoints_period_seconds")]
+    pub checkpoints_period: Option<u16>,
+
+    /// Genesis block hash value
+    #[serde(default)]
+    pub genesis_hash: Option<Vec<u8>>,
+
+    /// Decay value for reputation demurrage function
+    #[serde(default)]
+    pub reputation_demurrage: Option<f64>,
+
+    /// Punishment value for dishonestly use
+    #[serde(default)]
+    pub reputation_punishment: Option<f64>,
 }
 
 /// JSON-RPC API configuration
@@ -114,12 +127,6 @@ pub struct JsonRPC {
     /// JSON-RPC server address, that is, the socket address (interface ip and
     /// port) for the JSON-RPC server
     pub server_address: Option<SocketAddr>,
-}
-
-impl Default for Environment {
-    fn default() -> Environment {
-        Environment::Testnet1
-    }
 }
 
 impl Config {

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -64,6 +64,24 @@ pub trait Defaults {
         90
     }
 
+    /// Default Hash value for the genesis block
+    fn consensus_constants_genesis_hash(&self) -> Vec<u8> {
+        Vec::new()
+    }
+    // TODO Decide an appropriate default value
+
+    /// Default demurrage value for reputation algorithm
+    fn consensus_constants_reputation_demurrage(&self) -> f64 {
+        0.0
+    }
+    // TODO Decide an appropriate default value
+
+    /// Default punishment value for reputation algorithm
+    fn consensus_constants_reputation_punishment(&self) -> f64 {
+        0.0
+    }
+    // TODO Decide an appropriate default value
+
     /// Default JSON-RPC server addr
     fn jsonrpc_server_address(&self) -> SocketAddr;
 }

--- a/config/src/loaders/toml.rs
+++ b/config/src/loaders/toml.rs
@@ -68,8 +68,8 @@ pub fn from_str(contents: &str) -> Result<Config> {
 #[cfg(test)]
 mod tests {
     use crate::config::partial::*;
-    use crate::config::Environment;
     use std::path::{Path, PathBuf};
+    use witnet_data_structures::chain::Environment;
 
     #[test]
     fn test_load_empty_config() {

--- a/core/src/actors/storage_keys.rs
+++ b/core/src/actors/storage_keys.rs
@@ -1,2 +1,5 @@
 /// Constant to specify the peers key for the storage
 pub static PEERS_KEY: &'static [u8] = b"peers";
+
+/// Constant to specify the chain key for the storage
+pub static CHAIN_KEY: &'static [u8] = b"chain";

--- a/data_structures/Cargo.toml
+++ b/data_structures/Cargo.toml
@@ -10,3 +10,6 @@ edition = "2018"
 flatbuffers = "0.5.0"
 rand = "0.5.5"
 witnet_util = { path = "../util" }
+serde = "1.0.79"
+serde_derive = "1.0.79"
+toml = "0.4.6"

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1,0 +1,64 @@
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ChainInfo {
+    /// Blockchain valid environment
+    pub environment: Environment,
+
+    /// Blockchain Protocol constants
+    pub consensus_constants: ConsensusConstants,
+
+    /// Checkpoint of the last block in the blockchain
+    pub highest_block_checkpoint: Checkpoint,
+}
+
+/// Possible values for the "environment" configuration param.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum Environment {
+    /// "mainnet" environment
+    #[serde(rename = "mainnet")]
+    Mainnet,
+    /// "testnet" environment
+    #[serde(rename = "testnet-1")]
+    Testnet1,
+}
+
+impl Default for Environment {
+    fn default() -> Environment {
+        Environment::Testnet1
+    }
+}
+
+/// Consensus-critical configuration
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConsensusConstants {
+    /// Timestamp at checkpoint 0 (the start of epoch 0)
+    pub checkpoint_zero_timestamp: i64,
+
+    /// Seconds between the start of an epoch and the start of the next one
+    pub checkpoints_period: u16,
+
+    /// Genesis block hash value
+    pub genesis_hash: Vec<u8>,
+
+    /// Decay value for reputation demurrage function
+    //TODO Use fixed point arithmetic
+    pub reputation_demurrage: f64,
+
+    /// Punishment value for dishonestly use
+    //TODO Use fixed point arithmetic
+    pub reputation_punishment: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct Checkpoint {
+    pub number: u32,
+    pub hash: Vec<u8>,
+}
+
+impl Default for Checkpoint {
+    fn default() -> Checkpoint {
+        Checkpoint {
+            number: 0,
+            hash: Vec::new(),
+        }
+    }
+}

--- a/data_structures/src/lib.rs
+++ b/data_structures/src/lib.rs
@@ -1,6 +1,11 @@
 // To enable `#[allow(clippy::all)]`
 //#![feature(tool_lints)]
 
+#![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
+
+#[macro_use]
+extern crate serde_derive;
+
 /// Module containing functions to generate witnet's protocol messages
 pub mod builders;
 
@@ -12,3 +17,6 @@ pub mod serializers;
 
 /// Module containing witnet's protocol messages types
 pub mod types;
+
+/// Module containing ChainInfo data structure
+pub mod chain;

--- a/docs/architecture/managers/blocks-manager.md
+++ b/docs/architecture/managers/blocks-manager.md
@@ -12,11 +12,15 @@ The __blocks manager__ is the actor in charge of managing the blocks of the Witn
 
 ## State
 
-The blocks manager has no state for the time being.
+The state of the actor is an instance of the [`ChainInfo`][chain] data structures.
 
 ```rust
 /// BlocksManager actor
-pub struct BlocksManager {}
+#[derive(Default)]
+pub struct BlocksManager {
+    /// Blockchain information data structure
+    chain_info: Option<ChainInfo>,
+}
 ```
 
 ## Actor creation and registration
@@ -78,6 +82,34 @@ fn handle(&mut self, msg: EpochNotification<EpochPayload>, _ctx: &mut Context<Se
 }
 ```
 
+### Outgoing messages: Peers Manager -> Others
+
+These are the messages sent by the peers manager:
+
+| Message     | Destination       | Input type                                | Output type                 | Description                               |
+| ----------- | ----------------- | ----------------------------------------- | --------------------------- | ----------------------------------------- |
+| `GetConfig` | `ConfigManager`   | `()`                                      | `Result<Config, io::Error>` | Request the configuration                 |
+| `Get`       | `StorageManager`  | `&'static [u8]`                           | `StorageResult<Option<T>>`  | Wrapper to Storage `get()` method         |
+| `Put`       | `StorageManager`  | `&'static [u8]`, `Vec<u8>`                | `StorageResult<()>`         | Wrapper to Storage `put()` method         |
+
+#### GetConfig
+
+This message is sent to the [`ConfigManager`][config_manager] actor when the peers manager actor is started.
+
+The return value is used to initialize the list of known peers. For further information, see  [`ConfigManager`][config_manager].
+
+#### Get
+
+This message is sent to the [`StorageManager`][storage_manager] actor when the blocks manager actor is started.
+
+The return value is a `ChainInfo` structure from the storage which are added to the state of the actor.
+
+#### Put
+
+This message is sent to the [`StorageManager`][storage_manager] actor to persist the `ChainInfo` structure
+
+The return value is used to check if the storage process has been successful.
+
 ## Further information
 
 The full source code of the `BlocksManager` can be found at [`blocks_manager.rs`][blocks_manager].
@@ -85,3 +117,4 @@ The full source code of the `BlocksManager` can be found at [`blocks_manager.rs`
 [blocks_manager]: https://github.com/witnet/witnet-rust/blob/master/core/src/actors/blocks_manager.rs
 [epoch_manager]: https://github.com/witnet/witnet-rust/blob/master/core/src/actors/epoch_manager.rs
 [noders]: https://github.com/witnet/witnet-rust/blob/master/core/src/actors/node.rs
+[chain]: https://github.com/witnet/witnet-rust/tree/master/data_structures/src/chain.rs


### PR DESCRIPTION
This PR implements the requirements for the issues #130 #146 #150 

- Fix typo in config parameter `checkpoints_period`.
- Implement ChainInfo data structure.
- Make BlocksManager query ConfigManager for environment name and protocol constants and keep all that info into state.
- Make BlocksManager query StorageManager for the stored ChainInfo upon startup.
- Update documentation to reflect BlocksManager actor state.
- Update documentation to reflect all the new behavior and outcoming actor messages.

Close #130 
Close #146 
Close #150
