### PR TITLE
feat(data-structures): add get_data protocol message

### DIFF
--- a/data_structures/src/builders.rs
+++ b/data_structures/src/builders.rs
@@ -6,7 +6,8 @@ use rand::{thread_rng, Rng};
 use crate::chain::{Block, BlockHeaderWithProof, InvVector, Transaction};
 
 use crate::types::{
-    Address, Command, GetPeers, Inv, IpAddress, Message, Peers, Ping, Pong, Verack, Version,
+    Address, Command, GetData, GetPeers, Inv, IpAddress, Message, Peers, Ping, Pong, Verack,
+    Version,
 };
 
 use witnet_util::timestamp::get_timestamp;
@@ -100,6 +101,13 @@ impl Message {
     pub fn build_inv(inv_vectors: Vec<InvVector>) -> Message {
         Message::build_message(Command::Inv(Inv {
             inventory: inv_vectors,
+        }))
+    }
+
+    /// Function to build GetData messages
+    pub fn build_get_data(inv_elems: Vec<InvElem>) -> Message {
+        Message::build_message(Command::GetData(GetData {
+            inventory: inv_elems,
         }))
     }
 

--- a/data_structures/src/builders.rs
+++ b/data_structures/src/builders.rs
@@ -105,9 +105,9 @@ impl Message {
     }
 
     /// Function to build GetData messages
-    pub fn build_get_data(inv_elems: Vec<InvElem>) -> Message {
+    pub fn build_get_data(inv_vectors: Vec<InvVector>) -> Message {
         Message::build_message(Command::GetData(GetData {
-            inventory: inv_elems,
+            inventory: inv_vectors,
         }))
     }
 

--- a/data_structures/src/flatbuffers/protocol_generated.rs
+++ b/data_structures/src/flatbuffers/protocol_generated.rs
@@ -26,11 +26,11 @@ pub enum Command {
   Pong = 6,
   Block = 7,
   Inv = 8,
-
+  GetData = 9,
 }
 
 const ENUM_MIN_COMMAND: u8 = 0;
-const ENUM_MAX_COMMAND: u8 = 8;
+const ENUM_MAX_COMMAND: u8 = 9;
 
 impl<'a> flatbuffers::Follow<'a> for Command {
   type Inner = Self;
@@ -64,7 +64,7 @@ impl flatbuffers::Push for Command {
 }
 
 #[allow(non_camel_case_types)]
-const ENUM_VALUES_COMMAND:[Command; 9] = [
+const ENUM_VALUES_COMMAND:[Command; 10] = [
   Command::NONE,
   Command::Version,
   Command::Verack,
@@ -73,11 +73,12 @@ const ENUM_VALUES_COMMAND:[Command; 9] = [
   Command::Ping,
   Command::Pong,
   Command::Block,
-  Command::Inv
+  Command::Inv,
+  Command::GetData
 ];
 
 #[allow(non_camel_case_types)]
-const ENUM_NAMES_COMMAND:[&'static str; 9] = [
+const ENUM_NAMES_COMMAND:[&'static str; 10] = [
     "NONE",
     "Version",
     "Verack",
@@ -86,7 +87,8 @@ const ENUM_NAMES_COMMAND:[&'static str; 9] = [
     "Ping",
     "Pong",
     "Block",
-    "Inv"
+    "Inv",
+    "GetData"
 ];
 
 pub fn enum_name_command(e: Command) -> &'static str {
@@ -479,6 +481,15 @@ impl<'a> Message<'a> {
     }
   }
 
+  #[inline]
+  #[allow(non_snake_case)]
+  pub fn command_as_get_data(&'a self) -> Option<GetData> {
+    if self.command_type() == Command::GetData {
+      Some(GetData::init_from_table(self.command()))
+    } else {
+      None
+    }
+  }
 }
 
 pub struct MessageArgs {
@@ -2188,6 +2199,83 @@ impl<'a: 'b, 'b> InvBuilder<'a, 'b> {
     self.fbb_.required(o, Inv::VT_INVENTORY,"inventory");
     flatbuffers::WIPOffset::new(o.value())
   }
+}
+
+pub enum GetDataOffset {}
+#[derive(Copy, Clone, Debug, PartialEq)]
+
+pub struct GetData<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for GetData<'a> {
+    type Inner = GetData<'a>;
+    #[inline]
+    fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table { buf: buf, loc: loc },
+        }
+    }
+}
+
+impl<'a> GetData<'a> {
+    #[inline]
+    pub fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        GetData {
+            _tab: table,
+        }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args GetDataArgs<'args>) -> flatbuffers::WIPOffset<Inv<'bldr>> {
+        let mut builder = GetDataBuilder::new(_fbb);
+        if let Some(x) = args.inventory { builder.add_inventory(x); }
+        builder.finish()
+    }
+
+    pub const VT_INVENTORY: flatbuffers::VOffsetT = 4;
+
+    #[inline]
+    pub fn inventory(&self) -> flatbuffers::Vector<flatbuffers::ForwardsUOffset<InvElem<'a>>> {
+        self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<InvElem<'a>>>>>(GetData::VT_INVENTORY, None).unwrap()
+    }
+}
+
+pub struct GetDataArgs<'a> {
+    pub inventory: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<InvElem<'a >>>>>,
+}
+impl<'a> Default for GetDataArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        GetDataArgs {
+            inventory: None, // required field
+        }
+    }
+}
+pub struct GetDataBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> GetDataBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_inventory(&mut self, inventory: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<InvElem<'b >>>>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(GetData::VT_INVENTORY, inventory);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> GetDataBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        GetDataBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Inv<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        self.fbb_.required(o, GetData::VT_INVENTORY,"inventory");
+        flatbuffers::WIPOffset::new(o.value())
+    }
 }
 
 #[inline]

