### PR TITLE
feat(core): add method for requesting a lost block from a random session

### DIFF
--- a/core/src/actors/session/messages.rs
+++ b/core/src/actors/session/messages.rs
@@ -45,3 +45,16 @@ impl fmt::Display for SendBlock {
         write!(f, "SendBlock")
     }
 }
+
+/// Message to request blocks through the network
+#[derive(Clone, Debug, Message)]
+pub struct RequestBlock {
+    /// Block
+    pub block_entry: InventoryEntry,
+}
+
+impl fmt::Display for RequestBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RequestBlock")
+    }
+}

--- a/docs/architecture/managers/chain-manager.md
+++ b/docs/architecture/managers/chain-manager.md
@@ -136,7 +136,9 @@ These are the messages sent by the Chain Manager:
 | `Put`                      | `StorageManager`    | `&'static [u8]`, `Vec<u8>`                  | `StorageResult<()>`                 | Wrapper to Storage `put()` method              |
 | `Broadcast<AnnounceItems>` | `SessionsManager`   | `Vec<InventoryEntry>`                       | `()`                                | Announce new inventory entries to the sessions |
 | `ValidatePoE`              | `ReputationManager` | `CheckpointBeacon`,`LeadershipProof`        | `bool`                              | Request Proof of Eligibility validation        |
-| `AddItem`                  | `InventoryManager`  | `InventoryItem`                             | `Result<(), InventoryManagerError>` | Persist the `block_candidate`                  |
+| `AddItem`                  | `InventoryManager`  | `InventoryItem`                             | `Result<(), InventoryManagerError>` | Persist the `best_candidate.block`             |
+| `Broadcast<SendBlock>`     | `SessionsManager`   | `Block`                                     | `()`                                | Send a new block to the sessions               |
+| `Anycast<RequestBlock>`    | `SessionsManager`   | `InventoryEntry`                            | `()`                                | Request a lost block to a random session       |
 
 #### SubscribeEpoch
 

--- a/docs/architecture/session.md
+++ b/docs/architecture/session.md
@@ -43,10 +43,12 @@ Session::create(move |ctx| {
 
 These are the messages supported by the Session handlers:
 
-| Message         | Input type              | Output type | Description                    |
-| --------------- | ----------------------- | ----------- | ------------------------------ |
-| `GetPeers`      | `()`                    | `()`        | Request peers from a session   |
-| `AnnounceItems` | `Vec<InventoryEntry>` | `()`        | Announce new inventory entries |
+| Message         | Input type              | Output type | Description                       |
+| --------------- | ----------------------- | ----------- | ------------------------------    |
+| `GetPeers`      | `()`                    | `()`        | Request peers from a session      |
+| `AnnounceItems` | `Vec<InventoryEntry>`   | `()`        | Announce new inventory entries    |
+| `SendBlock`     | `Block`                 | `()`        | Send a `Block` to a session       |
+| `RequestBlock`  | `InventoryEntry`        | `()`        | `Request a `Block` from a session |
 
 #### GetPeers
 


### PR DESCRIPTION
Created a `RequestBlock` msg and handler in `session` actor to send a inventory_request_message with the `InventoryEntry::Block(Hash)` of the lost block.
Created a function to send an `Anycast<RequestBlock>` to `SessionsManager` actor.
Added updating `chain_info` for older blocks.
Added docs