### PR TITLE
fix(core): check session type in getpeers handler in session

### DIFF
--- a/core/src/actors/session/handlers.rs
+++ b/core/src/actors/session/handlers.rs
@@ -73,7 +73,7 @@ impl StreamHandler<BytesMut, Error> for Session {
                     // PEER DISCOVERY //
                     ////////////////////
                     // Handle GetPeers message
-                    (_, SessionStatus::Consolidated, Command::GetPeers(_)) => {
+                    (SessionType::Outbound, SessionStatus::Consolidated, Command::GetPeers(_)) => {
                         peer_discovery_get_peers(self, ctx);
                     }
                     // Handle Peers message


### PR DESCRIPTION
Now GetPeers handler checks the session type, if the session type is not outbound the GetPeers message is not created.
close #200 
