### PR TITLE
fix(chain_manager): fix some issues for block candidates

### DIFF
--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -102,7 +102,7 @@ impl Handler<AddNewBlock> for ChainManager {
     type Result = SessionUnitResult;
 
     fn handle(&mut self, msg: AddNewBlock, ctx: &mut Context<Self>) {
-        self.process_block_candidate(ctx, msg.block)
+        self.process_block(ctx, msg.block)
     }
 }
 

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -379,6 +379,11 @@ impl ChainManager {
                     Ok(hash) => {
                         self.broadcast_block(hash);
 
+                        // Update block candidate
+                        if Some(block.block_header.beacon.checkpoint) == self.current_epoch {
+                            self.block_candidate = Some(block.clone());
+                        }
+
                         // Save block to storage
                         // TODO: dont save the current candidate into storage
                         // Because it may not be the chosen block


### PR DESCRIPTION
This PR fixes some issues regarding some validations of the block candidate in the ChainManager:
- update `block_candidate` after verifying PoE
- verify epoch for checking if the node already has a better block candidate