### PR TITLE
refactor(crypto): remove data_structures dependency from crypto

### DIFF
--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -130,7 +130,7 @@ impl ChainManager {
 
     fn process_new_block(&mut self, block: Block) -> Result<Hash, ChainManagerError> {
         // Calculate the hash of the block
-        let hash = calculate_sha256(&block.to_bytes()?);
+        let hash = Hash::from(calculate_sha256(&block.to_bytes()?));
 
         // Check if we already have a block with that hash
         if let Some(_block) = self.blocks.get(&hash) {

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -8,5 +8,3 @@ edition = "2018"
 
 [dependencies]
 rust-crypto = "0.2"
-
-witnet_data_structures = { path = "../data_structures" }

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -1,15 +1,17 @@
 //! Various hash functions
 
-use witnet_data_structures::chain::Hash;
-
 use crypto::digest::Digest;
-use crypto::sha2::Sha256;
+use crypto::sha2;
+
+/// Secure hashing algorithm v2
+#[derive(Copy, Clone, Debug, PartialEq, Hash)]
+pub struct Sha256(pub [u8; 32]);
 
 /// Calculate the SHA256 hash
-pub fn calculate_sha256(bytes: &[u8]) -> Hash {
-    let mut hasher = Sha256::new();
+pub fn calculate_sha256(bytes: &[u8]) -> Sha256 {
+    let mut hasher = sha2::Sha256::new();
     hasher.input(&bytes);
     let mut hash = [0; 32];
     hasher.result(&mut hash);
-    Hash::SHA256(hash)
+    Sha256(hash)
 }

--- a/crypto/src/merkle.rs
+++ b/crypto/src/merkle.rs
@@ -12,54 +12,37 @@
 //! a b c d e f g
 //! ```
 
-use crate::hash::calculate_sha256;
-use witnet_data_structures::chain::Hash;
+use crate::hash::{calculate_sha256, Sha256};
 
 /// Calculate merkle tree root from the supplied hashes
-pub fn merkle_tree_root(hashes: &[Hash]) -> Hash {
+pub fn merkle_tree_root(hashes: &[Sha256]) -> Sha256 {
     if hashes.is_empty() {
         // On empty input, return empty SHA256 hash
         calculate_sha256(b"")
     } else {
-        let first = hashes[0];
-        match first {
-            Hash::SHA256(..) => {
-                // Check that all the hashes are SHA256, and return SHA256
-                let hashes_as_vec_of_u8_32 = hashes
-                    .iter()
-                    .map(|x| match x {
-                        Hash::SHA256(y) => y,
-                    })
-                    .collect::<Vec<_>>();
-                Hash::SHA256(merkle_tree_root_with_hashing_function(
-                    sha256_concat,
-                    &hashes_as_vec_of_u8_32,
-                ))
-            }
-        }
+        merkle_tree_root_with_hashing_function(sha256_concat, hashes)
     }
 }
 
 /// Calculate `sha256(a || b)` where || means concatenation
-fn sha256_concat(a: [u8; 32], b: [u8; 32]) -> [u8; 32] {
-    let mut h = a.to_vec();
-    h.extend(&b);
-    match calculate_sha256(&h) {
-        Hash::SHA256(x) => x,
-    }
+fn sha256_concat(a: Sha256, b: Sha256) -> Sha256 {
+    let mut h = a.0.to_vec();
+    h.extend(&b.0);
+    calculate_sha256(&h)
 }
 
 /// Generic merkle tree root calculation
-fn merkle_tree_root_with_hashing_function<T: Copy>(hash_concat: fn(T, T) -> T, hashes: &[&T]) -> T {
+fn merkle_tree_root_with_hashing_function<T: Copy>(hash_concat: fn(T, T) -> T, hashes: &[T]) -> T {
     match hashes.len() {
+        // The public interface guarantees this panic will never happen
         0 => panic!("Input is empty"),
         1 => {
             // 1 node: copy hash to next level
-            *hashes[0]
+            hashes[0]
         }
         2 => {
             // 2 nodes: concatenate hashes and hash that
-            hash_concat(*hashes[0], *hashes[1])
+            hash_concat(hashes[0], hashes[1])
         }
         n => {
             // n nodes: split into 2 and calculate the root for each half
@@ -82,7 +65,7 @@ mod test {
     fn dummy_hash() {
         // Example of using a different hashing function
         let x = [80u8; 16];
-        let hashes = vec![&x, &[15; 16]];
+        let hashes = vec![x, [15; 16]];
         let dummy = |a, _b| a;
         let root = merkle_tree_root_with_hashing_function(dummy, &hashes);
         assert_eq!(root, x);

--- a/crypto/tests/lib.rs
+++ b/crypto/tests/lib.rs
@@ -1,6 +1,4 @@
-use witnet_data_structures::chain::Hash;
-
-use witnet_crypto::hash::calculate_sha256;
+use witnet_crypto::hash::{calculate_sha256, Sha256};
 
 #[test]
 fn sha256() {
@@ -10,5 +8,5 @@ fn sha256() {
         0x5f, 0xe3,
     ];
     let witnet_hash = calculate_sha256(b"WITNET");
-    assert_eq!(witnet_hash, Hash::SHA256(expected_witnet_hash));
+    assert_eq!(witnet_hash, Sha256(expected_witnet_hash));
 }

--- a/crypto/tests/merkle.rs
+++ b/crypto/tests/merkle.rs
@@ -1,6 +1,5 @@
-use witnet_crypto::hash::calculate_sha256;
+use witnet_crypto::hash::{calculate_sha256, Sha256};
 use witnet_crypto::merkle::merkle_tree_root;
-use witnet_data_structures::chain::Hash;
 
 #[test]
 fn empty() {
@@ -16,13 +15,7 @@ fn one() {
 }
 
 // Helper function to test hash order
-fn hash_concat(a: Hash, b: Hash) -> Hash {
-    let a = match a {
-        Hash::SHA256(x) => x,
-    };
-    let b = match b {
-        Hash::SHA256(x) => x,
-    };
+fn hash_concat(Sha256(a): Sha256, Sha256(b): Sha256) -> Sha256 {
     let mut h = a.to_vec();
     h.extend(&b);
     calculate_sha256(&h)
@@ -32,8 +25,8 @@ fn hash_concat(a: Hash, b: Hash) -> Hash {
 fn two() {
     let a = [0x00; 32];
     let b = [0xFF; 32];
-    let a = Hash::SHA256(a);
-    let b = Hash::SHA256(b);
+    let a = Sha256(a);
+    let b = Sha256(b);
 
     // expected:
     // python -c "import sys; sys.stdout.write('\x00' * 32 + '\xFF' * 32)" | sha256sum
@@ -42,7 +35,7 @@ fn two() {
         0x7b, 0xf9, 0x19, 0x3b, 0x14, 0x35, 0x0d, 0x20, 0xfb, 0xa8, 0xa8, 0xb4, 0x06, 0x73, 0x0a,
         0xe3, 0x0a,
     ];
-    let expected = Hash::SHA256(expected);
+    let expected = Sha256(expected);
     assert_eq!(merkle_tree_root(&[a, b]), expected);
 
     // Test the hash_concat function
@@ -52,13 +45,13 @@ fn two() {
 
 #[test]
 fn manual_hash_test() {
-    let a = Hash::SHA256([0x00; 32]);
-    let b = Hash::SHA256([0x11; 32]);
-    let c = Hash::SHA256([0x22; 32]);
-    let d = Hash::SHA256([0x33; 32]);
-    let e = Hash::SHA256([0x44; 32]);
-    let f = Hash::SHA256([0x55; 32]);
-    let g = Hash::SHA256([0x66; 32]);
+    let a = Sha256([0x00; 32]);
+    let b = Sha256([0x11; 32]);
+    let c = Sha256([0x22; 32]);
+    let d = Sha256([0x33; 32]);
+    let e = Sha256([0x44; 32]);
+    let f = Sha256([0x55; 32]);
+    let g = Sha256([0x66; 32]);
 
     let h = hash_concat;
     // Verify the expected hash by manually hashing the elements in order

--- a/data_structures/Cargo.toml
+++ b/data_structures/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 flatbuffers = "0.5.0"
 failure = "0.1.2"
 rand = "0.5.5"
+witnet_crypto = { path = "../crypto" }
 witnet_util = { path = "../util" }
 serde = "1.0.79"
 serde_derive = "1.0.79"

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1,3 +1,5 @@
+use witnet_crypto::hash::Sha256;
+
 pub trait Hashable<T> {
     fn hash(value: T) -> Hash;
 }
@@ -139,6 +141,13 @@ pub struct Secp256k1Signature {
 pub enum Hash {
     /// SHA-256 Hash
     SHA256(SHA256),
+}
+
+/// Conversion between witnet_crypto::Sha256 and witnet_data_structures::Hash
+impl From<Sha256> for Hash {
+    fn from(x: Sha256) -> Self {
+        Hash::SHA256(x.0)
+    }
 }
 
 /// SHA-256 Hash


### PR DESCRIPTION
This allows to import crypto from data_structures, otherwise there would be a cyclic dependency.