### PR TITLE
chore(config): Add link to config-params docs

### DIFF
--- a/core/src/actors/mempool_manager/actor.rs
+++ b/core/src/actors/mempool_manager/actor.rs
@@ -1,0 +1,15 @@
+use actix::{Actor, Context, Supervised, SystemService};
+
+use super::MempoolManager;
+
+/// Implement Actor trait for `MempoolManager`
+impl Actor for MempoolManager {
+    /// Every actor has to provide execution `Context` in which it can run
+    type Context = Context<Self>;
+}
+
+/// Make the MempoolManager a Supervisor, which provides the ability to be restarted
+impl Supervised for MempoolManager {}
+
+/// Required trait for being able to retrieve MempoolManager address from registry
+impl SystemService for MempoolManager {}

--- a/core/src/actors/mempool_manager/mod.rs
+++ b/core/src/actors/mempool_manager/mod.rs
@@ -1,0 +1,22 @@
+//! # MempoolManager actor
+//!
+//! This module contains the MempoolManager actor which is in charge
+//! of managing and validating the transactions received through
+//! the protocol. Among its responsabilities are the following:
+//!
+//! * Validating transactions as they come from any [Session](actors::session::Session). This includes:
+//!     - Iterating over its inputs, asking the [UtxoManager](actors::utxo_manager::UtxoManager) for the to-be-spent UTXOs and adding the value of the inputs to calculate the value of the transaction.
+//!     - Running the output scripts, expecting them all to return `TRUE` and leave an empty stack.
+//!     - Verifying that the sum of all inputs is greater than or equal to the sum of all the outputs.
+//! * Keeping valid transactions into memory. This in-memory transaction pool is what we call the _mempool_. Valid transactions are immediately appended to the mempool.
+//! * Receiving confirmation notifications from [BlocksManager](actors::blocks_manager::BlocksManager). This notifications tell that a certain transaction ID has been anchored into a new block and thus it can be removed from the mempool and persisted into local storage (for archival purposes, non-archival nodes can just drop them).
+//! * Notifying [UtxoManager](actors::utxo_manager::UtxoManager) for it to apply a valid transaction on the UTXO set.
+
+mod actor;
+
+////////////////////////////////////////////////////////////////////////////////////////
+// ACTOR BASIC STRUCTURE
+////////////////////////////////////////////////////////////////////////////////////////
+/// MempoolManager actor
+#[derive(Default)]
+pub struct MempoolManager;

--- a/core/src/actors/mod.rs
+++ b/core/src/actors/mod.rs
@@ -33,3 +33,7 @@ pub mod blocks_manager;
 
 /// MempoolManager actor module
 pub mod mempool_manager;
+
+/// UtxoManager actor module
+pub mod utxo_manager;
+

--- a/core/src/actors/mod.rs
+++ b/core/src/actors/mod.rs
@@ -30,3 +30,6 @@ pub mod epoch_manager;
 
 /// BlocksManager actor module
 pub mod blocks_manager;
+
+/// MempoolManager actor module
+pub mod mempool_manager;

--- a/core/src/actors/node.rs
+++ b/core/src/actors/node.rs
@@ -10,6 +10,7 @@ use crate::actors::blocks_manager::BlocksManager;
 use crate::actors::config_manager::ConfigManager;
 use crate::actors::connections_manager::ConnectionsManager;
 use crate::actors::epoch_manager::EpochManager;
+use crate::actors::mempool_manager::MempoolManager;
 use crate::actors::peers_manager::PeersManager;
 use crate::actors::sessions_manager::SessionsManager;
 use crate::actors::storage_manager::StorageManager;
