### PR TITLE
getBlockChain

### DIFF
--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -40,8 +40,7 @@ use crate::actors::{
 };
 
 use log::{debug, error, info, warn};
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use witnet_data_structures::chain::{
     Block, BlockHeader, ChainInfo, Epoch, Hash, Hashable, InventoryEntry, InventoryItem, Output,
     OutputPointer, TransactionsPool,
@@ -90,7 +89,7 @@ pub struct ChainManager {
     chain_info: Option<ChainInfo>,
     /// Map that relates an epoch with the hashes of the blocks for that epoch
     // One epoch can have more than one block
-    epoch_to_block_hash: HashMap<Epoch, HashSet<Hash>>,
+    epoch_to_block_hash: BTreeMap<Epoch, HashSet<Hash>>,
     /// Map that stores blocks by their hash
     blocks: HashMap<Hash, Block>,
     /// Current Epoch

--- a/core/src/actors/session/handlers.rs
+++ b/core/src/actors/session/handlers.rs
@@ -557,14 +557,14 @@ fn todo_inbound_session_getblocks(
                         let range = (received_checkpoint + 1)..=highest_checkpoint;
 
                         chain_manager_addr
-                            .send(GetBlocksEpochRange { range })
+                            .send(GetBlocksEpochRange::new(range))
                             .into_actor(act)
                             .then(|res, act, _ctx| match res {
                                 Ok(Ok(blocks)) => {
                                     // Try to create an Inv protocol message with the items to
                                     // be announced
                                     if let Ok(inv_msg) =
-                                        WitnetMessage::build_inventory_announcement(blocks)
+                                        WitnetMessage::build_inventory_announcement(blocks.into_iter().map(|(_epoch, hash)| hash).collect())
                                     {
                                         // Send Inv message through the session network connection
                                         act.send_message(inv_msg);

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -4,6 +4,7 @@ use super::serializers::encoders::{
 };
 use std::collections::{BTreeSet, HashMap};
 use std::convert::AsRef;
+use std::fmt;
 use witnet_crypto::hash::{calculate_sha256, Sha256};
 
 pub trait Hashable {
@@ -203,6 +204,19 @@ impl Default for Hash {
 impl From<Sha256> for Hash {
     fn from(x: Sha256) -> Self {
         Hash::SHA256(x.0)
+    }
+}
+
+impl fmt::Display for Hash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Hash::SHA256(h) => f.write_str(
+                &h.into_iter()
+                    .fold(String::new(), |acc, x| format!("{}{:02x}", acc, x)),
+            )?,
+        };
+
+        Ok(())
     }
 }
 

--- a/docs/architecture/managers/chain-manager.md
+++ b/docs/architecture/managers/chain-manager.md
@@ -61,14 +61,17 @@ System::current().registry().set(chain_manager_addr);
 
 These are the messages supported by the `ChainManager` handlers:
 
-| Message                                | Input type                           | Output type                       | Description                                             |
-| -------------------------------------- | ------------------------------------ | --------------------------------- | ------------------------------------------------------- |
-| `EpochNotification<EpochPayload>`      | `Epoch`, `EpochPayload`              | `()`                              | The requested epoch has been reached                    |
-| `EpochNotification<EveryEpochPayload>` | `Epoch`, `EveryEpochPayload`         | `()`                              | A new epoch has been reached                            |
-| `GetHighestBlockCheckpoint`            | `()`                                 | `ChainInfoResult`                 | Request a copy of the highest block checkpoint          |
-| `AddNewBlock`                          | `Block`                              | `Result<(), ChainManagerError>`   | Add a new block and announce it to other sessions       |
-| `AddTransaction`                       | `Transaction`                        | `Result<(), ChainManagerError>`   | Add a new transaction and announce it to other sessions |
-| `BuildBlock`                           | `CheckpointBeacon`,`LeadershipProof` | `()`                              | Build a new block and add it                            |
+| Message                                | Input type                           | Output type                                               | Description                                                        |
+|----------------------------------------|--------------------------------------|-----------------------------------------------------------|--------------------------------------------------------------------|
+| `EpochNotification<EpochPayload>`      | `Epoch`, `EpochPayload`              | `()`                                                      | The requested epoch has been reached                               |
+| `EpochNotification<EveryEpochPayload>` | `Epoch`, `EveryEpochPayload`         | `()`                                                      | A new epoch has been reached                                       |
+| `GetHighestBlockCheckpoint`            | `()`                                 | `ChainInfoResult`                                         | Request a copy of the highest block checkpoint                     |
+| `AddNewBlock`                          | `Block`                              | `Result<(), ChainManagerError>`                           | Add a new block and announce it to other sessions                  |
+| `AddTransaction`                       | `Transaction`                        | `Result<(), ChainManagerError>`                           | Add a new transaction and announce it to other sessions            |
+| `GetBlock`                             | `Hash`                               | `Result<(), ChainManagerError>`                           | Ask for a block identified by its hash                             |
+| `GetBlocksEpochRange`                  | `(Bound<Epoch>, Bound<Epoch>)`       | `Result<Vec<(Epoch, InventoryEntry)>, ChainManagerError>` | Obtain a vector of epochs and block hashes using a range of epochs |
+| `BuildBlock`                           | `CheckpointBeacon`,`LeadershipProof` | `()`                                                      | Build a new block and add it                                       |
+| `DiscardExistingInventoryEntries`      | `Vec<InventoryEntries>`              | `InventoryEntriesResult`                                  | Discard inventory entries that exist in the BlocksManager          |
 
 Where `ChainInfoResult` is just:
 

--- a/docs/interface/json-rpc.md
+++ b/docs/interface/json-rpc.md
@@ -53,6 +53,24 @@ Response:
 {"jsonrpc":"2.0","result":true,"id":1}
 ```
 
+#### getBlockChain
+
+Get the list of all the known block hashes.
+
+Returns a list of `(epoch, block_hash)` pairs.
+
+Example:
+
+```
+{"jsonrpc": "2.0","method": "getBlockChain", "id": 1}
+```
+
+Response:
+
+```
+{"jsonrpc":"2.0","result":[[0,"ed28899af8c3148a4162736af942bc68c4466da93c5124dabfaa7c582af49e30"],[1,"9c9038cfb31a7050796920f91b17f4a68c7e9a795ee8962916b35d39fc1efefc"]],"id":1}
+```
+
 [json_rpc_server]: https://github.com/witnet/witnet-rust/blob/master/core/src/actors/json_rpc/server.rs
 [noders]: https://github.com/witnet/witnet-rust/blob/master/core/src/actors/node.rs
 [json_rpc_methods]: https://github.com/witnet/witnet-rust/blob/master/core/src/actors/json_rpc/json_rpc_methods.rs


### PR DESCRIPTION
Closes #280 

Implement the getBlockChain JSON-RPC method.

One major change is that now JSON-RPC requests are handled asynchronously, which looks like it solves #176.

Example request:

     {"jsonrpc": "2.0","method": "getBlockChain", "id": 1}

Example response:

    {"jsonrpc":"2.0","result":[[0,"ed28899af8c3148a4162736af942bc68c4466da93c5124dabfaa7c582af49e30"],[1,"9c9038cfb31a7050796920f91b17f4a68c7e9a795ee8962916b35d39fc1efefc"]],"id":1}

The hashes are obtained from the `ChainManager`, from the `epoch_to_block_hash` map, which should be stored in the storage as it is used to synchronize two nodes. Right now it is not stored, so the blockchain is lost when all the nodes shutdown. (Alternatively, the map could be rebuilt when the node starts, but it would need to naively read all the blocks from the storage one by one). Right now the blocks are stored, but the node is unable to send them to new nodes unless some node asks specifically for the block hash...
