### PR TITLE
feat(core): add BuildBlock message to ChainManager

### DIFF
--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -24,6 +24,7 @@ use super::messages::{
 };
 
 use witnet_crypto::{hash::calculate_sha256, merkle::merkle_tree_root};
+use witnet_data_structures::chain::Transaction;
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // ACTOR MESSAGE HANDLERS
@@ -175,8 +176,8 @@ impl Handler<BuildBlock> for ChainManager {
     fn handle(&mut self, msg: BuildBlock, ctx: &mut Context<Self>) -> Self::Result {
         // The leadership proof will be verified by the AddNewBlock handler
 
-        // FIXME(#238): get transactions
-        let txns = vec![];
+        // Get all the unspent transactions
+        let txns: Vec<Transaction> = self.transactions_pool.iter().cloned().collect();
         let epoch = msg.beacon.checkpoint;
         let _reward = block_reward(epoch);
         // TODO: push coinbase transaction
@@ -190,6 +191,7 @@ impl Handler<BuildBlock> for ChainManager {
         // TODO: what is version?
         let version = 0;
         let beacon = msg.beacon;
+        // TODO: use create_merkle_root from validations.rs
         let hash_merkle_root = Hash::from(merkle_tree_root(&txns_hashes));
         let block_header = BlockHeader {
             version,

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -12,7 +12,7 @@ use witnet_data_structures::{
     error::{ChainInfoError, ChainInfoErrorKind, ChainInfoResult},
 };
 
-use crate::validations::{validate_coinbase, validate_merkle_tree};
+use crate::validations::{block_reward, validate_coinbase, validate_merkle_tree};
 
 use witnet_util::error::WitnetError;
 
@@ -177,6 +177,8 @@ impl Handler<BuildBlock> for ChainManager {
 
         // FIXME(#238): get transactions
         let txns = vec![];
+        let epoch = msg.beacon.checkpoint;
+        let _reward = block_reward(epoch);
         // TODO: push coinbase transaction
         let txns_hashes = txns
             .iter()

--- a/core/src/actors/chain_manager/messages.rs
+++ b/core/src/actors/chain_manager/messages.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 
 use crate::actors::chain_manager::ChainManagerError;
 use witnet_data_structures::{
-    chain::{Block, CheckpointBeacon, Epoch, Hash, InventoryEntry},
+    chain::{Block, CheckpointBeacon, Epoch, Hash, InventoryEntry, LeadershipProof},
     error::ChainInfoResult,
 };
 
@@ -46,6 +46,15 @@ pub struct GetBlocksEpochRange {
 
 impl Message for GetBlocksEpochRange {
     type Result = Result<Vec<InventoryEntry>, ChainManagerError>;
+}
+
+/// Build a new block using the supplied leadership proof
+#[derive(Debug, Message)]
+pub struct BuildBlock {
+    /// Checkpoint beacon
+    pub beacon: CheckpointBeacon,
+    /// Proof of eligibility
+    pub leadership_proof: LeadershipProof,
 }
 
 /// Discard inventory entries that exist in the BlocksManager

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -89,7 +89,7 @@ pub struct ChainManager {
     /// Current Epoch
     current_epoch: Option<Epoch>,
     /// Transactions Pool
-    _transactions_pool: TransactionsPool,
+    transactions_pool: TransactionsPool,
 }
 
 /// Required trait for being able to retrieve ChainManager address from registry

--- a/core/src/validations.rs
+++ b/core/src/validations.rs
@@ -1,6 +1,6 @@
 use witnet_crypto::hash::Sha256;
 use witnet_crypto::merkle::merkle_tree_root as crypto_merkle_tree_root;
-use witnet_data_structures::chain::{Block, Hash, Hashable, Transaction};
+use witnet_data_structures::chain::{Block, Epoch, Hash, Hashable, Transaction};
 
 /// Function to validate block's coinbase
 pub fn validate_coinbase(_block: &Block) -> bool {
@@ -26,4 +26,20 @@ pub fn validate_merkle_tree(block: &Block) -> bool {
     let transactions = &block.txns;
 
     merkle_tree == merkle_tree_root(transactions)
+}
+
+/// 1 satowit is the minimal unit of value
+/// 1 wit = 100_000_000 satowits
+pub const SATOWITS_PER_WIT: u64 = 100_000_000;
+
+/// Calculate the block mining reward.
+/// Returns "satowits", where 1 wit = 100_000_000 satowits.
+pub fn block_reward(epoch: Epoch) -> u64 {
+    let initial_reward: u64 = 500 * SATOWITS_PER_WIT;
+    let halvings = epoch / 1_750_000;
+    if halvings < 64 {
+        initial_reward >> halvings
+    } else {
+        0
+    }
 }

--- a/core/tests/validations.rs
+++ b/core/tests/validations.rs
@@ -1,0 +1,19 @@
+use witnet_core::validations::block_reward;
+
+#[test]
+fn test_block_reward() {
+    // Satowits per wit
+    let spw = 100_000_000;
+
+    assert_eq!(block_reward(0), 500 * spw);
+    assert_eq!(block_reward(1), 500 * spw);
+    assert_eq!(block_reward(1_749_999), 500 * spw);
+    assert_eq!(block_reward(1_750_000), 250 * spw);
+    assert_eq!(block_reward(3_499_999), 250 * spw);
+    assert_eq!(block_reward(3_500_000), 125 * spw);
+    assert_eq!(block_reward(1_750_000 * 35), 1);
+    assert_eq!(block_reward(1_750_000 * 36), 0);
+    assert_eq!(block_reward(1_750_000 * 63), 0);
+    assert_eq!(block_reward(1_750_000 * 64), 0);
+    assert_eq!(block_reward(1_750_000 * 100), 0);
+}

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -347,9 +347,9 @@ impl TransactionsPool {
     /// pool.retain(|h, _| match h { Hash::SHA256(n) => n[0]== 0 });
     /// assert_eq!(pool.len(), 1);
     /// ```
-    pub fn retain<F>(&mut self, f: F)
+    pub fn retain<F>(&mut self, mut f: F)
     where
-        F: Fn(&Hash, &Transaction) -> bool,
+        F: FnMut(&Hash, &Transaction) -> bool,
     {
         let TransactionsPool {
             ref mut transactions,

--- a/docs/architecture/managers/chain-manager.md
+++ b/docs/architecture/managers/chain-manager.md
@@ -58,6 +58,7 @@ These are the messages supported by the `ChainManager` handlers:
 | `EpochNotification<EveryEpochPayload>` | `Epoch`, `EveryEpochPayload` | `()`                              | A new epoch has been reached                      |
 | `GetHighestBlockCheckpoint`            | `()`                         | `ChainInfoResult`                 | Request a copy of the highest block checkpoint    |
 | `AddNewBlock`                          | `Block`                      | `Result<(), ChainManagerError>` | Add a new block and announce it to other sessions |
+| `BuildBlock`                           | `CheckpointBeacon`,`LeadershipProof` | `()`                    | Build a new block and add it |
 
 Where `ChainInfoResult` is just:
 


### PR DESCRIPTION
This PR adds a method to create new blocks with a given proof of eligibility. It gets the maximum number of transactions (currently unimplemented). The block is then validated in the `AddNewBlock` handler, following the same path as external blocks (blocks from the network).

TODOs:

* Add coinbase transaction
* Calculate the total fee of the transactions
* Should there be any helper methods to build Block/BlockHeader/LeadershipProof?
