### PR TITLE
witnet cli getBlockChain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,14 @@ members = ["config", "core", "crypto", "data_structures", "p2p", "storage"]
 travis-ci = { repository = "https://github.com/witnet/witnet-rust", branch = "master" }
 
 [dependencies]
+bytecount = "0.4.0"
 ctrlc = "3.1.1"
 env_logger = "0.5.13"
 just = "0.3.12"
 failure = "0.1.3"
 log = "0.4"
 structopt = "0.2.13"
+serde = "1.0.84"
 serde_derive = "1.0.79"
 serde_json = "1.0.28"
 toml = "0.4.6"

--- a/docs/interface/cli.md
+++ b/docs/interface/cli.md
@@ -1,0 +1,95 @@
+# Command Line Interface (CLI)
+
+The cli subcommand provides a human friendly command-line interface to the [JSON-RPC API][jsonrpc].
+
+## Usage
+
+See all the available options by running the help command.
+`cargo run --` can be used to replace `witnet` in a development environment.
+
+```sh
+$ witnet cli --help
+$ cargo run -- cli --help
+```
+
+The JSON-RPC server address is obtained from the [configuration file][configuration].
+The path of this file can be set using the `-c` or `--config` flag.
+This flag must appear after `cli`.
+
+```sh
+$ witnet cli -c witnet.toml getBlockChain
+```
+
+```text
+$ witnet cli getBlockChain
+Block for epoch #46924 had digest e706995269bfc4fb5f4ab9082765a1bdb48fc6e58cdf5f95621c9e3f849301ed
+Block for epoch #46925 had digest 2dc469691916a862154eb92473278ea8591ace910ec7ecb560797cbb91fdc01e
+```
+
+If there is any error, the process will return a non-zero exit code.
+
+```text
+$ witnet cli getBlockChain
+ERROR 2019-01-03T12:01:51Z: witnet: Error: Connection refused (os error 111)
+```
+
+The executable implements the usual logging API, which can be enabled using `RUST_LOG=witnet=debug`:
+
+```text
+$ RUST_LOG=witnet=debug witnet cli getBlockChain
+ INFO 2019-01-03T12:04:43Z: witnet::json_rpc_client: Connecting to JSON-RPC server at 127.0.0.1:21338
+ERROR 2019-01-03T12:04:43Z: witnet: Error: Connection refused (os error 111)
+```
+
+### Commands
+
+#### raw
+
+The `raw` command allows sending raw JSON-RPC requests from the command line.
+It can be used in an interactive way: each line of user input will be sent
+to the JSON-RPC server without any modifications:
+
+```sh
+$ witnet cli -c witnet.toml raw
+```
+
+Each block represents a method call:
+the first line is a request, the second line is a response.
+
+```js
+hi
+{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}
+```
+```js
+{"jsonrpc": "2.0","method": "getBlockChain", "id": 1}
+{"jsonrpc":"2.0","result":[[242037,"3f8c9ed0fa721e39de9483f61f290f76a541757a828e54a8d951101b1940c59a"]],"id":1}
+```
+```js
+{"jsonrpc": "2.0","method": "someInvalidMethod", "id": 2}
+{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":2}
+```
+```js
+bye
+{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}
+```
+
+
+Alternatively, the input can be read from a file using pipes, as is usual in Unix-like environments:
+
+```text
+$ cat get_block_chain.txt | witnet cli raw
+{"jsonrpc":"2.0","result":[[242037,"3f8c9ed0fa721e39de9483f61f290f76a541757a828e54a8d951101b1940c59a"]],"id":1}
+```
+
+#### getBlockChain
+
+Returns the hashes of all the blocks in the blockchain, one per line:
+
+```text
+$ witnet cli getBlockChain -c witnet_01.toml
+Block for epoch #46924 had digest e706995269bfc4fb5f4ab9082765a1bdb48fc6e58cdf5f95621c9e3f849301ed
+Block for epoch #46925 had digest 2dc469691916a862154eb92473278ea8591ace910ec7ecb560797cbb91fdc01e
+```
+
+[jsonrpc]: json-rpc/
+[configuration]: ../configuration/toml-file/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
     - Witscript Parser: architecture/witscript.md
     - JSON-RPC Server: architecture/json-rpc-server.md
   - Interface:
