### PR TITLE
feat(chain_manager): persist blocks index into storage

### DIFF
--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -75,6 +75,9 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
 
                     // Persist chain_info into storage
                     self.persist_chain_info(ctx);
+
+                    // Persist block_chain into storage
+                    self.persist_block_chain(ctx);
                 }
                 None => {
                     error!("No ChainInfo loaded in ChainManager");
@@ -149,7 +152,7 @@ impl Handler<GetBlocksEpochRange> for ChainManager {
     ) -> Self::Result {
         debug!("GetBlocksEpochRange received {:?}", range);
         let hashes = self
-            .epoch_to_block_hash
+            .block_chain
             .range(range)
             .flat_map(|(epoch, hashset)| {
                 hashset

--- a/core/src/actors/storage_keys.rs
+++ b/core/src/actors/storage_keys.rs
@@ -3,3 +3,6 @@ pub static PEERS_KEY: &'static [u8] = b"peers";
 
 /// Constant to specify the chain key for the storage
 pub static CHAIN_KEY: &'static [u8] = b"chain";
+
+/// Constant to specify the blocks index key for the storage
+pub static BLOCK_CHAIN_KEY: &'static [u8] = b"block_chain";


### PR DESCRIPTION
Closes #293 

Remarks:

1. I already took the opportunity to rename `epoch_to_block_hash` to `block_chain` (mentioned in #295)
2. Maybe we could refactor the way in which we persist block chain status into storage, as we are storing `chain_info` and `block_chain` separately (i.e. using 2 `Put` messages).