### PR TITLE
Wait for epoch 0 before trying to bootstrap the chain

### DIFF
--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -1,5 +1,5 @@
 use actix::{
-    ActorFuture, AsyncContext, Context, ContextFutureSpawner, Handler, System, WrapFuture,
+    Actor, ActorFuture, AsyncContext, Context, ContextFutureSpawner, Handler, System, WrapFuture,
 };
 
 use crate::actors::chain_manager::{messages::SessionUnitResult, ChainManager, ChainManagerError};
@@ -38,8 +38,14 @@ pub struct EveryEpochPayload;
 impl Handler<EpochNotification<EpochPayload>> for ChainManager {
     type Result = ();
 
-    fn handle(&mut self, msg: EpochNotification<EpochPayload>, _ctx: &mut Context<Self>) {
+    fn handle(&mut self, msg: EpochNotification<EpochPayload>, ctx: &mut Context<Self>) {
         debug!("Epoch notification received {:?}", msg.checkpoint);
+
+        // Genesis checkpoint notification. We need to start building the chain.
+        if msg.checkpoint == 0 {
+            warn!("Genesis checkpoint is here! Starting to bootstrap the chain...");
+            self.started(ctx);
+        }
     }
 }
 

--- a/core/src/actors/epoch_manager/mod.rs
+++ b/core/src/actors/epoch_manager/mod.rs
@@ -29,7 +29,7 @@ pub enum EpochManagerError {
     // (unused because get_timestamp() cannot fail)
     //UnknownTimestamp,
     /// Checkpoint zero is in the future
-    CheckpointZeroInTheFuture,
+    CheckpointZeroInTheFuture(i64),
     /// Overflow when calculating the epoch timestamp
     Overflow,
 }
@@ -82,7 +82,7 @@ impl EpochManager {
             (Some(zero), Some(period)) => {
                 let elapsed = timestamp - zero;
                 if elapsed < 0 {
-                    Err(EpochManagerError::CheckpointZeroInTheFuture)
+                    Err(EpochManagerError::CheckpointZeroInTheFuture(zero))
                 } else {
                     let epoch = elapsed as Epoch / Epoch::from(period);
                     Ok(epoch)

--- a/core/tests/actors/epoch_manager.rs
+++ b/core/tests/actors/epoch_manager.rs
@@ -34,7 +34,7 @@ fn epoch_zero_in_the_future() {
 
     assert_eq!(
         em.epoch_at(now),
-        Err(EpochManagerError::CheckpointZeroInTheFuture)
+        Err(EpochManagerError::CheckpointZeroInTheFuture(zero))
     );
 }
 

--- a/util/src/timestamp.rs
+++ b/util/src/timestamp.rs
@@ -17,3 +17,16 @@ pub fn get_timestamp_nanos() -> (i64, u32) {
     // Return number of non-leap seconds since Unix epoch and the number of nanoseconds since the last second boundary
     (utc.timestamp(), utc.timestamp_subsec_nanos())
 }
+
+/// Function for pretty printing a timestamp as a human friendly date and time
+pub fn pretty_print(seconds: i64, nanoseconds: u32) -> String {
+    Utc.timestamp(seconds, nanoseconds).to_string()
+}
+
+#[test]
+fn pretty_print_test() {
+    let result = pretty_print(0, 0);
+    let expected = "1970-01-01 00:00:00 UTC";
+
+    assert_eq!(result, expected);
+}


### PR DESCRIPTION
This is a quick fix for making `ChainManager` wait for epoch 0 before bootstrapping the chain.