### PR TITLE
feat(core): discard existing inventory vectors in inv handler

### DIFF
--- a/core/src/actors/blocks_manager/handlers.rs
+++ b/core/src/actors/blocks_manager/handlers.rs
@@ -12,8 +12,10 @@ use witnet_util::error::WitnetError;
 
 use log::{debug, error};
 
-use super::messages::{AddNewBlock, GetBlock, GetBlocksEpochRange, GetHighestCheckpointBeacon};
-
+use super::messages::{
+    AddNewBlock, DiscardExistingInvVectors, GetBlock, GetBlocksEpochRange,
+    GetHighestCheckpointBeacon, InvVectorsResult,
+};
 use crate::actors::session::messages::AnnounceItems;
 use crate::actors::sessions_manager::{messages::Broadcast, SessionsManager};
 
@@ -134,5 +136,19 @@ impl Handler<GetBlocksEpochRange> for BlocksManager {
             .collect();
 
         Ok(hashes)
+    }
+}
+
+/// Handler for DiscardExistingInvVectors message
+impl Handler<DiscardExistingInvVectors> for BlocksManager {
+    type Result = InvVectorsResult;
+
+    fn handle(
+        &mut self,
+        msg: DiscardExistingInvVectors,
+        _ctx: &mut Context<Self>,
+    ) -> InvVectorsResult {
+        // Discard existing inventory vectors
+        self.discard_existing_inv_vectors(&msg.inv_vectors)
     }
 }

--- a/core/src/actors/blocks_manager/handlers.rs
+++ b/core/src/actors/blocks_manager/handlers.rs
@@ -149,6 +149,6 @@ impl Handler<DiscardExistingInvVectors> for BlocksManager {
         _ctx: &mut Context<Self>,
     ) -> InvVectorsResult {
         // Discard existing inventory vectors
-        self.discard_existing_inv_vectors(&msg.inv_vectors)
+        self.discard_existing_inv_vectors(msg.inv_vectors)
     }
 }

--- a/core/src/actors/blocks_manager/messages.rs
+++ b/core/src/actors/blocks_manager/messages.rs
@@ -44,3 +44,16 @@ pub struct GetBlocksEpochRange {
 impl Message for GetBlocksEpochRange {
     type Result = Result<Vec<InvVector>, BlocksManagerError>;
 }
+
+/// Discard inventory vectors that exist in the BlocksManager
+pub struct DiscardExistingInvVectors {
+    /// Vector of InvVectors
+    pub inv_vectors: Vec<InvVector>,
+}
+
+/// Result of the DiscardExistingInvVectors message handling
+pub type InvVectorsResult = Result<Vec<InvVector>, BlocksManagerError>;
+
+impl Message for DiscardExistingInvVectors {
+    type Result = InvVectorsResult;
+}

--- a/data_structures/src/error.rs
+++ b/data_structures/src/error.rs
@@ -36,3 +36,36 @@ impl fmt::Display for ChainInfoErrorKind {
 
 /// Result type for the ChainInfo in BlocksManager module.
 pub type ChainInfoResult<T> = WitnetResult<T, ChainInfoError>;
+
+/// Error in builders functions
+#[derive(Debug, Fail)]
+#[fail(display = "{} :  msg {}", kind, msg)]
+pub struct BuildersError {
+    /// Error kind
+    kind: BuildersErrorKind,
+    /// Error message
+    msg: String,
+}
+
+impl BuildersError {
+    /// Create a BuildersError based on kind and related info
+    pub fn new(kind: BuildersErrorKind, msg: String) -> Self {
+        Self { kind, msg }
+    }
+}
+
+/// Kind of errors while trying to create a data structure with a builder function
+#[derive(Debug)]
+pub enum BuildersErrorKind {
+    /// No inventory vectors available to create a message
+    NoInvVectors,
+}
+
+impl fmt::Display for BuildersErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BuildersError::{:?}", self)
+    }
+}
+
+/// Result type used as return value for the builder functions in the builders module
+pub type BuildersResult<T> = WitnetResult<T, BuildersError>;

--- a/data_structures/tests/builders.rs
+++ b/data_structures/tests/builders.rs
@@ -200,7 +200,7 @@ fn builders_build_verack() {
 }
 
 #[test]
-fn builders_build_inv() {
+fn builders_build_ok_inv() {
     // Inventory elements
     let inv_vector_1 = InvVector::Tx(Hash::SHA256([1; 32]));
     let inv_vector_2 = InvVector::Block(Hash::SHA256([2; 32]));
@@ -212,17 +212,29 @@ fn builders_build_inv() {
     });
 
     // Inventory message
-    let msg = Message {
+    let expected_msg = Message {
         kind: inv_cmd,
         magic: MAGIC,
     };
 
+    // Build Inv message using the builder function
+    let built_msg = Message::build_inv(inventory).unwrap();
+
     // Check that the build_inv function builds the expected message
-    assert_eq!(msg, Message::build_inv(inventory));
+    assert_eq!(expected_msg, built_msg);
 }
 
 #[test]
-fn builders_build_get_data() {
+fn builders_build_err_inv() {
+    // Try to build an Inv message with no inventory vectors
+    let result = Message::build_inv(Vec::new());
+
+    // Check that the build_inv function could not generate a message
+    assert!(result.is_err());
+}
+
+#[test]
+fn builders_build_ok_get_data() {
     // Inventory elements
     let inv_elem_1 = InvVector::Tx(Hash::SHA256([1; 32]));
     let inv_elem_2 = InvVector::Block(Hash::SHA256([2; 32]));
@@ -234,11 +246,23 @@ fn builders_build_get_data() {
     });
 
     // Inventory message
-    let msg = Message {
+    let expected_msg = Message {
         kind: get_data_cmd,
         magic: MAGIC,
     };
 
-    // Check that the build_inv function builds the expected message
-    assert_eq!(msg, Message::build_get_data(inventory));
+    // Build GetData message using the builder function
+    let built_msg = Message::build_get_data(inventory).unwrap();
+
+    // Check that the build_get_data function builds the expected message
+    assert_eq!(expected_msg, built_msg);
+}
+
+#[test]
+fn builders_build_err_get_data() {
+    // Try to build a GetData message with no inventory vectors
+    let result = Message::build_get_data(Vec::new());
+
+    // Check that the build_get_data function could not generate a message
+    assert!(result.is_err());
 }


### PR DESCRIPTION
This PR adds a message in the `BlocksManager` to discard existing inventory vectors (in memory) from a list of inventory vectors. The handler of this message just calls a library function (tests are also added for it).

When an `Inv` message is received at the `Session`, a message is sent to the `BlocksManager` to discard the inventory vectors that already exist and to send a `GetData` message only with those. This is also added in this PR.

