### PR TITLE
fix(core): add outbound/inbound checks in Session's StreamHandler

### DIFF
--- a/core/src/actors/session/handlers.rs
+++ b/core/src/actors/session/handlers.rs
@@ -82,8 +82,8 @@ impl StreamHandler<BytesMut, Error> for Session {
                     /////////////////////
                     (session_type, session_status, msg_type) => {
                         warn!(
-                            "Received a message of type \"{:?}\" for a session with {:?} type and\
-                             in {:?} status, which is not implemented yet",
+                            "Message of type \"{:?}\" for session (type: {:?}, status: {:?}) is \
+                             not supported",
                             msg_type, session_type, session_status
                         );
                     }


### PR DESCRIPTION
The handling of some protocol messages is only allowed for a certain type of sessions (outbound/inbound).

This PR introduces the check of the session type in the `StreamHandler`of the `Session`. It also fixes this check for the `Peers` message (`Peers` message should only be allowed for outbound sessions).