### PR TITLE
feat(core): Change AnnounceItem msg to Block msg when a block is mined

### DIFF
--- a/core/src/actors/session/messages.rs
+++ b/core/src/actors/session/messages.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use actix::Message;
-use witnet_data_structures::chain::InventoryEntry;
+use witnet_data_structures::chain::{Block, InventoryEntry};
 
 /// Message result of unit
 pub type SessionUnitResult = ();
@@ -30,5 +30,18 @@ pub struct AnnounceItems {
 impl fmt::Display for AnnounceItems {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "AnnounceItems")
+    }
+}
+
+/// Message to send blocks through the network
+#[derive(Clone, Debug, Message)]
+pub struct SendBlock {
+    /// Block
+    pub block: Block,
+}
+
+impl fmt::Display for SendBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SendBlock")
     }
 }


### PR DESCRIPTION
Created SendBlock msg and handler in session actor to send a block to another peers
Created broadcast_block function to send a Broadcast(SendBlock) msg to sessions manager
Changed candidate hash validation from < to <=
Added two options in process a new block:
* current epoch: update candidate and broadcast the block
* older epoch: broadcast an annoucement and persist block
 