--- a/data_structures/src/flatbuffers/protocol_generated.rs
+++ b/data_structures/src/flatbuffers/protocol_generated.rs
@@ -27,6 +27,7 @@ pub enum Command {
   Block = 7,
   Inv = 8,
   GetData = 9,
+
 }
 
 const ENUM_MIN_COMMAND: u8 = 0;
@@ -490,6 +491,7 @@ impl<'a> Message<'a> {
       None
     }
   }
+
 }
 
 pub struct MessageArgs {
@@ -2205,7 +2207,7 @@ pub enum GetDataOffset {}
 #[derive(Copy, Clone, Debug, PartialEq)]
 
 pub struct GetData<'a> {
-    pub _tab: flatbuffers::Table<'a>,
+  pub _tab: flatbuffers::Table<'a>,
 }
 
 impl<'a> flatbuffers::Follow<'a> for GetData<'a> {
@@ -2228,22 +2230,22 @@ impl<'a> GetData<'a> {
     #[allow(unused_mut)]
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
-        args: &'args GetDataArgs<'args>) -> flatbuffers::WIPOffset<Inv<'bldr>> {
-        let mut builder = GetDataBuilder::new(_fbb);
-        if let Some(x) = args.inventory { builder.add_inventory(x); }
-        builder.finish()
+        args: &'args GetDataArgs<'args>) -> flatbuffers::WIPOffset<GetData<'bldr>> {
+      let mut builder = GetDataBuilder::new(_fbb);
+      if let Some(x) = args.inventory { builder.add_inventory(x); }
+      builder.finish()
     }
 
     pub const VT_INVENTORY: flatbuffers::VOffsetT = 4;
 
-    #[inline]
-    pub fn inventory(&self) -> flatbuffers::Vector<flatbuffers::ForwardsUOffset<InvElem<'a>>> {
-        self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<InvElem<'a>>>>>(GetData::VT_INVENTORY, None).unwrap()
-    }
+  #[inline]
+  pub fn inventory(&self) -> flatbuffers::Vector<flatbuffers::ForwardsUOffset<InvVector<'a>>> {
+    self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<flatbuffers::ForwardsUOffset<InvVector<'a>>>>>(GetData::VT_INVENTORY, None).unwrap()
+  }
 }
 
 pub struct GetDataArgs<'a> {
