### PR TITLE
Fix mint and transactions

### DIFF
--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -78,7 +78,10 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                     );
 
                     debug!("{:?}", candidate.block);
-                    debug!("Mint transaction hash: {:?}", candidate.block.txns[0].hash());
+                    debug!(
+                        "Mint transaction hash: {:?}",
+                        candidate.block.txns[0].hash()
+                    );
 
                     // Update utxo_set and transactions_pool with block_candidate transactions
                     self.chain_state.unspent_outputs_pool = candidate.utxo_set;
@@ -189,120 +192,118 @@ impl Handler<AddTransaction> for ChainManager {
                     .find_unspent_outputs(&msg.transaction.inputs)
                 {
                     /*
-use crate::utils::{
-    count_tally_outputs, is_commit_input, is_commit_output, is_data_request_input,
-    is_reveal_output, is_tally_output, is_value_transfer_output, validate_tally_output_uniqueness,
-    validate_value_transfer_output_position,
-};
-                    // Validate transaction
-                    // DRO RULE 1. Multiple data request outputs can be included into a single transaction.
-                    // As long as the inputs are greater than the outputs, the rule still hold true. The difference
-                    // with VTOs is that the total output value for data request outputs also includes the
-                    // commit fee, reveal fee and tally fee.
-                    let inputs_sum = outputs_from_inputs.iter().map(Output::value).sum();
-                    let outputs_sum = msg.transaction.outputs_sum();
+                    use crate::utils::{
+                        count_tally_outputs, is_commit_input, is_commit_output, is_data_request_input,
+                        is_reveal_output, is_tally_output, is_value_transfer_output, validate_tally_output_uniqueness,
+                        validate_value_transfer_output_position,
+                    };
+                                        // Validate transaction
+                                        // DRO RULE 1. Multiple data request outputs can be included into a single transaction.
+                                        // As long as the inputs are greater than the outputs, the rule still hold true. The difference
+                                        // with VTOs is that the total output value for data request outputs also includes the
+                                        // commit fee, reveal fee and tally fee.
+                                        let inputs_sum = outputs_from_inputs.iter().map(Output::value).sum();
+                                        let outputs_sum = msg.transaction.outputs_sum();
 
-                    if outputs_sum < inputs_sum {
-                        let mut is_valid_input = true;
-                        let mut is_valid_output = true;
-                        let iter = outputs.iter().zip(inputs.iter());
+                                        if outputs_sum < inputs_sum {
+                                            let mut is_valid_input = true;
+                                            let mut is_valid_output = true;
+                                            let iter = outputs.iter().zip(inputs.iter());
 
-                        // VTO RULE 2. The number of VTOs in a single transaction is virtually unlimited as
-                        // long as the VTOs are all contiguous and located at the end of the outputs list.
-                        let is_valid_vto_position =
-                            validate_value_transfer_output_position(outputs);
+                                            // VTO RULE 2. The number of VTOs in a single transaction is virtually unlimited as
+                                            // long as the VTOs are all contiguous and located at the end of the outputs list.
+                                            let is_valid_vto_position =
+                                                validate_value_transfer_output_position(outputs);
 
-                        // TO RULE 1. Any transaction can contain at most one tally output.
-                        let consensus_output_overflow = count_tally_outputs(outputs) > 1;
+                                            // TO RULE 1. Any transaction can contain at most one tally output.
+                                            let consensus_output_overflow = count_tally_outputs(outputs) > 1;
 
-                        let is_valid_transaction = iter
-                            .take_while(|(output, input)| {
-                                // Validate input
-                                is_valid_input =
-                                    match &self.chain_state.get_output_from_input(input) {
-                                        // VTO RULE 4. The value brought into a transaction by an input pointing
-                                        // to a VTO can be freely assigned to any output of any type unless otherwise
-                                        // restricted by the specific validation rules for such output type.
-                                        Some(Output::ValueTransfer(_)) => true,
+                                            let is_valid_transaction = iter
+                                                .take_while(|(output, input)| {
+                                                    // Validate input
+                                                    is_valid_input =
+                                                        match &self.chain_state.get_output_from_input(input) {
+                                                            // VTO RULE 4. The value brought into a transaction by an input pointing
+                                                            // to a VTO can be freely assigned to any output of any type unless otherwise
+                                                            // restricted by the specific validation rules for such output type.
+                                                            Some(Output::ValueTransfer(_)) => true,
 
-                                        // DRO RULE 2. The value brought into a transaction by an input pointing
-                                        // to a data request output can only be spent by commit outputs.
-                                        Some(Output::DataRequest(_)) => is_commit_output(output),
+                                                            // DRO RULE 2. The value brought into a transaction by an input pointing
+                                                            // to a data request output can only be spent by commit outputs.
+                                                            Some(Output::DataRequest(_)) => is_commit_output(output),
 
-                                        // CO RULE 3. The value brought into a transaction by an input pointing
-                                        // to a commit output can only be spent by reveal or tally outputs.
-                                        Some(Output::Commit(_)) => {
-                                            is_reveal_output(output) || is_tally_output(output)
-                                        }
+                                                            // CO RULE 3. The value brought into a transaction by an input pointing
+                                                            // to a commit output can only be spent by reveal or tally outputs.
+                                                            Some(Output::Commit(_)) => {
+                                                                is_reveal_output(output) || is_tally_output(output)
+                                                            }
 
-                                        // RO 3. The value brought into a transaction by an input pointing to a
-                                        // reveal output can only be spent by value transfer outputs.
-                                        Some(Output::Reveal(_)) => match output {
-                                            Output::ValueTransfer(_) => true,
-                                            _ => false,
-                                        },
-                                        // TO RULE 4. The value brought into a transaction by an input pointing
-                                        // to a tally output can be freely assigned to any output of any type
-                                        // unless otherwise restricted by the specific validation rules for such
-                                        // output type.
-                                        Some(Output::Tally(_)) => true,
+                                                            // RO 3. The value brought into a transaction by an input pointing to a
+                                                            // reveal output can only be spent by value transfer outputs.
+                                                            Some(Output::Reveal(_)) => match output {
+                                                                Output::ValueTransfer(_) => true,
+                                                                _ => false,
+                                                            },
+                                                            // TO RULE 4. The value brought into a transaction by an input pointing
+                                                            // to a tally output can be freely assigned to any output of any type
+                                                            // unless otherwise restricted by the specific validation rules for such
+                                                            // output type.
+                                                            Some(Output::Tally(_)) => true,
 
-                                        None => false,
-                                    };
+                                                            None => false,
+                                                        };
 
-                                is_valid_output = match output {
-                                    Output::ValueTransfer(_) => true,
+                                                    is_valid_output = match output {
+                                                        Output::ValueTransfer(_) => true,
 
-                                    Output::DataRequest(_) => true,
-                                    // CO RULE 1. Commit outputs can only take value from data request inputs
-                                    // whose index in the inputs list is the same as their own index in the outputs list.
-                                    // CO RULE 2. Multiple commit outputs can exist in a single transaction,
-                                    // but each of them needs to be coupled with a data request input occupying
-                                    // the same index in the inputs list as their own in the outputs list.
-                                    // Predictably, as a result of the previous rule, each of the multiple
-                                    // commit outputs only takes value from the data request input with the same index.
-                                    Output::Commit(_) => is_data_request_input(input),
+                                                        Output::DataRequest(_) => true,
+                                                        // CO RULE 1. Commit outputs can only take value from data request inputs
+                                                        // whose index in the inputs list is the same as their own index in the outputs list.
+                                                        // CO RULE 2. Multiple commit outputs can exist in a single transaction,
+                                                        // but each of them needs to be coupled with a data request input occupying
+                                                        // the same index in the inputs list as their own in the outputs list.
+                                                        // Predictably, as a result of the previous rule, each of the multiple
+                                                        // commit outputs only takes value from the data request input with the same index.
+                                                        Output::Commit(_) => is_data_request_input(input),
 
-                                    Output::Reveal(_) => {
-                                        // RO RULE 3. The value brought into a transaction by an input pointing
-                                        // to a reveal output can only be spent by value transfer outputs.
-                                        is_value_transfer_output(output)
-                                        // RO RULE 1. Reveal outputs can only take value from commit inputs
-                                        // whose index in the inputs list is the same as their own index in the outputs list.
-                                        // RO RULE 2. Multiple reveal outputs can exist in a single transaction,
-                                        // but each of them needs to be coupled with a commit input occupying
-                                        // the same index in the inputs list as their own in the outputs list.
-                                        // Predictably, as a result of the previous rule, each of the multiple
-                                        // reveal outputs only takes value from the commit input with the same index.
-                                        && is_commit_input(input)
-                                        // TODO: validate only once
-                                        // RO RULE 4. Any transaction including an input pointing to a
-                                        // reveal output must also include exactly only one tally output.
-                                        && validate_tally_output_uniqueness(outputs)
-                                    }
-                                    Output::Tally(_) => true,
-                                };
+                                                        Output::Reveal(_) => {
+                                                            // RO RULE 3. The value brought into a transaction by an input pointing
+                                                            // to a reveal output can only be spent by value transfer outputs.
+                                                            is_value_transfer_output(output)
+                                                            // RO RULE 1. Reveal outputs can only take value from commit inputs
+                                                            // whose index in the inputs list is the same as their own index in the outputs list.
+                                                            // RO RULE 2. Multiple reveal outputs can exist in a single transaction,
+                                                            // but each of them needs to be coupled with a commit input occupying
+                                                            // the same index in the inputs list as their own in the outputs list.
+                                                            // Predictably, as a result of the previous rule, each of the multiple
+                                                            // reveal outputs only takes value from the commit input with the same index.
+                                                            && is_commit_input(input)
+                                                            // TODO: validate only once
+                                                            // RO RULE 4. Any transaction including an input pointing to a
+                                                            // reveal output must also include exactly only one tally output.
+                                                            && validate_tally_output_uniqueness(outputs)
+                                                        }
+                                                        Output::Tally(_) => true,
+                                                    };
 
-                                is_valid_input && is_valid_output
-                            })
-                            .last();
+                                                    is_valid_input && is_valid_output
+                                                })
+                                                .last();
 
-                        if is_valid_transaction.is_some()
-                            && is_valid_vto_position
-                            && !consensus_output_overflow
-                        {*/
-                            info!("Transaction added successfully");
-                            // Broadcast valid transaction
-                            self.broadcast_item(InventoryItem::Transaction(
-                                msg.transaction.clone(),
-                            ));
+                                            if is_valid_transaction.is_some()
+                                                && is_valid_vto_position
+                                                && !consensus_output_overflow
+                                            {*/
+                    info!("Transaction added successfully");
+                    // Broadcast valid transaction
+                    self.broadcast_item(InventoryItem::Transaction(msg.transaction.clone()));
 
-                            // Add valid transaction to transactions_pool
-                            self.transactions_pool
-                                .insert(msg.transaction.hash(), msg.transaction);/*
-                        }
-                    }
-                    */
+                    // Add valid transaction to transactions_pool
+                    self.transactions_pool
+                        .insert(msg.transaction.hash(), msg.transaction); /*
+                                                                              }
+                                                                          }
+                                                                          */
                 } else {
                     warn!("Input OutputPointer not in pool");
                 }

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -80,14 +80,9 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                     debug!("{:?}", candidate.block);
                     debug!("Mint transaction hash: {:?}", candidate.block.txns[0].hash());
 
-                    // FIXME: The transactions pool should not be overwritten with the candidate
-                    // because new transactions are stored in self.transactions_pool and not in
-                    // candidate.txn_mempool
-                    self.transactions_pool.retain(|k, _v| {
-                        !candidate.utxo_set.contains_key(&OutputPointer { transaction_id: *k, output_index: 0})
-                    });//candidate.txn_mempool;
                     // Update utxo_set and transactions_pool with block_candidate transactions
                     self.chain_state.unspent_outputs_pool = candidate.utxo_set;
+                    self.update_transaction_pool(candidate.block.txns.as_ref());
                     self.data_request_pool = candidate.data_request_pool;
 
                     let reveals = self.data_request_pool.update_data_request_stages();

--- a/core/src/actors/chain_manager/mining.rs
+++ b/core/src/actors/chain_manager/mining.rs
@@ -16,13 +16,13 @@ use crate::actors::{
 };
 
 use witnet_crypto::hash::calculate_sha256;
+use witnet_data_structures::chain::UnspentOutputsPool;
 use witnet_data_structures::chain::{
     Block, BlockHeader, CheckpointBeacon, Hash, Input, LeadershipProof, Output, PublicKeyHash,
     RevealInput, Secp256k1Signature, Signature, TallyOutput, Transaction, TransactionsPool,
     ValueTransferOutput,
 };
 use witnet_storage::storage::Storable;
-use witnet_data_structures::chain::UnspentOutputsPool;
 
 use futures::future::{join_all, Future};
 
@@ -369,6 +369,8 @@ mod tests {
         };
         transaction_pool.insert(transaction.hash(), transaction.clone());
 
+        let unspent_outputs_pool = UnspentOutputsPool::default();
+
         // Set `max_block_weight` to zero (no transaction should be included)
         let max_block_weight = 0;
 
@@ -382,6 +384,7 @@ mod tests {
         // Build empty block (because max weight is zero)
         let block = build_block(
             &transaction_pool,
+            &unspent_outputs_pool,
             max_block_weight,
             block_beacon,
             block_proof,
@@ -470,6 +473,8 @@ mod tests {
         transaction_pool.insert(transaction_2.hash(), transaction_2.clone());
         transaction_pool.insert(transaction_3.hash(), transaction_3.clone());
 
+        let unspent_outputs_pool = UnspentOutputsPool::default();
+
         // Set `max_block_weight` to fit only `transaction_1` size
         let max_block_weight = transaction_1.size();
 
@@ -483,6 +488,7 @@ mod tests {
         // Build block with
         let block = build_block(
             &transaction_pool,
+            &unspent_outputs_pool,
             max_block_weight,
             block_beacon,
             block_proof,

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -57,6 +57,7 @@ use witnet_data_structures::chain::{
 
 use witnet_storage::{error::StorageError, storage::Storable};
 use witnet_util::error::WitnetError;
+use crate::actors::chain_manager::validations::block_reward;
 
 mod actor;
 mod data_request;
@@ -434,8 +435,8 @@ impl ChainManager {
                             error!("Unexpected error");
                         }
                     }
-                } else if block.validate(0, &self.transactions_pool).is_err() {
-                    warn!("Block's mint transaction is not valid");
+                } else if let Err(e) = block.validate(block_reward(block_epoch), &self.chain_state.unspent_outputs_pool) {
+                    warn!("Block's mint transaction is not valid: {:?}", e);
                 } else {
                     if block_epoch < current_epoch {
                         // FIXME(#235): check proof of eligibility from the past

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -52,12 +52,13 @@ use self::validations::{validate_merkle_tree, validate_transactions};
 
 use witnet_data_structures::chain::{
     Block, Blockchain, ChainState, CheckpointBeacon, DataRequestReport, Epoch, Hash, Hashable,
-    InventoryEntry, InventoryItem, OutputPointer, Transaction, TransactionsPool, UnspentOutputsPool,
+    InventoryEntry, InventoryItem, OutputPointer, Transaction, TransactionsPool,
+    UnspentOutputsPool,
 };
 
+use crate::actors::chain_manager::validations::block_reward;
 use witnet_storage::{error::StorageError, storage::Storable};
 use witnet_util::error::WitnetError;
-use crate::actors::chain_manager::validations::block_reward;
 
 mod actor;
 mod data_request;
@@ -465,7 +466,7 @@ impl ChainManager {
             });
     }
 
-    fn update_transaction_pool(&mut self, transactions: &Vec<Transaction>) {
+    fn update_transaction_pool(&mut self, transactions: &[Transaction]) {
         for transaction in transactions {
             self.transactions_pool.remove(&transaction.hash());
         }

--- a/core/src/actors/chain_manager/validations.rs
+++ b/core/src/actors/chain_manager/validations.rs
@@ -21,7 +21,7 @@ pub fn validate_transaction<S: ::std::hash::BuildHasher>(
 // TODO: Add verifications related to data requests (e.g. enough commitment transactions for a data request)
 pub fn validate_transactions<S: ::std::hash::BuildHasher>(
     utxo_set: &mut HashMap<OutputPointer, Output, S>,
-    txn_pool: &mut TransactionsPool,
+    _txn_pool: &TransactionsPool,
     data_request_pool: &mut DataRequestPool,
     block: &Block,
 ) -> bool {
@@ -48,8 +48,6 @@ pub fn validate_transactions<S: ::std::hash::BuildHasher>(
 
                 utxo_set.insert(output_pointer, output.clone());
             }
-
-            txn_pool.remove(&txn_hash);
 
             // Add DataRequests from the block into the data_request_pool
             data_request_pool.process_transaction(

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -312,11 +312,8 @@ pub enum TransactionError {
     #[fail(display = "A hash is missing in the pool {}", 0)]
     PoolMiss(Hash),
     /// An output with the given index wasn't found in a transaction.
-    #[fail(
-        display = "An output with index {} was not found in transaction {}",
-        1, 0
-    )]
-    OutputNotFound(Hash, usize),
+    #[fail(display = "Output not found: {}", 0)]
+    OutputNotFound(OutputPointer),
 }
 
 impl Transaction {
@@ -358,27 +355,9 @@ impl Transaction {
         let mut total_value = 0;
 
         for input in &self.inputs {
-            /*
-            let OutputPointer {
-                transaction_id,
-                output_index,
-            } = input.output_pointer();
-            let index = output_index as usize;
-            let pointed_transaction = pool
-                .get(&transaction_id)
-                .ok_or_else(|| TransactionError::PoolMiss(transaction_id))?;
-            let pointed_value = pointed_transaction
-                .get_output_value(index)
-                .ok_or_else(|| TransactionError::OutputNotFound(transaction_id, index))?;
-                */
             let pointed_value = pool
                 .get(&input.output_pointer())
-                .ok_or_else(|| {
-                    TransactionError::OutputNotFound(
-                        input.output_pointer().transaction_id,
-                        input.output_pointer().output_index as usize,
-                    )
-                })?
+                .ok_or_else(|| TransactionError::OutputNotFound(input.output_pointer()))?
                 .value();
             total_value += pointed_value;
         }

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -371,9 +371,15 @@ impl Transaction {
                 .get_output_value(index)
                 .ok_or_else(|| TransactionError::OutputNotFound(transaction_id, index))?;
                 */
-            let pointed_value = pool.get(&input.output_pointer()).ok_or_else(
-                || TransactionError::OutputNotFound(input.output_pointer().transaction_id, input.output_pointer().output_index as usize)
-            )?.value();
+            let pointed_value = pool
+                .get(&input.output_pointer())
+                .ok_or_else(|| {
+                    TransactionError::OutputNotFound(
+                        input.output_pointer().transaction_id,
+                        input.output_pointer().output_index as usize,
+                    )
+                })?
+                .value();
             total_value += pointed_value;
         }
 

--- a/data_structures/src/tests.rs
+++ b/data_structures/src/tests.rs
@@ -259,7 +259,7 @@ mod transaction {
 
     #[test]
     fn test_inputs_sum() {
-        let mut pool = TransactionsPool::new();
+        let mut pool = UnspentOutputsPool::new();
         let hash = HASH;
         let transaction = Transaction {
             version: 0,
@@ -284,26 +284,34 @@ mod transaction {
         assert!(transaction.inputs_sum(&pool).is_err());
 
         pool.insert(
-            hash,
-            Transaction {
-                version: 0,
-                signatures: Vec::new(),
-                inputs: Vec::new(),
-                outputs: vec![
-                    Output::Commit(CommitOutput {
-                        commitment: hash,
-                        value: 123,
-                    }),
-                    Output::Commit(CommitOutput {
-                        commitment: hash,
-                        value: 10,
-                    }),
-                    Output::Commit(CommitOutput {
-                        commitment: hash,
-                        value: 1,
-                    }),
-                ],
+            OutputPointer {
+                transaction_id: hash,
+                output_index: 0,
             },
+            Output::Commit(CommitOutput {
+                commitment: hash,
+                value: 123,
+            }),
+        );
+        pool.insert(
+            OutputPointer {
+                transaction_id: hash,
+                output_index: 1,
+            },
+            Output::Commit(CommitOutput {
+                commitment: hash,
+                value: 10,
+            }),
+        );
+        pool.insert(
+            OutputPointer {
+                transaction_id: hash,
+                output_index: 2,
+            },
+            Output::Commit(CommitOutput {
+                commitment: hash,
+                value: 1,
+            }),
         );
 
         assert_eq!(transaction.inputs_sum(&pool).unwrap(), 124);
@@ -341,7 +349,7 @@ mod transaction {
 
     #[test]
     fn test_fee() {
-        let pool = TransactionsPool::new();
+        let pool = UnspentOutputsPool::new();
         let transaction = Transaction {
             version: 0,
             signatures: Vec::new(),
@@ -375,7 +383,7 @@ mod block {
 
     #[test]
     fn test_validate_correct_block() {
-        let pool = TransactionsPool::new();
+        let pool = UnspentOutputsPool::new();
         let reward = 123;
         let block = Block {
             block_header: HEADER,
@@ -396,7 +404,7 @@ mod block {
 
     #[test]
     fn test_validate_empty_block() {
-        let pool = TransactionsPool::new();
+        let pool = UnspentOutputsPool::new();
         let reward = 123;
         let block = Block {
             block_header: HEADER,
@@ -414,7 +422,7 @@ mod block {
 
     #[test]
     fn test_validate_block_with_no_mint() {
-        let pool = TransactionsPool::new();
+        let pool = UnspentOutputsPool::new();
         let reward = 123;
         let block = Block {
             block_header: HEADER,
@@ -445,7 +453,7 @@ mod block {
 
     #[test]
     fn test_validate_block_with_multiple_mint() {
-        let pool = TransactionsPool::new();
+        let pool = UnspentOutputsPool::new();
         let reward = 123;
         let mint = Transaction {
             version: 0,
@@ -472,7 +480,7 @@ mod block {
 
     #[test]
     fn test_validate_block_with_mismatched_mint_value() {
-        let pool = TransactionsPool::new();
+        let pool = UnspentOutputsPool::new();
         let reward = 123;
         let block = Block {
             block_header: HEADER,


### PR DESCRIPTION
The mint transaction is now validated correctly.

Transaction validation incorrectly used the `TransactionPool` instead of the `UnspentOutputsPool`.

Block consolidation now correctly updates the `TransactionPool`.

In `AddTransaction`, the validations are disabled because they failed to recognize a valid commitment transaction. The only checks enabled are whether the input of the transaction is present in the unspent outputs pool.