### PR TITLE
feat(actors): add unspent outputs pool to ChainManager

### DIFF
--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -5,7 +5,7 @@
 //! received through the protocol, and also encapsulates the logic of the
 //! _unspent transaction outputs_.
 //!
-//! Among its responsabilities are the following:
+//! Among its responsibilities are the following:
 //!
 //! * Initializing the chain info upon running the node for the first time and persisting it into storage [StorageManager](actors::storage_manager::StorageManager)
 //! * Recovering the chain info from storage and keeping it in its state.
@@ -40,8 +40,8 @@ use log::{debug, error, info};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use witnet_data_structures::chain::{
-    Block, BlockHeader, ChainInfo, Epoch, Hash, Hashable, InventoryEntry, InventoryItem,
-    Transaction, TransactionsPool,
+    Block, BlockHeader, ChainInfo, Epoch, Hash, Hashable, InventoryEntry, InventoryItem, Output,
+    Transaction, TransactionsPool, UnspentOutput,
 };
 
 use crate::actors::session::messages::AnnounceItems;
@@ -96,6 +96,8 @@ pub struct ChainManager {
     transactions_pool: TransactionsPool,
     /// Block candidate to update chain_info in the next epoch
     block_candidate: Option<Block>,
+    /// Unspent Outputs Pool
+    _unspent_outputs_pool: HashMap<UnspentOutput, Output>,
 }
 
 /// Required trait for being able to retrieve ChainManager address from registry

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -63,21 +63,12 @@ pub struct ConsensusConstants {
 }
 
 /// Checkpoint beacon structure
-#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
 pub struct CheckpointBeacon {
     /// The serial number for an epoch
     pub checkpoint: Epoch,
     /// The 256-bit hash of the previous block header
     pub hash_prev_block: Hash,
-}
-
-impl Default for CheckpointBeacon {
-    fn default() -> CheckpointBeacon {
-        CheckpointBeacon {
-            checkpoint: 0,
-            hash_prev_block: Hash::SHA256([0; 32]),
-        }
-    }
 }
 
 /// Epoch id (starting from 0)
@@ -182,6 +173,12 @@ pub struct Secp256k1Signature {
 pub enum Hash {
     /// SHA-256 Hash
     SHA256(SHA256),
+}
+
+impl Default for Hash {
+    fn default() -> Hash {
+        Hash::SHA256([0; 32])
+    }
 }
 
 /// Conversion between witnet_crypto::Sha256 and witnet_data_structures::Hash

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -526,6 +526,14 @@ impl TransactionsPool {
     }
 }
 
+/// Unspent output data structure (equivalent of Bitcoin's UTXO)
+/// It is used to locate the output by its transaction identifier and its position
+#[derive(Debug, Default, Hash, Clone, Eq, PartialEq)]
+pub struct UnspentOutput {
+    pub transaction_id: Hash,
+    pub output_index: u32,
+}
+
 /// Inventory entry data structure
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum InventoryEntry {


### PR DESCRIPTION
As discussed in #244, I implemented the data structure that some of us thought was more appropriate.

I am not entirely satisfied with the name of the struct for identifying the unspent outputs (`UnspentOutput` in data_structures `chain.rs`). Suggestions are welcome! :smiley: 

Closes #244