-    pub inventory: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<InvElem<'a >>>>>,
+    pub inventory: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a , flatbuffers::ForwardsUOffset<InvVector<'a >>>>>,
 }
 impl<'a> Default for GetDataArgs<'a> {
     #[inline]
@@ -2254,28 +2256,28 @@ impl<'a> Default for GetDataArgs<'a> {
     }
 }
 pub struct GetDataBuilder<'a: 'b, 'b> {
-    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
-    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b> GetDataBuilder<'a, 'b> {
-    #[inline]
-    pub fn add_inventory(&mut self, inventory: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<InvElem<'b >>>>) {
-        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(GetData::VT_INVENTORY, inventory);
+  #[inline]
+  pub fn add_inventory(&mut self, inventory: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<InvVector<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(GetData::VT_INVENTORY, inventory);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> GetDataBuilder<'a, 'b> {
+    let start = _fbb.start_table();
+    GetDataBuilder {
+      fbb_: _fbb,
+      start_: start,
     }
-    #[inline]
-    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> GetDataBuilder<'a, 'b> {
-        let start = _fbb.start_table();
-        GetDataBuilder {
-            fbb_: _fbb,
-            start_: start,
-        }
-    }
-    #[inline]
-    pub fn finish(self) -> flatbuffers::WIPOffset<Inv<'a>> {
-        let o = self.fbb_.end_table(self.start_);
-        self.fbb_.required(o, GetData::VT_INVENTORY,"inventory");
-        flatbuffers::WIPOffset::new(o.value())
-    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<GetData<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    self.fbb_.required(o, GetData::VT_INVENTORY,"inventory");
+    flatbuffers::WIPOffset::new(o.value())
+  }
 }
 
 #[inline]

--- a/data_structures/src/types.rs
+++ b/data_structures/src/types.rs
@@ -12,6 +12,7 @@ pub enum Command {
     Version(Version),
     Block(Block),
     Inv(Inv),
+    GetData(GetData),
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -53,6 +54,11 @@ pub struct Inv {
     pub inventory: Vec<InvVector>,
 }
 
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct GetData {
+    pub inventory: Vec<InvElem>,
+}
+
 impl fmt::Display for Command {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
@@ -67,6 +73,7 @@ impl fmt::Display for Command {
                 Command::Version(_) => "VERSION",
                 Command::Block(_) => "BLOCK",
                 Command::Inv(_) => "INV",
+                Command::GetData(_) => "GET_DATA",
             }
         )
     }

--- a/data_structures/src/types.rs
+++ b/data_structures/src/types.rs
@@ -56,7 +56,7 @@ pub struct Inv {
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct GetData {
-    pub inventory: Vec<InvElem>,
+    pub inventory: Vec<InvVector>,
 }
 
 impl fmt::Display for Command {

--- a/data_structures/tests/builders.rs
+++ b/data_structures/tests/builders.rs
@@ -206,3 +206,25 @@ fn builders_build_inv() {
     // Check that the build_inv function builds the expected message
     assert_eq!(msg, Message::build_inv(inventory));
 }
+
+#[test]
+fn builders_build_get_data() {
+    // Inventory elements
+    let inv_elem_1 = InvElem::Tx(Hash::SHA256([1; 32]));
+    let inv_elem_2 = InvElem::Block(Hash::SHA256([2; 32]));
+    let inventory = vec![inv_elem_1, inv_elem_2];
+
+    // Inventory command
+    let get_data_cmd = Command::GetData(GetData {
+        inventory: inventory.clone(),
+    });
+
+    // Inventory message
+    let msg = Message {
+        kind: get_data_cmd,
+        magic: MAGIC,
+    };
+
+    // Check that the build_inv function builds the expected message
+    assert_eq!(msg, Message::build_get_data(inventory));
+}

--- a/data_structures/tests/builders.rs
+++ b/data_structures/tests/builders.rs
@@ -210,8 +210,8 @@ fn builders_build_inv() {
 #[test]
 fn builders_build_get_data() {
     // Inventory elements
-    let inv_elem_1 = InvElem::Tx(Hash::SHA256([1; 32]));
-    let inv_elem_2 = InvElem::Block(Hash::SHA256([2; 32]));
+    let inv_elem_1 = InvVector::Tx(Hash::SHA256([1; 32]));
+    let inv_elem_2 = InvVector::Block(Hash::SHA256([2; 32]));
     let inventory = vec![inv_elem_1, inv_elem_2];
 
     // Inventory command

--- a/data_structures/tests/serializers.rs
+++ b/data_structures/tests/serializers.rs
@@ -594,8 +594,8 @@ fn message_inv_encode_decode() {
 #[test]
 fn message_get_data_to_bytes() {
     // Inventory elements
-    let inv_elem_1 = InvElem::Tx(Hash::SHA256([1; 32]));
-    let inv_elem_2 = InvElem::Block(Hash::SHA256([2; 32]));
+    let inv_elem_1 = InvVector::Tx(Hash::SHA256([1; 32]));
+    let inv_elem_2 = InvVector::Block(Hash::SHA256([2; 32]));
 
     // Inventory message
     let msg = Message {
@@ -627,8 +627,8 @@ fn message_get_data_to_bytes() {
 #[test]
 fn message_get_data_from_bytes() {
     // Inventory elements
-    let inv_elem_1 = InvElem::Tx(Hash::SHA256([1; 32]));
-    let inv_elem_2 = InvElem::Block(Hash::SHA256([2; 32]));
+    let inv_elem_1 = InvVector::Tx(Hash::SHA256([1; 32]));
+    let inv_elem_2 = InvVector::Block(Hash::SHA256([2; 32]));
 
     // Inventory message
     let expected_msg = Message {
@@ -654,8 +654,8 @@ fn message_get_data_from_bytes() {
 #[test]
 fn message_get_data_encode_decode() {
     // Inventory elements
-    let inv_elem_1 = InvElem::Tx(Hash::SHA256([1; 32]));
-    let inv_elem_2 = InvElem::Block(Hash::SHA256([2; 32]));
+    let inv_elem_1 = InvVector::Tx(Hash::SHA256([1; 32]));
+    let inv_elem_2 = InvVector::Block(Hash::SHA256([2; 32]));
 
     // Inventory message
     let msg = Message {

--- a/data_structures/tests/serializers.rs
+++ b/data_structures/tests/serializers.rs
@@ -590,3 +590,83 @@ fn message_inv_encode_decode() {
 
     assert_eq!(cloned_msg, Message::try_from(result).unwrap());
 }
+
+#[test]
+fn message_get_data_to_bytes() {
+    // Inventory elements
+    let inv_elem_1 = InvElem::Tx(Hash::SHA256([1; 32]));
+    let inv_elem_2 = InvElem::Block(Hash::SHA256([2; 32]));
+
+    // Inventory message
+    let msg = Message {
+        kind: Command::GetData(GetData {
+            inventory: vec![inv_elem_1, inv_elem_2],
+        }),
+        magic: 1,
+    };
+
+    // Expected bytes
+    let expected_buf: Vec<u8> = [
+        16, 0, 0, 0, 0, 0, 10, 0, 14, 0, 6, 0, 5, 0, 8, 0, 10, 0, 0, 0, 0, 9, 1, 0, 12, 0, 0, 0, 0,
+        0, 6, 0, 8, 0, 4, 0, 6, 0, 0, 0, 4, 0, 0, 0, 2, 0, 0, 0, 72, 0, 0, 0, 4, 0, 0, 0, 200, 255,
+        255, 255, 0, 0, 0, 2, 4, 0, 0, 0, 192, 255, 255, 255, 4, 0, 0, 0, 32, 0, 0, 0, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 8, 0,
+        12, 0, 7, 0, 8, 0, 8, 0, 0, 0, 0, 0, 0, 1, 12, 0, 0, 0, 8, 0, 8, 0, 0, 0, 4, 0, 8, 0, 0, 0,
+        4, 0, 0, 0, 32, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    ]
+    .to_vec();
+
+    // Serialize message to bytes
+    let result: Vec<u8> = msg.into();
+
+    // Test check
+    assert_eq!(result, expected_buf);
+}
+
+#[test]
+fn message_get_data_from_bytes() {
+    // Inventory elements
+    let inv_elem_1 = InvElem::Tx(Hash::SHA256([1; 32]));
+    let inv_elem_2 = InvElem::Block(Hash::SHA256([2; 32]));
+
+    // Inventory message
+    let expected_msg = Message {
+        kind: Command::GetData(GetData {
+            inventory: vec![inv_elem_1, inv_elem_2],
+        }),
+        magic: 1,
+    };
+    let buf: Vec<u8> = [
+        16, 0, 0, 0, 0, 0, 10, 0, 14, 0, 6, 0, 5, 0, 8, 0, 10, 0, 0, 0, 0, 9, 1, 0, 12, 0, 0, 0, 0,
+        0, 6, 0, 8, 0, 4, 0, 6, 0, 0, 0, 4, 0, 0, 0, 2, 0, 0, 0, 72, 0, 0, 0, 4, 0, 0, 0, 200, 255,
+        255, 255, 0, 0, 0, 2, 4, 0, 0, 0, 192, 255, 255, 255, 4, 0, 0, 0, 32, 0, 0, 0, 2, 2, 2, 2,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 8, 0,
+        12, 0, 7, 0, 8, 0, 8, 0, 0, 0, 0, 0, 0, 1, 12, 0, 0, 0, 8, 0, 8, 0, 0, 0, 4, 0, 8, 0, 0, 0,
+        4, 0, 0, 0, 32, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    ]
+    .to_vec();
+
+    assert_eq!(Message::try_from(buf).unwrap(), expected_msg);
+}
+
+#[test]
+fn message_get_data_encode_decode() {
+    // Inventory elements
+    let inv_elem_1 = InvElem::Tx(Hash::SHA256([1; 32]));
+    let inv_elem_2 = InvElem::Block(Hash::SHA256([2; 32]));
+
+    // Inventory message
+    let msg = Message {
+        kind: Command::GetData(GetData {
+            inventory: vec![inv_elem_1, inv_elem_2],
+        }),
+        magic: 1,
+    };
+
+    let cloned_msg = msg.clone();
+    let result: Vec<u8> = msg.into();
+
+    assert_eq!(cloned_msg, Message::try_from(result).unwrap());
+}

--- a/schemas/protocol.fbs
+++ b/schemas/protocol.fbs
@@ -6,7 +6,7 @@ namespace Protocol;
 // MAIN TYPES
 /////////////////////////////////////////////////////////
 // List of available commands
-union Command (required) { Version, Verack, GetPeers, Peers, Ping, Pong, Block, Inv }
+union Command (required) { Version, Verack, GetPeers, Peers, Ping, Pong, Block, Inv, GetData }
 
 // Message format with header
 table Message {
@@ -127,4 +127,7 @@ table Inv {
     inventory: [InvVector] (required);
 }
 
+table GetData {
+    inventory: [InvElem] (required);
+}
 root_type Message;

--- a/schemas/protocol.fbs
+++ b/schemas/protocol.fbs
@@ -128,6 +128,6 @@ table Inv {
 }
 
 table GetData {
-    inventory: [InvElem] (required);
+    inventory: [InvVector] (required);
 }
 root_type Message;


### PR DESCRIPTION
Implement get_data as a Command in the FlatBuffers schema.
Implement get_data as a native data structure.
Implement get_data and its builder as a WitnetMessage in witnet_data_structures::types::Message
Add tests for the serializer and builder functions.

Close #163 