### PR TITLE
Fix peer discovery

### DIFF
--- a/core/src/actors/session/handlers.rs
+++ b/core/src/actors/session/handlers.rs
@@ -81,11 +81,7 @@ impl StreamHandler<BytesMut, Error> for Session {
                         peer_discovery_get_peers(self, ctx);
                     }
                     // Handle Peers message
-                    (
-                        SessionType::Outbound,
-                        SessionStatus::Consolidated,
-                        Command::Peers(Peers { peers }),
-                    ) => {
+                    (_, SessionStatus::Consolidated, Command::Peers(Peers { peers })) => {
                         peer_discovery_peers(&peers);
                     }
                     ///////////////////////


### PR DESCRIPTION
This makes the `Session` actor handle `GetPeers` and `Peers` messages from inbound sessions too, as needed because of #277.