### PR TITLE
refactor(config manager): Use Arc to share the loaded config

### DIFF
--- a/core/src/actors/config_manager/actor.rs
+++ b/core/src/actors/config_manager/actor.rs
@@ -1,6 +1,7 @@
 use super::ConfigManager;
 use actix::{Actor, Context};
 use log::{debug, info};
+use std::sync::Arc;
 use witnet_config::config::Config;
 use witnet_config::loaders::toml;
 
@@ -13,6 +14,8 @@ impl Actor for ConfigManager {
             "Reading configuration from file: {}",
             self.config_file.to_string_lossy()
         );
-        self.config = Config::from_partial(&toml::from_file(&self.config_file).unwrap())
+        self.config = Arc::new(Config::from_partial(
+            &toml::from_file(&self.config_file).unwrap(),
+        ))
     }
 }

--- a/core/src/actors/config_manager/messages.rs
+++ b/core/src/actors/config_manager/messages.rs
@@ -2,6 +2,7 @@ use actix::Message;
 
 use std::io;
 
+use std::sync::Arc;
 use witnet_config::config::Config;
 
 /// Message to obtain the configuration managed by the `ConfigManager`
@@ -9,7 +10,7 @@ use witnet_config::config::Config;
 pub struct GetConfig;
 
 /// Result of the GetConfig message handling
-pub type ConfigResult = Result<Config, io::Error>;
+pub type ConfigResult = Result<Arc<Config>, io::Error>;
 
 impl Message for GetConfig {
     type Result = ConfigResult;

--- a/core/src/actors/config_manager/mod.rs
+++ b/core/src/actors/config_manager/mod.rs
@@ -5,6 +5,7 @@ use actix::{
 
 use log::error;
 use std::path::PathBuf;
+use std::sync::Arc;
 use witnet_config::config::Config;
 
 // Internal Actor implementation for ConfigManager
@@ -27,7 +28,7 @@ pub const CONFIG_DEFAULT_FILENAME: &str = "witnet.toml";
 #[derive(Debug)]
 pub struct ConfigManager {
     /// Loaded configuration
-    config: Config,
+    config: Arc<Config>,
 
     /// Configuration file from which to read the configuration when
     /// the actor starts
@@ -37,7 +38,7 @@ pub struct ConfigManager {
 impl Default for ConfigManager {
     fn default() -> Self {
         Self {
-            config: Config::default(),
+            config: Arc::new(Config::default()),
             config_file: PathBuf::from(CONFIG_DEFAULT_FILENAME),
         }
     }
@@ -48,7 +49,7 @@ impl ConfigManager {
     /// given configuration file name.
     pub fn new(config_file: Option<PathBuf>) -> Self {
         Self {
-            config: Config::default(),
+            config: Arc::new(Config::default()),
             config_file: match config_file {
                 Some(path) => path,
                 None => PathBuf::from(CONFIG_DEFAULT_FILENAME),
@@ -100,7 +101,7 @@ where
 /// Method to process ConfigManager GetConfig response
 pub fn process_get_config_response<T>(
     response: Result<messages::ConfigResult, MailboxError>,
-) -> FutureResult<Config, (), T> {
+) -> FutureResult<Arc<Config>, (), T> {
     // Process the Result<ConfigResult, MailboxError>
     match response {
         Err(e) => {


### PR DESCRIPTION
Change `ConfigManager` actor to contain an `Arc<Config>` so the handler for the `GetConfig` message returns a reference to the loaded configuration instead of a deep copy.