### PR TITLE
feat(chain_manager, sessions_manager): add network ready flag

### DIFF
--- a/core/src/actors/chain_manager/messages.rs
+++ b/core/src/actors/chain_manager/messages.rs
@@ -12,6 +12,16 @@ use witnet_data_structures::{
 /// Message result of unit
 pub type SessionUnitResult = ();
 
+/// Set `network_ready` flag
+pub struct SetNetworkReady {
+    /// Block
+    pub network_ready: bool,
+}
+
+impl Message for SetNetworkReady {
+    type Result = SessionUnitResult;
+}
+
 /// Message to obtain the highest block checkpoint managed by the `ChainManager`
 /// actor.
 pub struct GetHighestCheckpointBeacon;

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -90,6 +90,8 @@ impl From<WitnetError<StorageError>> for ChainManagerError {
 /// ChainManager actor
 #[derive(Default)]
 pub struct ChainManager {
+    /// Flag indicating if network is ready
+    network_ready: bool,
     /// Blockchain state data structure
     chain_state: ChainState,
     /// Map that relates an epoch with the hashes of the blocks for that epoch (blocks index)

--- a/core/src/actors/session/messages.rs
+++ b/core/src/actors/session/messages.rs
@@ -58,3 +58,13 @@ impl fmt::Display for RequestBlock {
         write!(f, "RequestBlock")
     }
 }
+
+/// Message to indicate that the session needs start an inventory exchange
+#[derive(Clone, Debug, Message)]
+pub struct InventoryExchange;
+
+impl fmt::Display for InventoryExchange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "InventoryExchange")
+    }
+}


### PR DESCRIPTION
This PR adds a `network_ready` flag in order to *pause* the `ChainManager` until the network is considered ready, i.e. there are enough connected peers. It should avoid potential forks if mining capability is enabled.