### PR TITLE
feat(core): add GetBlockMessage in BlocksManager

### DIFF
--- a/core/src/actors/blocks_manager/handlers.rs
+++ b/core/src/actors/blocks_manager/handlers.rs
@@ -4,7 +4,7 @@ use crate::actors::blocks_manager::{BlocksManager, BlocksManagerError};
 use crate::actors::epoch_manager::messages::EpochNotification;
 
 use witnet_data_structures::{
-    chain::{CheckpointBeacon, Hash, InvVector},
+    chain::{Block, CheckpointBeacon, Hash, InvVector},
     error::{ChainInfoError, ChainInfoErrorKind, ChainInfoResult},
 };
 
@@ -12,7 +12,7 @@ use witnet_util::error::WitnetError;
 
 use log::{debug, error};
 
-use super::messages::{AddNewBlock, GetHighestCheckpointBeacon};
+use super::messages::{AddNewBlock, GetBlock, GetHighestCheckpointBeacon};
 use crate::actors::session::messages::AnnounceItems;
 use crate::actors::sessions_manager::{messages::Broadcast, SessionsManager};
 
@@ -66,6 +66,7 @@ impl Handler<GetHighestCheckpointBeacon> for BlocksManager {
     }
 }
 
+/// Handler for AddNewBlock message
 impl Handler<AddNewBlock> for BlocksManager {
     type Result = Result<Hash, BlocksManagerError>;
 
@@ -92,8 +93,25 @@ impl Handler<AddNewBlock> for BlocksManager {
             Err(BlocksManagerError::StorageError(_)) => {
                 debug!("Error when serializing block");
             }
+            Err(_) => {
+                debug!("Unexpected error");
+            }
         };
 
         res
+    }
+}
+
+/// Handler for GetBlock message
+impl Handler<GetBlock> for BlocksManager {
+    type Result = Result<Block, BlocksManagerError>;
+
+    fn handle(
+        &mut self,
+        msg: GetBlock,
+        _ctx: &mut Context<Self>,
+    ) -> Result<Block, BlocksManagerError> {
+        // Try to get block by hash
+        self.try_to_get_block(msg.hash)
     }
 }

--- a/core/src/actors/blocks_manager/messages.rs
+++ b/core/src/actors/blocks_manager/messages.rs
@@ -24,7 +24,7 @@ impl Message for AddNewBlock {
     type Result = Result<Hash, BlocksManagerError>;
 }
 
-/// Get a block from its hash
+/// Ask for a block identified by its hash
 pub struct GetBlock {
     /// Block hash
     pub hash: Hash,

--- a/core/src/actors/blocks_manager/messages.rs
+++ b/core/src/actors/blocks_manager/messages.rs
@@ -23,3 +23,13 @@ pub struct AddNewBlock {
 impl Message for AddNewBlock {
     type Result = Result<Hash, BlocksManagerError>;
 }
+
+/// Get a block from its hash
+pub struct GetBlock {
+    /// Block hash
+    pub hash: Hash,
+}
+
+impl Message for GetBlock {
+    type Result = Result<Block, BlocksManagerError>;
+}

--- a/core/src/actors/blocks_manager/mod.rs
+++ b/core/src/actors/blocks_manager/mod.rs
@@ -46,7 +46,7 @@ pub enum BlocksManagerError {
     /// A block being processed was already known to this node
     BlockAlreadyExists,
     /// A block does not exist
-    BlockNotExists,
+    BlockDoesNotExist,
     /// StorageError
     StorageError(WitnetError<StorageError>),
 }
@@ -148,12 +148,11 @@ impl BlocksManager {
     }
 
     fn try_to_get_block(&mut self, hash: Hash) -> Result<Block, BlocksManagerError> {
-        // Check if we already have a block with that hash
-        if let Some(block) = self.blocks.get(&hash) {
-            Ok(block.clone())
-        } else {
-            Err(BlocksManagerError::BlockNotExists)
-        }
+        // Check if we have a block with that hash
+        self.blocks.get(&hash).map_or_else(
+            || Err(BlocksManagerError::BlockDoesNotExist),
+            |block| Ok(block.clone()),
+        )
     }
 }
 

--- a/core/src/actors/blocks_manager/mod.rs
+++ b/core/src/actors/blocks_manager/mod.rs
@@ -45,6 +45,8 @@ pub mod messages;
 pub enum BlocksManagerError {
     /// A block being processed was already known to this node
     BlockAlreadyExists,
+    /// A block does not exist
+    BlockNotExists,
     /// StorageError
     StorageError(WitnetError<StorageError>),
 }
@@ -142,6 +144,15 @@ impl BlocksManager {
             self.blocks.insert(hash, block);
 
             Ok(hash)
+        }
+    }
+
+    fn try_to_get_block(&mut self, hash: Hash) -> Result<Block, BlocksManagerError> {
+        // Check if we already have a block with that hash
+        if let Some(block) = self.blocks.get(&hash) {
+            Ok(block.clone())
+        } else {
+            Err(BlocksManagerError::BlockNotExists)
         }
     }
 }

--- a/core/src/actors/blocks_manager/mod.rs
+++ b/core/src/actors/blocks_manager/mod.rs
@@ -280,4 +280,52 @@ mod tests {
             .unwrap()
             .contains(&hash_b));
     }
+
+    #[test]
+    fn get_existing_block() {
+        // Create empty BlocksManager
+        let mut bm = BlocksManager::default();
+
+        // Create a hardcoded block
+        use witnet_data_structures::chain::*;
+        let checkpoint = 2;
+        let block_a = Block {
+            header: BlockHeaderWithProof {
+                block_header: BlockHeader {
+                    version: 1,
+                    beacon: CheckpointBeacon {
+                        checkpoint,
+                        hash_prev_block: Hash::SHA256([4; 32]),
+                    },
+                    hash_merkle_root: Hash::SHA256([3; 32]),
+                },
+                proof: LeadershipProof {
+                    block_sig: None,
+                    influence: 99999,
+                },
+            },
+            txn_count: 1,
+            txns: vec![Transaction],
+        };
+
+        // Add the block to the BlocksManager
+        let hash_a = bm.process_new_block(block_a.clone()).unwrap();
+
+        // Try to get the block from the BlocksManager
+        let stored_block = bm.try_to_get_block(hash_a).unwrap();
+
+        assert_eq!(stored_block, block_a);
+    }
+
+    #[test]
+    fn get_non_existent_block() {
+        // Create empty BlocksManager
+        let mut bm = BlocksManager::default();
+
+        // Try to get a block with an invented hash
+        let result = bm.try_to_get_block(Hash::SHA256([1; 32]));
+
+        // Check that an error was obtained
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
This PR add a `GetBlock` message in the `BlocksManager` to add the functionality to get a block from the `BlocksManager` from its hash.

Required for the demo for the `GetData` handler in the `Session` to retrieve the block from the `BlocksManager`.