+    - Command Line Interface (CLI): interface/cli.md
     - JSON-RPC: interface/json-rpc.md
   - Advanced:
     - Network constants: advanced/constants.md

--- a/src/json_rpc_client.rs
+++ b/src/json_rpc_client.rs
@@ -1,0 +1,218 @@
+use crate::cli::CliCommand;
+use failure::Fail;
+use log::{info, warn};
+use serde::Deserialize;
+use serde_derive::Deserialize;
+use std::{
+    fmt,
+    io::{self, BufRead, BufReader, Read, Write},
+    net::TcpStream,
+    path::PathBuf,
+};
+use witnet_config::config::Config;
+use witnet_config::loaders::toml;
+use witnet_core::actors::config_manager::CONFIG_DEFAULT_FILENAME;
+
+pub(crate) fn run(last_config: Option<PathBuf>, cmd: CliCommand) -> Result<(), failure::Error> {
+    match cmd {
+        CliCommand::Raw { config } => {
+            // The -c/--config argument can come both after and before getBlockChain:
+            // witnet cli -c witnet.toml getBlockChain
+            // witnet cli getBlockChain -c witnet.toml
+            // The last one takes priority
+            let config = config.or(last_config);
+            let mut stream = start_client(config)?;
+            // The request is read from stdin, one line at a time
+            let mut request = String::new();
+            let stdin = io::stdin();
+            let mut stdin = stdin.lock();
+            loop {
+                request.clear();
+                let count = stdin.read_line(&mut request)?;
+                if count == 0 {
+                    break Ok(());
+                }
+                let response = send_request(&mut stream, &request)?;
+                // The response includes a newline, so use print instead of println
+                print!("{}", response);
+            }
+        }
+        CliCommand::GetBlockChain { config } => {
+            let config = config.or(last_config);
+            let mut stream = start_client(config)?;
+            let response = send_request(
+                &mut stream,
+                r#"{"jsonrpc": "2.0","method": "getBlockChain", "id": 1}"#,
+            )?;
+            info!("{}", response);
+            let block_chain: ResponseBlockChain<'_> = parse_response(&response)?;
+
+            for (epoch, hash) in block_chain {
+                println!("Block for epoch #{} had digest {}", epoch, hash);
+            }
+
+            Ok(())
+        }
+    }
+}
+
+// Response of the getBlockChain JSON-RPC method
+type ResponseBlockChain<'a> = Vec<(u32, &'a str)>;
+
+// Quick and simple JSON-RPC client implementation
+
+/// Generic response which is used to extract the result
+#[derive(Debug, Deserialize)]
+struct JsonRpcResponse<'a, T> {
+    // Lifetimes allow zero-copy string deserialization
+    jsonrpc: &'a str,
+    id: Id<'a>,
+    result: T,
+}
+
+/// A failed request returns an error with code and message
+#[derive(Debug, Deserialize)]
+struct JsonRpcError<'a> {
+    jsonrpc: &'a str,
+    id: Id<'a>,
+    error: ServerError,
+}
+
+/// Id. Can be null, a number, or a string
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Id<'a> {
+    Null,
+    Number(u64),
+    String(&'a str),
+}
+
+/// A failed request returns an error with code and message
+#[derive(Debug, Deserialize, Fail)]
+struct ServerError {
+    code: i32,
+    // This cannot be a &str because the error may outlive the current function
+    message: String,
+}
+
+#[derive(Debug, Fail)]
+struct ServerDisabled;
+
+#[derive(Debug, Fail)]
+struct ProtocolError(String);
+
+// Required for Fail derive
+impl fmt::Display for ServerDisabled {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("JSON-RPC server disabled by configuration")?;
+        Ok(())
+    }
+}
+
+// Required for Fail derive
+impl fmt::Display for ServerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&format!("{:?}", self))?;
+        Ok(())
+    }
+}
+
+// Required for Fail derive
+impl fmt::Display for ProtocolError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&format!(
+            "Incompatible JSON-RPC version used by server: {}",
+            self.0
+        ))?;
+        Ok(())
+    }
+}
+
+fn start_client(config_path: Option<PathBuf>) -> Result<TcpStream, failure::Error> {
+    let config_file = config_path.unwrap_or_else(|| PathBuf::from(CONFIG_DEFAULT_FILENAME));
+    let config = Config::from_partial(&toml::from_file(&config_file)?);
+    if !config.jsonrpc.enabled {
+        return Err(ServerDisabled.into());
+    }
+    let addr = config.jsonrpc.server_address;
+    info!("Connecting to JSON-RPC server at {}", addr);
+    let stream = TcpStream::connect(addr);
+
+    stream.map_err(|e| e.into())
+}
+
+fn send_request<S: Read + Write>(stream: &mut S, request: &str) -> Result<String, io::Error> {
+    stream.write_all(request.as_bytes())?;
+    // Write missing newline, if needed
+    match bytecount::count(request.as_bytes(), b'\n') {
+        0 => stream.write_all(b"\n")?,
+        1 => {}
+        _ => {
+            warn!("The request contains more than one newline, only the first response will be returned");
+        }
+    }
+    // Read only one line
+    let mut r = BufReader::new(stream);
+    let mut buf = String::new();
+    r.read_line(&mut buf)?;
+    Ok(buf)
+}
+
+fn parse_response<'a, T: Deserialize<'a>>(response: &'a str) -> Result<T, failure::Error> {
+    match serde_json::from_str::<JsonRpcResponse<'a, T>>(response) {
+        Ok(x) => {
+            // x.id should also be checked if we want to support more than one call at a time
+            if x.jsonrpc != "2.0" {
+                Err(ProtocolError(x.jsonrpc.to_string()).into())
+            } else {
+                Ok(x.result)
+            }
+        }
+        Err(e) => {
+            info!("{}", e);
+            let error_json: JsonRpcError<'a> = serde_json::from_str(response)?;
+            Err(error_json.error.into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_invalid() {
+        let nothing: Result<(), _> = parse_response("");
+        assert!(nothing.is_err());
+        let asdf: Result<(), _> = parse_response("asdf");
+        assert!(asdf.is_err());
+    }
+
+    #[test]
+    fn parse_server_error() {
+        let response =
+            r#"{"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":1}"#;
+        let block_chain: Result<ResponseBlockChain<'_>, _> = parse_response(&response);
+        assert!(block_chain.is_err());
+    }
+
+    #[test]
+    fn parse_get_block_chain() {
+        let response = r#"{"jsonrpc":"2.0","result":[[0,"ed28899af8c3148a4162736af942bc68c4466da93c5124dabfaa7c582af49e30"],[1,"9c9038cfb31a7050796920f91b17f4a68c7e9a795ee8962916b35d39fc1efefc"]],"id":1}"#;
+        let block_chain: ResponseBlockChain<'_> = parse_response(&response).unwrap();
+        assert_eq!(
+            block_chain[0],
+            (
+                0,
+                "ed28899af8c3148a4162736af942bc68c4466da93c5124dabfaa7c582af49e30"
+            )
+        );
+        assert_eq!(
+            block_chain[1],
+            (
+                1,
+                "9c9038cfb31a7050796920f91b17f4a68c7e9a795ee8962916b35d39fc1efefc"
+            )
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use structopt::StructOpt;
 use witnet_core as core;
 
 mod cli;
+mod json_rpc_client;
 
 fn main() {
     // Init app logger


### PR DESCRIPTION
Close #281, close #302 

Implement a human friendly command-line interface to query the getBlockChain JSON-RPC method. Usage example:

```text
$ cargo run -- cli getBlockChain
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s                                                          
     Running `target/debug/witnet cli getBlockChain`
Block for epoch #46924 had digest e706995269bfc4fb5f4ab9082765a1bdb48fc6e58cdf5f95621c9e3f849301ed
Block for epoch #46925 had digest 2dc469691916a862154eb92473278ea8591ace910ec7ecb560797cbb91fdc01e
```

Support --config and -c flag to set the config file, because the JSON-RPC server address is obtained from the config file.

Also implement the raw command: send raw JSON-RPC requests:

```text
$ cat get_block_chain.txt | cargo run -- cli raw
{"jsonrpc":"2.0","result":[[242037,"3f8c9ed0fa721e39de9483f61f290f76a541757a828e54a8d951101b1940c59a"]],"id":1}
```

Unresolved questions: would it be better to use an external crate for the JSON-RPC client?