### PR TITLE
Fix bugs found while trying mining demo

### DIFF
--- a/core/src/actors/chain_manager/actor.rs
+++ b/core/src/actors/chain_manager/actor.rs
@@ -142,9 +142,6 @@ impl Actor for ChainManager {
                     actix::fut::ok(())
                 })
                 .wait(ctx);
-
-            // Persist chain_info into storage
-            act.persist_chain_info(ctx);
         });
     }
 }

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -71,6 +71,9 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
 
             // Send block to Inventory Manager
             self.persist_item(ctx, InventoryItem::Block(candidate));
+
+            // Persist chain_info into storage
+            self.persist_chain_info(ctx);
         }
     }
 }

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -16,12 +16,14 @@ use crate::validations::{validate_coinbase, validate_merkle_tree};
 
 use witnet_util::error::WitnetError;
 
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 
 use super::messages::{
     AddNewBlock, BuildBlock, DiscardExistingInventoryEntries, GetBlock, GetBlocksEpochRange,
     GetHighestCheckpointBeacon, InventoryEntriesResult,
 };
+
+use std::time::Duration;
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // ACTOR MESSAGE HANDLERS
@@ -203,10 +205,18 @@ impl Handler<BuildBlock> for ChainManager {
     fn handle(&mut self, msg: BuildBlock, ctx: &mut Context<Self>) -> Self::Result {
         // Build the block using the supplied beacon and eligibility proof
         let block = self.build_block(&msg);
+        info!(
+            "Mined a new block with hash {:?}:\n{:?}",
+            block.hash(),
+            block
+        );
 
         // Send AddNewBlock message to self
         // This will run all the validations again
-        ctx.notify(AddNewBlock { block })
+        // Wait 2 seconds because otherwise the block can arrive to other peers just
+        // before the epoch checkpoint, which marks the blocks as invalid because the
+        // current epoch is N while the block header checkpoint is N+1
+        ctx.notify_later(AddNewBlock { block }, Duration::from_secs(2));
     }
 }
 

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -247,7 +247,7 @@ impl Handler<GetBlocksEpochRange> for ChainManager {
     ) -> Self::Result {
         debug!("GetBlocksEpochRange received {:?}", range);
         let hashes = range
-            .map(|epoch| &self.epoch_to_block_hash[&epoch])
+            .flat_map(|epoch| self.epoch_to_block_hash.get(&epoch))
             .flatten()
             .map(|hash| InventoryEntry::Block(*hash))
             .collect();

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -16,14 +16,12 @@ use crate::validations::{validate_coinbase, validate_merkle_tree};
 
 use witnet_util::error::WitnetError;
 
-use log::{debug, error, info, warn};
+use log::{debug, error, warn};
 
 use super::messages::{
     AddNewBlock, BuildBlock, DiscardExistingInventoryEntries, GetBlock, GetBlocksEpochRange,
     GetHighestCheckpointBeacon, InventoryEntriesResult,
 };
-
-use std::time::Duration;
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // ACTOR MESSAGE HANDLERS
@@ -266,18 +264,10 @@ impl Handler<BuildBlock> for ChainManager {
     fn handle(&mut self, msg: BuildBlock, ctx: &mut Context<Self>) -> Self::Result {
         // Build the block using the supplied beacon and eligibility proof
         let block = self.build_block(&msg);
-        info!(
-            "Mined a new block with hash {:?}:\n{:?}",
-            block.hash(),
-            block
-        );
 
         // Send AddNewBlock message to self
         // This will run all the validations again
-        // Wait 2 seconds because otherwise the block can arrive to other peers just
-        // before the epoch checkpoint, which marks the blocks as invalid because the
-        // current epoch is N while the block header checkpoint is N+1
-        ctx.notify_later(AddNewBlock { block }, Duration::from_secs(2));
+        ctx.notify(AddNewBlock { block })
     }
 }
 

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -112,14 +112,65 @@ impl Handler<AddNewBlock> for ChainManager {
         let block_epoch = msg.block.block_header.beacon.checkpoint;
         if self.current_epoch.is_none() {
             warn!("ChainManager doesn't have current epoch");
-        } else if Some(block_epoch) != self.current_epoch {
-            warn!("Block epoch not valid");
-        } else if candidate_better_eligibility {
-            warn!("Block hash bigger than candidate hash");
         } else if !validate_coinbase(&msg.block) {
             warn!("Block coinbase not valid");
         } else if !validate_merkle_tree(&msg.block) {
             warn!("Block merkle tree not valid");
+        } else if Some(block_epoch) > self.current_epoch {
+            warn!(
+                "Block epoch from the future: current: {}, block: {}",
+                self.current_epoch.unwrap(),
+                block_epoch
+            );
+        } else if Some(block_epoch) < self.current_epoch {
+            warn!(
+                "Block epoch mismatch: current: {}, block: {}",
+                self.current_epoch.unwrap(),
+                block_epoch
+            );
+            // Add old block
+            // FIXME(#235): check proof of eligibility from the past
+            // ReputationManager should have a method to validate PoE from a past epoch
+            reputation_manager_addr
+                .send(ValidatePoE {
+                    beacon: msg.block.block_header.beacon,
+                    proof: msg.block.proof,
+                })
+                .into_actor(self)
+                .then(|res, act, ctx| {
+                    match res {
+                        Err(e) => {
+                            // Error when sending message
+                            error!("Unsuccessful communication with reputation manager: {}", e);
+                        }
+                        Ok(false) => {
+                            warn!("Block PoE not valid");
+                        }
+                        Ok(true) => {
+                            // Insert in blocks mempool
+                            let res = act.process_new_block(msg.block.clone());
+                            match res {
+                                Ok(hash) => {
+                                    act.broadcast_block(hash);
+
+                                    // Save block to storage
+                                    act.persist_item(ctx, InventoryItem::Block(msg.block));
+                                }
+                                Err(ChainManagerError::BlockAlreadyExists) => {
+                                    warn!("Block already exists");
+                                }
+                                Err(_) => {
+                                    error!("Unexpected error");
+                                }
+                            };
+                        }
+                    }
+
+                    actix::fut::ok(())
+                })
+                .wait(ctx);
+        } else if candidate_better_eligibility {
+            warn!("Block hash bigger than candidate hash");
         } else {
             // Request proof of eligibility validation to ReputationManager
             reputation_manager_addr
@@ -128,7 +179,7 @@ impl Handler<AddNewBlock> for ChainManager {
                     proof: msg.block.proof,
                 })
                 .into_actor(self)
-                .then(|res, act, _ctx| {
+                .then(|res, act, ctx| {
                     match res {
                         Err(e) => {
                             // Error when sending message
@@ -142,10 +193,17 @@ impl Handler<AddNewBlock> for ChainManager {
                             act.block_candidate = Some(msg.block.clone());
 
                             // Insert in blocks mempool
-                            let res = act.process_new_block(msg.block);
+                            let res = act.process_new_block(msg.block.clone());
                             match res {
                                 Ok(hash) => {
                                     act.broadcast_block(hash);
+
+                                    // Save block to storage
+                                    // TODO: dont save the current candidate into storage
+                                    // Because it may not be the chosen block
+                                    // Add in Session a method to retrieve the block candidate
+                                    // before checking for blocks in storage
+                                    act.persist_item(ctx, InventoryItem::Block(msg.block));
                                 }
                                 Err(ChainManagerError::BlockAlreadyExists) => {
                                     warn!("Block already exists");

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -244,10 +244,7 @@ impl ChainManager {
             beacon,
             hash_merkle_root,
         };
-        let proof = LeadershipProof {
-            block_sig: None,
-            influence: 0,
-        };
+        let proof = msg.leadership_proof;
 
         Block {
             block_header,

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -40,19 +40,18 @@ use log::{debug, error, info};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use witnet_data_structures::chain::{
-    Block, BlockHeader, ChainInfo, Epoch, Hash, InventoryEntry, InventoryItem, LeadershipProof,
+    Block, BlockHeader, ChainInfo, Epoch, Hash, Hashable, InventoryEntry, InventoryItem,
     Transaction, TransactionsPool,
 };
 
 use crate::actors::session::messages::AnnounceItems;
 use crate::actors::sessions_manager::{messages::Broadcast, SessionsManager};
 
-use witnet_storage::{error::StorageError, storage::Storable};
+use witnet_storage::error::StorageError;
 
 use crate::actors::chain_manager::messages::BuildBlock;
 use crate::validations::block_reward;
 use crate::validations::merkle_tree_root;
-use witnet_crypto::hash::calculate_sha256;
 use witnet_util::error::WitnetError;
 
 mod actor;
@@ -174,7 +173,7 @@ impl ChainManager {
 
     fn process_new_block(&mut self, block: Block) -> Result<Hash, ChainManagerError> {
         // Calculate the hash of the block
-        let hash: Hash = Hash::from(calculate_sha256(&block.to_bytes()?));
+        let hash: Hash = block.hash();
 
         // Check if we already have a block with that hash
         if let Some(_block) = self.blocks.get(&hash) {

--- a/core/src/actors/mining_manager/actor.rs
+++ b/core/src/actors/mining_manager/actor.rs
@@ -3,6 +3,7 @@ use actix::{Actor, Context};
 use crate::actors::config_manager::send_get_config_request;
 
 use super::MiningManager;
+use witnet_util::timestamp::get_timestamp;
 
 /// Make actor from MiningManager
 impl Actor for MiningManager {
@@ -11,6 +12,9 @@ impl Actor for MiningManager {
 
     /// Method to be executed when the actor is started
     fn started(&mut self, ctx: &mut Self::Context) {
+        // Use the current timestamp as a random value to modify the signature
+        // Wait at least 1 second before starting each node
+        self.random = get_timestamp() as u64;
         send_get_config_request(self, ctx, Self::process_config)
     }
 }

--- a/core/src/actors/mining_manager/handlers.rs
+++ b/core/src/actors/mining_manager/handlers.rs
@@ -59,7 +59,11 @@ impl Handler<EpochNotification<EveryEpochPayload>> for MiningManager {
 
                 // TODO: send Sign message to CryptoManager
                 let sign = |x, _k| match x {
-                    Hash::SHA256(x) => x,
+                    Hash::SHA256(mut x) => {
+                        // Add some randomness to the signature
+                        x[0] = act.random as u8;
+                        x
+                    }
                 };
                 let signed_beacon_hash = sign(beacon_hash, private_key);
                 // Currently, every hash is valid

--- a/core/src/actors/mining_manager/mod.rs
+++ b/core/src/actors/mining_manager/mod.rs
@@ -19,7 +19,12 @@ mod handlers;
 ////////////////////////////////////////////////////////////////////////////////////////
 /// MiningManager actor
 #[derive(Default)]
-pub struct MiningManager {}
+pub struct MiningManager {
+    // Random value to help with debugging because there is no signature
+    // and all the mined blocks have the same hash.
+    // This random value helps to distinguish blocks mined on different nodes
+    random: u64,
+}
 
 /// Auxiliary methods for MiningManager actor
 impl MiningManager {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -10,7 +10,7 @@ description = "Witnet storage module that conveniently abstracts a key/value API
 env_logger = "0.5.13"
 failure = "0.1.2"
 log = "0.4"
-rmp-serde = "0.13"
+serde_json = "1.0"
 rocksdb = { version = "0.10.1", optional = true }
 serde = "1.0"
 witnet_util = { path = "../util" }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -46,7 +46,7 @@ where
 {
     /// Convert `Self` into `Vec<u8>`
     fn to_bytes(&self) -> StorageResult<Vec<u8>> {
-        rmp_serde::to_vec(&self).map_err(|e| {
+        serde_json::to_vec(&self).map_err(|e| {
             WitnetError::from(StorageError::new(
                 StorageErrorKind::Encode,
                 "Error when encoding value".to_string(),
@@ -54,9 +54,9 @@ where
             ))
         })
     }
-    /// Convert `Vec<u8>` into `Self
+    /// Convert `Vec<u8>` into `Self`
     fn from_bytes(x: &[u8]) -> StorageResult<Self> {
-        rmp_serde::from_slice(x).map_err(|e| {
+        serde_json::from_slice(x).map_err(|e| {
             WitnetError::from(StorageError::new(
                 StorageErrorKind::Decode,
                 "Error when decoding value".to_string(),


### PR DESCRIPTION
The following works correctly:

* The block with the lowest hash will be chosen when there are 2 candidates
* A new node will ask for the all the blocks that it is missing
* The blocks are correctly mined and sent
* The blocks are successfully stored and retrieved from the `InventoryManager`

Aside from a few minor bugs, the following changes should be discussed:

* replace MessagePack with Json as a temporary workarround for a MessagePack bug
* accept blocks from a past epoch
* add randomness to mining manager to help testing the block candidate logic