@@ -49,6 +50,10 @@ pub fn run(config: Option<PathBuf>, callback: fn()) -> Result<(), io::Error> {
     // Start blocks manager actor
     let blocks_manager_addr = BlocksManager::default().start();
     System::current().registry().set(blocks_manager_addr);
+
+    // Start mempool manager actor
+    let mempool_manager_addr = MempoolManager::start_default();
+    System::current().registry().set(mempool_manager_addr);
 
     // Run system
     system.run();

--- a/core/src/actors/node.rs
+++ b/core/src/actors/node.rs
@@ -14,6 +14,7 @@ use crate::actors::mempool_manager::MempoolManager;
 use crate::actors::peers_manager::PeersManager;
 use crate::actors::sessions_manager::SessionsManager;
 use crate::actors::storage_manager::StorageManager;
+use crate::actors::utxo_manager::UtxoManager;
 
 /// Function to run the main system
 pub fn run(config: Option<PathBuf>, callback: fn()) -> Result<(), io::Error> {
@@ -54,6 +55,10 @@ pub fn run(config: Option<PathBuf>, callback: fn()) -> Result<(), io::Error> {
     // Start mempool manager actor
     let mempool_manager_addr = MempoolManager::start_default();
     System::current().registry().set(mempool_manager_addr);
+
+    // Start UTXO manager actor
+    let utxo_manager_addr = UtxoManager::start_default();
+    System::current().registry().set(utxo_manager_addr);
 
     // Run system
     system.run();

--- a/core/src/actors/utxo_manager/actor.rs
+++ b/core/src/actors/utxo_manager/actor.rs
@@ -1,0 +1,14 @@
+use actix::{Actor, Context, Supervised, SystemService};
+
+use super::UtxoManager;
+
+/// Implement Actor trait for [UtxoManager](actors::utxo_manager::UtxoManager)
+impl Actor for UtxoManager {
+    type Context = Context<Self>;
+}
+
+/// Required trait for being able to retrieve UtxoManager address from registry
+impl Supervised for UtxoManager {}
+
+/// Required trait for being able to retrieve UtxoManager address from registry
+impl SystemService for UtxoManager {}

--- a/core/src/actors/utxo_manager/mod.rs
+++ b/core/src/actors/utxo_manager/mod.rs
@@ -1,0 +1,16 @@
+//! # UTXO Manager
+//!
+//! The __UTXO manager__ is the actor that encapsulates the logic of the _unspent transaction outputs_, that is, it will be in charge of:
+//!
+//! * Keeping every unspent transaction output (UTXO) in the block chain in memory. This is called the _UTXO set_.
+//! * Updating the UTXO set with valid transactions that have already been anchored into a valid block. This includes:
+//!     - Removing the UTXOs that the transaction spends as inputs.
+//!     - Adding a new UTXO for every output in the transaction.
+mod actor;
+
+////////////////////////////////////////////////////////////////////////////////////////
+// ACTOR BASIC STRUCTURE
+////////////////////////////////////////////////////////////////////////////////////////
+/// UtxoManager actor
+#[derive(Default)]
+pub struct UtxoManager;

--- a/docs/architecture/managers/mempool-manager.md
+++ b/docs/architecture/managers/mempool-manager.md
@@ -1,0 +1,39 @@
+# Mempool Manager
+
+The __mempool manager__ is the actor in charge of:
+
+* Validating transactions as they come from any `Session`. This includes:
+    - Iterating over its inputs, asking the `UtxoManager` for the to-be-spent UTXOs and adding the value of the inputs to calculate the value of the transaction.
+    - Running the output scripts, expecting them all to return `TRUE` and leave an empty stack.
+    - Verifying that the sum of all inputs is greater than or equal to the sum of all the outputs.
+* Keeping valid transactions into memory. This in-memory transaction pool is what we call the _mempool_. Valid transactions are immediately appended to the mempool.
+* Receiving confirmation notifications from `BlocksManager`. This notifications tell that a certain transaction ID has been anchored into a new block and thus it can be removed from the mempool and persisted into local storage (for archival purposes, non-archival nodes can just drop them).
+* Notifying `UtxoManager` for it to apply a valid transaction on the UTXO set.
+
+The mempool actor is not backed by any persistance medium. If a node goes down, it will need to ask its peers for the entire mempool.
+
+## Actor creation and registration
+
+The creation of the mempool actor and its registration into the system registry are
+performed directly by the main process [`node.rs`][noders]:
+
+```rust
+let mempool_manager_addr = MempoolManager::start_default();
+System::current().registry().set(mempool_manager_addr);
+```
+
+## API
+
+### Incoming: Others -> MempoolManager
+
+These are the messages supported by the `MempoolManager` handlers:
+
+| Message                                   | Input type                    | Output type              | Description                                    |
+|-------------------------------------------|-------------------------------|--------------------------| -----------------------------------------------|
+
+### Outgoing messages: MempoolManager -> Others
+
+These are the messages sent by the blocks manager:
+
+| Message           | Destination       | Input type                                    | Output type                 | Description                       |
+|-------------------|-------------------|-----------------------------------------------|-----------------------------|-----------------------------------|

--- a/docs/architecture/managers/utxo-manager.md
+++ b/docs/architecture/managers/utxo-manager.md
@@ -1,0 +1,33 @@
+# UTXO Manager
+
+The __UTXO manager__ is the actor that encapsulates the logic of the _unspent transaction outputs_, that is, it will be in charge of:
+
+* Keeping every unspent transaction output (UTXO) in the block chain in memory. This is called the _UTXO set_.
+* Updating the UTXO set with valid transactions that have already been anchored into a valid block. This includes:
+    - Removing the UTXOs that the transaction spends as inputs.
+    - Adding a new UTXO for every output in the transaction.
+
+## Actor creation and registration
+
+The creation of the UTXO manager actor is performed directly by the `main` process:
+
+```rust
+let utxo_manager_addr = UtxoManager::start_default();
+System::current().registry().set(utxo_manager_addr);
+```
+
+## API
+ 
+### Incoming messages: Others -> UTXO manager
+ 
+These are the messages supported by the UTXO manager handlers:
+
+| Message   | Input type                                | Output type                           | Description                               |
+|-----------|-------------------------------------------|---------------------------------------|-------------------------------------------|
+
+### Outgoing messages: UTXO manager -> Others
+
+These are the messages sent by the UTXO manager:
+
+| Message           | Destination   | Input type    | Output type                        | Description                          |
+|-------------------|---------------|---------------|------------------------------------|--------------------------------------|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Config Manager: architecture/managers/config-manager.md
       - Connections Manager: architecture/managers/connections-manager.md
       - Epoch Manager: architecture/managers/epoch-manager.md
+      - Mempool Manager: architecture/managers/mempool-manager.md
       - Peers Manager: architecture/managers/peers-manager.md
       - Sessions Manager: architecture/managers/sessions-manager.md
       - Storage Manager: architecture/managers/storage-manager.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - Peers Manager: architecture/managers/peers-manager.md
       - Sessions Manager: architecture/managers/sessions-manager.md
       - Storage Manager: architecture/managers/storage-manager.md
+      - UTXO Manager: architecture/managers/utxo-manager.md
     - Session: architecture/session.md
     - Mempool Management: architecture/mempool-mgmt.md
     - Block Management: architecture/block-mgmt.md

--- a/witnet.toml
+++ b/witnet.toml
@@ -1,3 +1,5 @@
+# You can read more about all the configuration params in
+# https://docs.witnet.io/configuration/toml-file/
 [connections]
 server_addr = "0.0.0.0:21337"
 


### PR DESCRIPTION
#### Context
- We try to use very expressive names for configuration variables.
- Each variable is encumbered with a comment.
- Even though, we should add a header to the `witnet.toml` configuration file, including a link to the documentation page for the same file.
- This lets us keep the comments in the configuration file succinct while providing a way for the users to learn more about each variable and discover example values for them.

#### Actionables
- [X] Find the URL for the documentation of the configuration file in https://docs.witnet.io
- [X] Modify `witnet.toml` to add a friendly and expressive header pointing to the URL.
- [X] Create PR and link it to this issue.