### PR TITLE
feat(data_structures): add method to validate Block's mint

### DIFF
--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -154,14 +154,12 @@ impl Handler<AddTransaction> for ChainManager {
                 // Check that all inputs point to unspent outputs
                 if self.find_unspent_outputs(&msg.transaction.inputs) {
                     // Validate transaction
-                    let inputs_sum = msg
-                        .transaction
-                        // DRO RULE 1. Multiple data request outputs can be included into a single transaction
-                        // as long as the inputs are greater than outputs rule still hold true. The difference
-                        // with VTOs is that the total output value for data request outputs also includes the
-                        // commit fee, reveal fee and tally fee.
-                        .calculate_outputs_sum_of(&outputs_from_inputs);
-                    let outputs_sum = msg.transaction.calculate_outputs_sum();
+                    // DRO RULE 1. Multiple data request outputs can be included into a single transaction
+                    // as long as the inputs are greater than outputs rule still hold true. The difference
+                    // with VTOs is that the total output value for data request outputs also includes the
+                    // commit fee, reveal fee and tally fee.
+                    let inputs_sum = outputs_from_inputs.iter().map(Output::value).sum();
+                    let outputs_sum = msg.transaction.outputs_sum();
 
                     if outputs_sum < inputs_sum {
                         let mut is_valid_input = true;

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -154,8 +154,8 @@ impl Handler<AddTransaction> for ChainManager {
                 // Check that all inputs point to unspent outputs
                 if self.find_unspent_outputs(&msg.transaction.inputs) {
                     // Validate transaction
-                    // DRO RULE 1. Multiple data request outputs can be included into a single transaction
-                    // as long as the inputs are greater than outputs rule still hold true. The difference
+                    // DRO RULE 1. Multiple data request outputs can be included into a single transaction.
+                    // As long as the inputs are greater than the outputs, the rule still hold true. The difference
                     // with VTOs is that the total output value for data request outputs also includes the
                     // commit fee, reveal fee and tally fee.
                     let inputs_sum = outputs_from_inputs.iter().map(Output::value).sum();

--- a/core/src/actors/chain_manager/mining.rs
+++ b/core/src/actors/chain_manager/mining.rs
@@ -131,7 +131,8 @@ fn build_block(
     for transaction in transactions_pool.iter() {
         // Currently, 1 weight unit is equivalent to 1 byte
         let transaction_weight = transaction.size();
-        let transaction_fee = transaction.fee();
+        // FIXME (anler): Remove unwrap and handle error correctly
+        let transaction_fee = transaction.fee(transactions_pool).unwrap();
         let new_block_weight = block_weight + transaction_weight;
 
         if new_block_weight <= max_block_weight {
@@ -220,6 +221,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn build_block_with_transactions() {
         // Build sample transactions
         let transaction_1 = Transaction {

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -53,7 +53,7 @@ use witnet_data_structures::chain::{
     OutputPointer, TransactionsPool,
 };
 
-use crate::validations::{validate_merkle_tree, validate_mint, validate_transactions};
+use crate::validations::{validate_merkle_tree, validate_transactions};
 
 use self::data_request::DataRequestPool;
 use witnet_data_structures::chain::CheckpointBeacon;
@@ -426,8 +426,8 @@ impl ChainManager {
                             error!("Unexpected error");
                         }
                     }
-                } else if !validate_mint(&block) {
-                    warn!("Block mint not valid");
+                } else if block.validate(0, &self.transactions_pool).is_err() {
+                    warn!("Block's mint transaction is not valid");
                 } else {
                     if block_epoch < current_epoch {
                         // FIXME(#235): check proof of eligibility from the past

--- a/core/src/validations.rs
+++ b/core/src/validations.rs
@@ -6,12 +6,6 @@ use witnet_data_structures::chain::{
     Block, Epoch, Hash, Hashable, Output, OutputPointer, Transaction, TransactionsPool,
 };
 
-/// Function to validate block's mint
-pub fn validate_mint(_block: &Block) -> bool {
-    // TODO Implement validate mint algorithm
-    true
-}
-
 /// Function to validate a transaction
 pub fn validate_transaction<S: ::std::hash::BuildHasher>(
     _transaction: &Transaction,

--- a/data_structures/Cargo.toml
+++ b/data_structures/Cargo.toml
@@ -1,18 +1,24 @@
 [package]
-name = "witnet_data_structures"
-version = "0.1.0"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
-workspace = ".."
 description = "data structures component"
 edition = "2018"
+name = "witnet_data_structures"
+version = "0.1.0"
+workspace = ".."
 
 [dependencies]
+failure = "0.1.5"
 flatbuffers = "0.5.0"
-failure = "0.1.2"
 rand = "0.5.5"
-witnet_crypto = { path = "../crypto" }
-witnet_util = { path = "../util" }
 serde = "1.0.79"
 serde_derive = "1.0.79"
 toml = "0.4.6"
-partial_struct = { path = "../partial_struct" }
+
+[dependencies.partial_struct]
+path = "../partial_struct"
+
+[dependencies.witnet_crypto]
+path = "../crypto"
+
+[dependencies.witnet_util]
+path = "../util"

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -289,15 +289,13 @@ pub struct Transaction {
 /// The error type for operations on a [`Transaction`](Transaction)
 #[derive(Debug, Fail)]
 pub enum TransactionError {
-    /// Error indicating the transaction creates value
+    /// The transaction creates value
     #[fail(display = "Transaction creates value (its fee is negative)")]
     NegativeFee,
-    /// Error indicating that a transaction with the given hash wasn't
-    /// found in a pool.
+    /// A transaction with the given hash wasn't found in a pool.
     #[fail(display = "A hash is missing in the pool {}", 0)]
     PoolMiss(Hash),
-    /// Error indicating that an output with the given index wasn't
-    /// found in a transaction.
+    /// An output with the given index wasn't found in a transaction.
     #[fail(
         display = "An output with index {} was not found in transaction {}",
         1, 0

--- a/data_structures/src/lib.rs
+++ b/data_structures/src/lib.rs
@@ -23,3 +23,6 @@ pub mod types;
 
 /// Module containing error definitions
 pub mod error;
+
+#[cfg(test)]
+pub mod tests;

--- a/data_structures/src/tests.rs
+++ b/data_structures/src/tests.rs
@@ -306,7 +306,7 @@ mod transaction {
             },
         );
 
-        assert_eq!(transaction.inputs_sum(&pool), Ok(124));
+        assert_eq!(transaction.inputs_sum(&pool).unwrap(), 124);
     }
 
     #[test]
@@ -352,7 +352,7 @@ mod transaction {
             })],
         };
 
-        assert_eq!(transaction.fee(&pool), Ok(123));
+        assert_eq!(transaction.fee(&pool).unwrap(), 123);
     }
 }
 
@@ -391,7 +391,7 @@ mod block {
             }],
         };
 
-        assert_eq!(block.validate(reward, &pool), Ok(()));
+        assert_eq!(block.validate(reward, &pool).unwrap(), ());
     }
 }
 

--- a/data_structures/src/tests.rs
+++ b/data_structures/src/tests.rs
@@ -1,0 +1,422 @@
+use super::chain::*;
+
+const HASH: Hash = Hash::SHA256([0; 32]);
+
+#[test]
+fn test_block_hashable_trait() {
+    let block_header = BlockHeader {
+        version: 0,
+        beacon: CheckpointBeacon {
+            checkpoint: 0,
+            hash_prev_block: HASH,
+        },
+        hash_merkle_root: HASH,
+    };
+    let signature = Signature::Secp256k1(Secp256k1Signature {
+        r: [0; 32],
+        s: [0; 32],
+        v: 0,
+    });
+    let proof = LeadershipProof {
+        block_sig: Some(signature.clone()),
+        influence: 0,
+    };
+    let keyed_signatures = vec![KeyedSignature {
+        public_key: [0; 32],
+        signature,
+    }];
+    let commit_input = Input::Commit(CommitInput {
+        nonce: 0,
+        output_index: 0,
+        reveal: [0; 32].to_vec(),
+        transaction_id: HASH,
+    });
+    let reveal_input = Input::Reveal(RevealInput {
+        output_index: 0,
+        transaction_id: HASH,
+    });
+    let data_request_input = Input::DataRequest(DataRequestInput {
+        output_index: 0,
+        poe: [0; 32],
+        transaction_id: HASH,
+    });
+    let value_transfer_output = Output::ValueTransfer(ValueTransferOutput {
+        pkh: [0; 20],
+        value: 0,
+    });
+
+    let rad_aggregate = RADAggregate { script: vec![0] };
+
+    let rad_retrieve_1 = RADRetrieve {
+        kind: RADType::HttpGet,
+        url: "https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22".to_string(),
+        script: vec![0],
+    };
+
+    let rad_retrieve_2 = RADRetrieve {
+        kind: RADType::HttpGet,
+        url: "https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22".to_string(),
+        script: vec![0],
+    };
+
+    let rad_consensus = RADConsensus { script: vec![0] };
+
+    let rad_deliver_1 = RADDeliver {
+        kind: RADType::HttpGet,
+        url: "https://hooks.zapier.com/hooks/catch/3860543/l2awcd/".to_string(),
+    };
+
+    let rad_deliver_2 = RADDeliver {
+        kind: RADType::HttpGet,
+        url: "https://hooks.zapier.com/hooks/catch/3860543/l1awcw/".to_string(),
+    };
+
+    let rad_request = RADRequest {
+        aggregate: rad_aggregate,
+        not_before: 0,
+        retrieve: vec![rad_retrieve_1, rad_retrieve_2],
+        consensus: rad_consensus,
+        deliver: vec![rad_deliver_1, rad_deliver_2],
+    };
+
+    let data_request_output = Output::DataRequest(DataRequestOutput {
+        backup_witnesses: 0,
+        commit_fee: 0,
+        data_request: rad_request,
+        pkh: [0; 20],
+        reveal_fee: 0,
+        tally_fee: 0,
+        time_lock: 0,
+        value: 0,
+        witnesses: 0,
+    });
+    let commit_output = Output::Commit(CommitOutput {
+        commitment: HASH,
+        value: 0,
+    });
+    let reveal_output = Output::Reveal(RevealOutput {
+        pkh: [0; 20],
+        reveal: [0; 32].to_vec(),
+        value: 0,
+    });
+    let consensus_output = Output::Tally(TallyOutput {
+        pkh: [0; 20],
+        result: vec![0],
+        value: 0,
+    });
+    let inputs = vec![commit_input, data_request_input, reveal_input];
+    let outputs = vec![
+        value_transfer_output,
+        data_request_output,
+        commit_output,
+        reveal_output,
+        consensus_output,
+    ];
+    let txns: Vec<Transaction> = vec![Transaction {
+        inputs,
+        signatures: keyed_signatures,
+        outputs,
+        version: 0,
+    }];
+    let block = Block {
+        block_header,
+        proof,
+        txns,
+    };
+    let expected = Hash::SHA256([
+        204, 111, 204, 123, 50, 100, 176, 227, 102, 35, 195, 223, 178, 106, 185, 156, 160, 24, 18,
+        210, 236, 116, 217, 170, 103, 95, 92, 236, 208, 52, 134, 63,
+    ]);
+    assert_eq!(block.hash(), expected);
+}
+
+#[test]
+fn test_transaction_hashable_trait() {
+    let signature = Signature::Secp256k1(Secp256k1Signature {
+        r: [0; 32],
+        s: [0; 32],
+        v: 0,
+    });
+    let signatures = vec![KeyedSignature {
+        public_key: [0; 32],
+        signature,
+    }];
+    let commit_input = Input::Commit(CommitInput {
+        nonce: 0,
+        output_index: 0,
+        reveal: [0; 32].to_vec(),
+        transaction_id: HASH,
+    });
+    let reveal_input = Input::Reveal(RevealInput {
+        output_index: 0,
+        transaction_id: HASH,
+    });
+    let data_request_input = Input::DataRequest(DataRequestInput {
+        output_index: 0,
+        poe: [0; 32],
+        transaction_id: HASH,
+    });
+    let value_transfer_output = Output::ValueTransfer(ValueTransferOutput {
+        pkh: [0; 20],
+        value: 0,
+    });
+
+    let rad_aggregate = RADAggregate { script: vec![0] };
+
+    let rad_retrieve_1 = RADRetrieve {
+        kind: RADType::HttpGet,
+        url: "https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22".to_string(),
+        script: vec![0],
+    };
+
+    let rad_retrieve_2 = RADRetrieve {
+        kind: RADType::HttpGet,
+        url: "https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22".to_string(),
+        script: vec![0],
+    };
+
+    let rad_consensus = RADConsensus { script: vec![0] };
+    let rad_deliver_1 = RADDeliver {
+        kind: RADType::HttpGet,
+        url: "https://hooks.zapier.com/hooks/catch/3860543/l2awcd/".to_string(),
+    };
+
+    let rad_deliver_2 = RADDeliver {
+        kind: RADType::HttpGet,
+        url: "https://hooks.zapier.com/hooks/catch/3860543/l1awcw/".to_string(),
+    };
+
+    let rad_request = RADRequest {
+        aggregate: rad_aggregate,
+        not_before: 0,
+        retrieve: vec![rad_retrieve_1, rad_retrieve_2],
+        consensus: rad_consensus,
+        deliver: vec![rad_deliver_1, rad_deliver_2],
+    };
+    let data_request_output = Output::DataRequest(DataRequestOutput {
+        backup_witnesses: 0,
+        commit_fee: 0,
+        data_request: rad_request,
+        pkh: [0; 20],
+        reveal_fee: 0,
+        tally_fee: 0,
+        time_lock: 0,
+        value: 0,
+        witnesses: 0,
+    });
+    let commit_output = Output::Commit(CommitOutput {
+        commitment: HASH,
+        value: 0,
+    });
+    let reveal_output = Output::Reveal(RevealOutput {
+        pkh: [0; 20],
+        reveal: [0; 32].to_vec(),
+        value: 0,
+    });
+    let consensus_output = Output::Tally(TallyOutput {
+        pkh: [0; 20],
+        result: [0; 32].to_vec(),
+        value: 0,
+    });
+    let inputs = vec![commit_input, data_request_input, reveal_input];
+    let outputs = vec![
+        value_transfer_output,
+        data_request_output,
+        commit_output,
+        reveal_output,
+        consensus_output,
+    ];
+    let transaction: Transaction = Transaction {
+        inputs,
+        outputs,
+        signatures,
+        version: 0,
+    };
+    let expected = Hash::SHA256([
+        10, 241, 147, 199, 165, 174, 93, 237, 233, 213, 202, 27, 217, 126, 244, 196, 189, 74, 84,
+        243, 4, 214, 2, 34, 22, 0, 118, 115, 137, 32, 203, 237,
+    ]);
+    assert_eq!(transaction.hash(), expected);
+}
+
+mod transaction {
+    use super::*;
+
+    #[test]
+    fn test_output_value() {
+        let transaction = Transaction {
+            version: 0,
+            signatures: Vec::new(),
+            inputs: Vec::new(),
+            outputs: vec![Output::Commit(CommitOutput {
+                commitment: HASH,
+                value: 123,
+            })],
+        };
+
+        assert_eq!(transaction.get_output_value(0), Some(123));
+    }
+
+    #[test]
+    fn test_inputs_sum() {
+        let mut pool = TransactionsPool::new();
+        let hash = HASH;
+        let transaction = Transaction {
+            version: 0,
+            signatures: Vec::new(),
+            outputs: Vec::new(),
+            inputs: vec![
+                Input::Commit(CommitInput {
+                    transaction_id: hash,
+                    output_index: 0,
+                    reveal: vec![],
+                    nonce: 0,
+                }),
+                Input::Commit(CommitInput {
+                    transaction_id: hash,
+                    output_index: 2,
+                    reveal: vec![],
+                    nonce: 0,
+                }),
+            ],
+        };
+
+        assert!(transaction.inputs_sum(&pool).is_err());
+
+        pool.insert(
+            hash,
+            Transaction {
+                version: 0,
+                signatures: Vec::new(),
+                inputs: Vec::new(),
+                outputs: vec![
+                    Output::Commit(CommitOutput {
+                        commitment: hash,
+                        value: 123,
+                    }),
+                    Output::Commit(CommitOutput {
+                        commitment: hash,
+                        value: 10,
+                    }),
+                    Output::Commit(CommitOutput {
+                        commitment: hash,
+                        value: 1,
+                    }),
+                ],
+            },
+        );
+
+        assert_eq!(transaction.inputs_sum(&pool), Ok(124));
+    }
+
+    #[test]
+    fn test_outputs_sum() {
+        let transaction = Transaction {
+            version: 0,
+            signatures: Vec::new(),
+            inputs: Vec::new(),
+            outputs: vec![Output::Commit(CommitOutput {
+                commitment: HASH,
+                value: 123,
+            })],
+        };
+
+        assert_eq!(transaction.outputs_sum(), 123);
+    }
+
+    #[test]
+    fn test_is_mint() {
+        let transaction = Transaction {
+            version: 0,
+            signatures: Vec::new(),
+            inputs: Vec::new(),
+            outputs: vec![Output::Commit(CommitOutput {
+                commitment: HASH,
+                value: 123,
+            })],
+        };
+
+        assert!(transaction.is_mint());
+    }
+
+    #[test]
+    fn test_fee() {
+        let pool = TransactionsPool::new();
+        let transaction = Transaction {
+            version: 0,
+            signatures: Vec::new(),
+            inputs: Vec::new(),
+            outputs: vec![Output::Commit(CommitOutput {
+                commitment: HASH,
+                value: 123,
+            })],
+        };
+
+        assert_eq!(transaction.fee(&pool), Ok(123));
+    }
+}
+
+mod block {
+    use super::*;
+
+    const HEADER: BlockHeader = BlockHeader {
+        version: 0,
+        beacon: CheckpointBeacon {
+            checkpoint: 0,
+            hash_prev_block: HASH,
+        },
+        hash_merkle_root: HASH,
+    };
+
+    const PROOF: LeadershipProof = LeadershipProof {
+        block_sig: None,
+        influence: 123,
+    };
+
+    #[test]
+    fn test_validate_correct_block() {
+        let pool = TransactionsPool::new();
+        let reward = 123;
+        let block = Block {
+            block_header: HEADER,
+            proof: PROOF,
+            txns: vec![Transaction {
+                version: 0,
+                signatures: Vec::new(),
+                inputs: Vec::new(),
+                outputs: vec![Output::Commit(CommitOutput {
+                    commitment: HASH,
+                    value: reward,
+                })],
+            }],
+        };
+
+        assert_eq!(block.validate(reward, &pool), Ok(()));
+    }
+}
+
+#[test]
+fn test_input_output_pointer() {
+    let input = Input::ValueTransfer(ValueTransferInput {
+        transaction_id: HASH,
+        output_index: 123,
+    });
+
+    assert_eq!(
+        input.output_pointer(),
+        OutputPointer {
+            transaction_id: HASH,
+            output_index: 123
+        }
+    );
+}
+
+#[test]
+fn test_output_value() {
+    let output = Output::Commit(CommitOutput {
+        commitment: HASH,
+        value: 123,
+    });
+
+    assert_eq!(output.value(), 123);
+}


### PR DESCRIPTION
Add several methods to Transaction and Block that ultimately add up to support Block's validate method that so far it only validates the mint transaction. This method probably should grow to validate everything related to the block that currently is spread out through the ChainManager actor handlers.

Things to highlight:
- Merged two different `impl` blocks that existed for `Transaction`
- Removed the `validate_coinbase` function inside `validations.rs` module
- Created a `validate` method inside `Block` that so far it only validates the mint transaction, but my recommendation is that everything related to block validation goes in there
- Implemented the `fee` method for `Transaction`
- Implemented an `inputs_sum` method for `Transaction`
- Implemented an `is_mint` method for `Transaction`
- Implemented an `output_value` method for `Transaction` that returns the value of an output given its index
- Renamed `sum_outputs` to `outputs_sum` to mirror `inputs_sum`
- Removed `calculate_outputs_sum` and `calculate_outputs_sum_of` methods in `Transaction`, they are very similar if not the same as `sum_outputs`
- Implemented `value` method for `Output` that returns the value of an output no matter what type of output it is
- Implemented `output_pointer` method for `Input` that returns the output pointer of an input no matter what type of input is
- Implemented `get` method for `TransactionsPool`

~WIP: I still need to add tests, but apart from that it can be reviewed if necessary~