### PR TITLE
feat(data structures): add TransactionsPool struct

### DIFF
--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -29,7 +29,7 @@ use actix::{
     ActorFuture, Context, ContextFutureSpawner, Supervised, System, SystemService, WrapFuture,
 };
 
-use witnet_data_structures::chain::ChainInfo;
+use witnet_data_structures::chain::{ChainInfo, TransactionsPool};
 
 use crate::actors::{
     chain_manager::messages::InventoryEntriesResult,
@@ -88,6 +88,8 @@ pub struct ChainManager {
     blocks: HashMap<Hash, Block>,
     /// Current Epoch
     current_epoch: Option<Epoch>,
+    /// Transactions Pool
+    _transactions_pool: TransactionsPool,
 }
 
 /// Required trait for being able to retrieve ChainManager address from registry

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1,4 +1,5 @@
 use super::serializers::{build_block_flatbuffer, BlockArgs};
+use std::collections::{BTreeSet, HashMap};
 use witnet_crypto::hash::{calculate_sha256, Sha256};
 
 pub trait Hashable {
@@ -143,7 +144,7 @@ pub struct Secp256k1Signature {
 }
 
 /// Hash
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, Deserialize, Hash)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Copy, Clone, Serialize, Deserialize, Hash)]
 pub enum Hash {
     /// SHA-256 Hash
     SHA256(SHA256),
@@ -163,6 +164,166 @@ pub type SHA256 = [u8; 32];
 // FIXME(#99): define Transaction as defined in issue
 #[derive(Copy, Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Transaction;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct WeightedHash(u64, Hash);
+
+/// A pool of validated transactions that supports constant access by
+/// [`Hash`](Hash) and iteration over the
+/// transactions sorted from by transactions with bigger fees to
+/// transactions with smaller fees.
+#[derive(Debug, Default, Clone)]
+pub struct TransactionsPool {
+    transactions: HashMap<Hash, Transaction>,
+    sorted_index: BTreeSet<WeightedHash>,
+}
+
+impl TransactionsPool {
+    /// Makes a new empty pool of transactions.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use witnet_data_structures::chain::TransactionsPool;
+    /// let pool = TransactionsPool::new();
+    /// ```
+    pub fn new() -> Self {
+        TransactionsPool {
+            transactions: HashMap::new(),
+            sorted_index: BTreeSet::new(),
+        }
+    }
+
+    /// Makes a new pool of transactions with the specified capacity.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use witnet_data_structures::chain::TransactionsPool;
+    /// let pool = TransactionsPool::with_capacity(20);
+    /// ```
+    pub fn with_capacity(capacity: usize) -> Self {
+        TransactionsPool {
+            transactions: HashMap::with_capacity(capacity),
+            sorted_index: BTreeSet::new(),
+        }
+    }
+
+    /// Returns the number of transactions the pool can hold without
+    /// reallocating.
+    ///
+    /// This number is a lower bound; the pool might be able to hold
+    /// more, but is guaranteed to be able to hold at least this many.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use witnet_data_structures::chain::TransactionsPool;
+    /// let pool = TransactionsPool::with_capacity(20);
+    ///
+    /// assert!(pool.capacity() >= 20);
+    /// ```
+    pub fn capacity(&self) -> usize {
+        self.transactions.capacity()
+    }
+
+    /// Returns `true` if the pool contains no transactions.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use witnet_data_structures::chain::TransactionsPool;
+    /// let mut pool = TransactionsPool::new();
+    ///
+    /// assert!(pool.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.transactions.is_empty()
+    }
+
+    /// Returns the number of transactions in the pool.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use witnet_data_structures::chain::{TransactionsPool, Transaction, Hash};
+    /// let mut pool = TransactionsPool::new();
+    ///
+    /// assert_eq!(pool.len(), 0);
+    ///
+    /// pool.insert(Hash::SHA256([0 as u8; 32]), Transaction);
+    ///
+    /// assert_eq!(pool.len(), 1);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.transactions.len()
+    }
+
+    /// Returns `true` if the pool contains a transaction for the specified hash.
+    ///
+    /// The `key` may be any borrowed form of the hash, but `Hash` and
+    /// `Eq` on the borrowed form must match those for the key type.
+    ///
+    /// # Examples:
+    /// ```
+    /// # use witnet_data_structures::chain::{TransactionsPool, Transaction, Hash};
+    /// let mut pool = TransactionsPool::new();
+    /// let hash = Hash::SHA256([0 as u8; 32]);
+    ///
+    /// assert!(!pool.contains(&hash));
+    ///
+    /// pool.insert(hash, Transaction);
+    ///
+    /// assert!(pool.contains(&hash));
+    /// ```
+    pub fn contains(&self, key: &Hash) -> bool {
+        self.transactions.contains_key(key)
+    }
+
+    /// Insert a transaction identified by `key` into the pool.
+    ///
+    /// # Examples:
+    ///
+    /// ```
+    /// # use witnet_data_structures::chain::{TransactionsPool, Transaction, Hash};
+    /// let mut pool = TransactionsPool::new();
+    ///
+    /// pool.insert(Hash::SHA256([0 as u8; 32]), Transaction);
+    ///
+    /// assert!(!pool.is_empty());
+    /// ```
+    pub fn insert(&mut self, key: Hash, transaction: Transaction) {
+        let weight = 0; // TODO: weight = transaction-fee / transaction-weight
+        self.transactions.insert(key, transaction);
+        self.sorted_index.insert(WeightedHash(weight, key));
+    }
+
+    /// An iterator visiting all the transactions in the pool in
+    /// descending-fee order, that is, transactions with bigger fees
+    /// come first.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// # use witnet_data_structures::chain::{TransactionsPool, Transaction, Hash};
+    /// let mut pool = TransactionsPool::new();
+    ///
+    /// pool.insert(Hash::SHA256([0 as u8; 32]), Transaction);
+    /// pool.insert(Hash::SHA256([0 as u8; 32]), Transaction);
+    ///
+    /// let mut iter = pool.iter();
+    /// let tx1 = iter.next();
+    /// let tx2 = iter.next();
+    ///
+    /// // TODO: assert!(tx1.weight() >= tx2.weight());
+    /// ```
+    pub fn iter(&self) -> impl Iterator<Item = &Transaction> {
+        self.sorted_index
+            .iter()
+            .rev()
+            .filter_map(move |WeightedHash(_, h)| self.transactions.get(h))
+    }
+}
 
 /// Inventory entry data structure
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -327,7 +327,7 @@ impl TransactionsPool {
     /// Retains only the elements specified by the predicate.
     ///
     /// In other words, remove all transactions such that
-    /// `f(&Hash,&mut Transaction)` returns `false`.
+    /// `f(&Hash, &Transaction)` returns `false`.
     ///
     /// # Examples
     ///
@@ -341,9 +341,9 @@ impl TransactionsPool {
     /// pool.retain(|h, _| match h { Hash::SHA256(n) => n[0]== 0 });
     /// assert_eq!(pool.len(), 1);
     /// ```
-    pub fn retain<F>(&mut self, mut f: F)
+    pub fn retain<F>(&mut self, f: F)
     where
-        F: FnMut(&Hash, &mut Transaction) -> bool,
+        F: Fn(&Hash, &Transaction) -> bool,
     {
         let TransactionsPool {
             ref mut transactions,


### PR DESCRIPTION
Add TransactionsPool struct which is a container of Transaction objects providing constant time lookup by transaction-hash and iteration over the transactions sorted by K, where:

```
    transaction fee
K = ------------------
    transaction weight
```

This pool is used internally by the ChainManager as its mempool.

See the generated docs for the data structure for more examples.