### PR TITLE
feat(core): AnnounceItems actor message

### DIFF
--- a/core/src/actors/session/handlers.rs
+++ b/core/src/actors/session/handlers.rs
@@ -22,7 +22,7 @@ use witnet_data_structures::{
 use witnet_p2p::sessions::{SessionStatus, SessionType};
 
 use super::{
-    messages::{GetPeers, SessionUnitResult},
+    messages::{AnnounceItems, GetPeers, SessionUnitResult},
     Session,
 };
 
@@ -103,6 +103,22 @@ impl Handler<GetPeers> for Session {
         let get_peers_msg = WitnetMessage::build_get_peers();
         // Write get peers message in session
         self.send_message(get_peers_msg);
+    }
+}
+
+/// Handler for AnnounceItems message (sent by other actors)
+impl Handler<AnnounceItems> for Session {
+    type Result = SessionUnitResult;
+
+    fn handle(&mut self, msg: AnnounceItems, _: &mut Context<Self>) {
+        debug!(
+            "Sending AnnounceItems message to peer at {:?}",
+            self.remote_addr
+        );
+        // Create AnnounceItems message
+        let announce_items_msg = WitnetMessage::build_inv(msg.items);
+        // Write message in session
+        self.send_message(announce_items_msg);
     }
 }
 

--- a/core/src/actors/session/messages.rs
+++ b/core/src/actors/session/messages.rs
@@ -1,4 +1,5 @@
 use actix::Message;
+use witnet_data_structures::chain::InvVector;
 
 /// Message result of unit
 pub type SessionUnitResult = ();
@@ -8,4 +9,11 @@ pub struct GetPeers;
 
 impl Message for GetPeers {
     type Result = SessionUnitResult;
+}
+
+/// Message to announce new inventory items through the network
+#[derive(Clone, Message)]
+pub struct AnnounceItems {
+    /// Inventory items
+    pub items: Vec<InvVector>,
 }

--- a/docs/architecture/session.md
+++ b/docs/architecture/session.md
@@ -42,15 +42,18 @@ Session::create(move |ctx| {
 
 These are the messages supported by the session handlers:
 
-| Message          | Input type            | Output type                       | Description            |
-| ---------------- | --------------------- | --------------------------------- | ---------------------- |
-| `GetPeers`       | `()`                  | `()`                              | Empty                  |
+| Message          | Input type            | Output type                       | Description                            |
+| ---------------- | --------------------- | --------------------------------- | -------------------------------------- |
+| `GetPeers`       | `()`                  | `()`                              | Request peers from a session           |
+| `AnnounceItems`  | `Vec<InvVector>`      | `()`                              | Announce new inventory items           |
 
 #### GetPeers
-The handler of `GetPeers` message is currently empty.
 
-// TODO Update documentation when `GetPeers` gets any actual functionality.
+Ask the peer on the other side of the connection for their own list of peer addresses.
 
+#### AnnounceItems
+
+Announce new inventory items.
 
 ### Outgoing messages: Session -> Others
 


### PR DESCRIPTION
Add `AnnounceItems` message to `Session` actor. Allows to announce a new inventory item to the outbound peers.