### PR TITLE
 feat(mining): create commit and reveal transactions in mining

### DIFF
--- a/core/src/actors/chain_manager/data_request.rs
+++ b/core/src/actors/chain_manager/data_request.rs
@@ -23,6 +23,19 @@ pub struct DataRequestPool {
 }
 
 impl DataRequestPool {
+    /// Get all available data requests for an epoch
+    pub fn get_data_requests_by_epoch(&self, epoch: Epoch) -> Vec<&DataRequestState> {
+        let range = 0..=epoch;
+        self.data_requests_by_epoch
+            .range(range)
+            .flat_map(|(_epoch, hashset)| {
+                hashset
+                    .iter()
+                    .flat_map(|output_pointer| self.data_request_pool.get(output_pointer))
+            })
+            .collect()
+    }
+
     /// Add a data request to the data request pool
     pub fn add_data_request(
         &mut self,

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -138,6 +138,7 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
 
         if self.mining_enabled {
             self.try_mine_block(ctx);
+            self.try_mine_data_request(ctx);
         }
     }
 }

--- a/core/src/actors/chain_manager/validations.rs
+++ b/core/src/actors/chain_manager/validations.rs
@@ -104,6 +104,11 @@ pub fn block_reward(epoch: Epoch) -> u64 {
         0
     }
 }
+/// Function to check poe validation for data requests
+// TODO: Implement logic for this function
+pub fn verify_poe_data_request() -> bool {
+    true
+}
 
 #[cfg(test)]
 mod tests {

--- a/core/src/actors/node.rs
+++ b/core/src/actors/node.rs
@@ -7,8 +7,8 @@ use crate::actors::{
     chain_manager::ChainManager, config_manager::ConfigManager,
     connections_manager::ConnectionsManager, epoch_manager::EpochManager,
     inventory_manager::InventoryManager, json_rpc::JsonRpcServer, peers_manager::PeersManager,
-    reputation_manager::ReputationManager, sessions_manager::SessionsManager,
-    storage_manager::StorageManager,
+    rad_manager::RadManager, reputation_manager::ReputationManager,
+    sessions_manager::SessionsManager, storage_manager::StorageManager,
 };
 
 /// Function to run the main system
@@ -54,6 +54,10 @@ pub fn run(config: Option<PathBuf>, callback: fn()) -> Result<(), io::Error> {
     // Start ReputationManager actor
     let reputation_manager_addr = ReputationManager::start_default();
     System::current().registry().set(reputation_manager_addr);
+
+    // Start RadManager actor
+    let rad_manager_addr = RadManager::default().start();
+    System::current().registry().set(rad_manager_addr);
 
     // Start JSON RPC server (this doesn't need to be in the registry)
     let _json_rpc_server_addr = JsonRpcServer::default().start();

--- a/core/src/actors/rad_manager/actor.rs
+++ b/core/src/actors/rad_manager/actor.rs
@@ -1,5 +1,5 @@
 use super::RadManager;
-use actix::{Actor, Context};
+use actix::{Actor, Context, Supervised, SystemService};
 use log;
 
 /// Implement Actor trait for `RadManager`
@@ -12,3 +12,7 @@ impl Actor for RadManager {
         log::debug!("RadManager actor has been started!");
     }
 }
+
+impl Supervised for RadManager {}
+
+impl SystemService for RadManager {}

--- a/core/src/actors/rad_manager/handlers.rs
+++ b/core/src/actors/rad_manager/handlers.rs
@@ -1,16 +1,18 @@
 //! Message handlers for `RadManager`
 use super::{messages, RadManager};
-use actix::Handler;
+use actix::{Handler, Message};
 use log;
 use witnet_radon as radon;
 
 impl Handler<messages::ResolveRA> for RadManager {
-    type Result = ();
+    type Result = <messages::ResolveRA as Message>::Result;
 
-    fn handle(&mut self, _msg: messages::ResolveRA, _ctx: &mut Self::Context) {
+    fn handle(&mut self, _msg: messages::ResolveRA, _ctx: &mut Self::Context) -> Self::Result {
         log::warn!("ResolveRA: unimplemented handler!");
         radon::run_retrieval();
         radon::run_aggregate();
+
+        Ok(Vec::new())
     }
 }
 

--- a/core/src/actors/rad_manager/messages.rs
+++ b/core/src/actors/rad_manager/messages.rs
@@ -18,5 +18,6 @@ pub struct RunConsensus;
 pub type SessionUnitResult = ();
 
 impl Message for ResolveRA {
-    type Result = SessionUnitResult;
+    // TODO: Use RAD error
+    type Result = Result<Vec<u8>, String>;
 }

--- a/core/src/actors/rad_manager/messages.rs
+++ b/core/src/actors/rad_manager/messages.rs
@@ -1,11 +1,22 @@
 //! Messages for `RadManager`
 use actix::Message;
+use witnet_data_structures::chain::RADRequest;
 
 /// Message for resolving the request-aggregate step of a data
 /// request.
-#[derive(Debug, Message)]
-pub struct ResolveRA;
+#[derive(Debug)]
+pub struct ResolveRA {
+    /// RAD request to be executed
+    pub script: RADRequest,
+}
 
 /// Message for running the consensus step of a data request.
 #[derive(Debug, Message)]
 pub struct RunConsensus;
+
+/// Message result of unit
+pub type SessionUnitResult = ();
+
+impl Message for ResolveRA {
+    type Result = SessionUnitResult;
+}


### PR DESCRIPTION
Created a function in `data_request.rs` to extract a vector of `DataRequestState` available for one `Epoch`
Added a RADRequest field in the `ResolveRA` msg 
Added a mocked `verify_poe_data_request` function
Start `RadManager` in node
Added functionality to send `ResolveRA` msgs to `RadManager` in mining to execute `rad_requests`
Added function to create a commit transaction
Added function to create a reveal transaction and update `DataRequestState`
Broadcast commit transactions

Close #351
Close #356