### PR TITLE
feat(actor): Add reputation manager actor

### DIFF
--- a/core/src/actors/mod.rs
+++ b/core/src/actors/mod.rs
@@ -34,5 +34,8 @@ pub mod chain_manager;
 /// InventoryManager actor module
 pub mod inventory_manager;
 
+/// ReputationManager actor module
+pub mod reputation_manager;
+
 /// JSON RPC server
 pub mod json_rpc;

--- a/core/src/actors/node.rs
+++ b/core/src/actors/node.rs
@@ -7,7 +7,8 @@ use crate::actors::{
     chain_manager::ChainManager, config_manager::ConfigManager,
     connections_manager::ConnectionsManager, epoch_manager::EpochManager,
     inventory_manager::InventoryManager, json_rpc::JsonRpcServer, peers_manager::PeersManager,
-    sessions_manager::SessionsManager, storage_manager::StorageManager,
+    reputation_manager::ReputationManager, sessions_manager::SessionsManager,
+    storage_manager::StorageManager,
 };
 
 /// Function to run the main system
@@ -49,6 +50,10 @@ pub fn run(config: Option<PathBuf>, callback: fn()) -> Result<(), io::Error> {
     // Start inventory manager actor
     let inventory_manager_addr = InventoryManager::start_default();
     System::current().registry().set(inventory_manager_addr);
+
+    // Start reputation manager actor
+    let reputation_manager_addr = ReputationManager::start_default();
+    System::current().registry().set(reputation_manager_addr);
 
     // Start JSON RPC server (this doesn't need to be in the registry)
     let _json_rpc_server_addr = JsonRpcServer::default().start();

--- a/core/src/actors/reputation_manager/actor.rs
+++ b/core/src/actors/reputation_manager/actor.rs
@@ -1,0 +1,15 @@
+use super::ReputationManager;
+use actix::{Actor, Context, Supervised, SystemService};
+use log;
+
+impl Actor for ReputationManager {
+    type Context = Context<Self>;
+
+    fn started(&mut self, _ctx: &mut Self::Context) {
+        log::debug!("Reputation Manager actor has been started!");
+    }
+}
+
+impl Supervised for ReputationManager {}
+
+impl SystemService for ReputationManager {}

--- a/core/src/actors/reputation_manager/handlers.rs
+++ b/core/src/actors/reputation_manager/handlers.rs
@@ -1,0 +1,13 @@
+use super::{messages, ReputationManager};
+use actix::{Handler, Message};
+
+impl Handler<messages::ValidatePoE> for ReputationManager {
+    type Result = <messages::ValidatePoE as Message>::Result;
+
+    fn handle(&mut self, _msg: messages::ValidatePoE, _ctx: &mut Self::Context) -> Self::Result {
+        // TODO: This implementation is dummy. The real implementation
+        // should be done in the future. See
+        // https://github.com/witnet/witnet-rust/issues/235
+        true
+    }
+}

--- a/core/src/actors/reputation_manager/messages.rs
+++ b/core/src/actors/reputation_manager/messages.rs
@@ -1,0 +1,10 @@
+use actix::Message;
+
+/// Message for checking that a proof of eligibility is valid for the
+/// known reputation of the issuer of the proof
+#[derive(Debug)]
+pub struct ValidatePoE;
+
+impl Message for ValidatePoE {
+    type Result = bool;
+}

--- a/core/src/actors/reputation_manager/mod.rs
+++ b/core/src/actors/reputation_manager/mod.rs
@@ -1,0 +1,21 @@
+//! # Reputation Manager
+//!
+//! The __Reputation manager__ is the actor that encapsulates the
+//! logic related to the reputation of the node inside the Witnet
+//! network, that is, it will be in charge of:
+//!
+//! * Checking that proofs of eligibility are valid for the known
+//! reputation of the issuers of such proofs
+//! * Keeping score of the reputation balances for everyone in the
+//! network
+mod actor;
+
+/// Message handlers for [`ReputationManager`](ReputationManager) actor
+pub mod handlers;
+
+/// Messages for [`ReputationManager`](ReputationManager) actor
+pub mod messages;
+
+/// Reputation Manager Actor
+#[derive(Debug, Default)]
+pub struct ReputationManager;

--- a/docs/architecture/managers/reputation-manager.md
+++ b/docs/architecture/managers/reputation-manager.md
@@ -1,0 +1,33 @@
+# Reputation Manager
+
+The __Reputation manager__ is the actor that encapsulates the logic related to the reputation of the node inside the Witnet network, that is, it will be in charge of:
+
+* Checking that proofs of eligibility are valid for the known reputation of the issuers of such proofs
+* Keeping score of the reputation balances for everyone in the network
+
+## Actor creation and registration
+
+The creation of the Reputation manager actor is performed directly by the `main` process:
+
+```rust
+let reputation_manager_addr = ReputationManager::start_default();
+System::current().registry().set(reputation_manager_addr);
+```
+
+## API
+ 
+### Incoming messages: Others -> Reputation manager
+ 
+These are the messages supported by the Reputation manager handlers:
+
+| Message     | Input type | Output type | Description                                         |
+|-------------|------------|-------------|-----------------------------------------------------|
+| ValidatePoE | -          | bool        | Checks that the given proof of eligibility is valid |
+
+
+### Outgoing messages: Reputation manager -> Others
+
+These are the messages sent by the Reputation manager:
+
+| Message | Destination | Input type | Output type | Description |
+|---------|-------------|------------|-------------|-------------|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
       - Inventory Manager: arquitecture/managers/inventory-manager.md
       - Mempool Manager: architecture/managers/mempool-manager.md
       - Peers Manager: architecture/managers/peers-manager.md
+      - Reputation Manager: architecture/managers/reputation-manager.md
       - Sessions Manager: architecture/managers/sessions-manager.md
       - Storage Manager: architecture/managers/storage-manager.md
       - UTXO Manager: architecture/managers/utxo-manager.md


### PR DESCRIPTION
Add reputation manager actor and a dummy implementation for the `ValidatePoE` (validate proof of eligibility) message that always assumes it's valid.

I've created #235 to keep track of the pending work.