### PR TITLE
fix(chain_manager): block_chain should only have consolidated blocks

### DIFF
--- a/core/src/actors/chain_manager/actor.rs
+++ b/core/src/actors/chain_manager/actor.rs
@@ -12,9 +12,9 @@ use super::{
 };
 
 use crate::actors::{
-    chain_manager::{data_request::DataRequestPool, Blockchain},
+    chain_manager::data_request::DataRequestPool,
     config_manager::send_get_config_request,
-    storage_keys::{BLOCK_CHAIN_KEY, CHAIN_STATE_KEY},
+    storage_keys::CHAIN_STATE_KEY,
     storage_manager::{messages::Get, StorageManager},
 };
 
@@ -24,6 +24,7 @@ use witnet_data_structures::chain::{
 use witnet_util::timestamp::{get_timestamp, pretty_print};
 
 use log::{debug, error, warn};
+use std::collections::BTreeMap;
 
 /// Implement Actor trait for `ChainManager`
 impl Actor for ChainManager {
@@ -196,37 +197,8 @@ impl Actor for ChainManager {
                             chain_info: Some(chain_info),
                             unspent_outputs_pool: UnspentOutputsPool::default(),
                             data_request_pool: ActiveDataRequestPool::default(),
+                            block_chain: BTreeMap::default(),
                         };
-                    }
-                    actix::fut::ok(())
-                })
-                .wait(ctx);
-
-            storage_manager_addr
-                // Send a message to read block_chain from the storage
-                .send(Get::<Blockchain>::new(BLOCK_CHAIN_KEY))
-                .into_actor(act)
-                // Process the response
-                .then(|res, _act, _ctx| match res {
-                    Err(e) => {
-                        // Error when sending message
-                        error!("Unsuccessful communication with storage manager: {}", e);
-                        actix::fut::err(())
-                    }
-                    Ok(res) => match res {
-                        Err(e) => {
-                            // Storage error
-                            error!("Error while getting block chain from storage: {}", e);
-                            actix::fut::err(())
-                        }
-                        Ok(res) => actix::fut::ok(res),
-                    },
-                })
-                .and_then(move |block_chain_from_storage, act, _ctx| {
-                    // block_chain_from_storage can be None if the storage does not contain that key
-                    if let Some(block_chain_from_storage) = block_chain_from_storage {
-                        act.block_chain = block_chain_from_storage;
-                        debug!("Blockchain (blocks index) successfully obtained from storage");
                     }
                     actix::fut::ok(())
                 })

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -63,18 +63,22 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
             // Update chain_info
             match self.chain_state.chain_info.as_mut() {
                 Some(chain_info) => {
+                    let block_hash = candidate.block.hash();
+                    let block_epoch = candidate.block.block_header.beacon.checkpoint;
+
                     let beacon = CheckpointBeacon {
                         checkpoint: msg.checkpoint,
-                        hash_prev_block: candidate.block.hash(),
+                        hash_prev_block: block_hash,
                     };
 
                     chain_info.highest_block_checkpoint = beacon;
+                    self.chain_state.block_chain.insert(block_epoch, block_hash);
 
                     info!(
                         "{} Block {} consolidated for epoch #{}",
                         Purple.bold().paint("[Chain]"),
                         Purple.bold().paint(candidate.block.hash().to_string()),
-                        Purple.bold().paint(beacon.checkpoint.to_string()),
+                        Purple.bold().paint(block_epoch.to_string()),
                     );
 
                     debug!("{:?}", candidate.block);
@@ -125,9 +129,6 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
 
                     // Persist chain_info into storage
                     self.persist_chain_state(ctx);
-
-                    // Persist block_chain into storage
-                    self.persist_block_chain(ctx);
                 }
                 None => {
                     error!("No ChainInfo loaded in ChainManager");
@@ -341,13 +342,10 @@ impl Handler<GetBlocksEpochRange> for ChainManager {
     ) -> Self::Result {
         debug!("GetBlocksEpochRange received {:?}", range);
         let hashes = self
+            .chain_state
             .block_chain
             .range(range)
-            .flat_map(|(epoch, hashset)| {
-                hashset
-                    .iter()
-                    .map(move |hash| (*epoch, InventoryEntry::Block(*hash)))
-            })
+            .map(|(k, v)| (*k, InventoryEntry::Block(*v)))
             .collect();
 
         Ok(hashes)

--- a/core/src/actors/chain_manager/mining.rs
+++ b/core/src/actors/chain_manager/mining.rs
@@ -16,11 +16,10 @@ use crate::actors::{
 };
 
 use witnet_crypto::hash::calculate_sha256;
-use witnet_data_structures::chain::UnspentOutputsPool;
 use witnet_data_structures::chain::{
     Block, BlockHeader, CheckpointBeacon, Hash, Input, LeadershipProof, Output, PublicKeyHash,
     RevealInput, Secp256k1Signature, Signature, TallyOutput, Transaction, TransactionsPool,
-    ValueTransferOutput,
+    UnspentOutputsPool, ValueTransferOutput,
 };
 use witnet_storage::storage::Storable;
 

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -31,7 +31,7 @@ use actix::{
 };
 use ansi_term::Color::Purple;
 use log::{debug, error, info, warn};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use self::messages::InventoryEntriesResult;
 
@@ -43,7 +43,7 @@ use crate::actors::{
         messages::{Anycast, Broadcast},
         SessionsManager,
     },
-    storage_keys::{BLOCK_CHAIN_KEY, CHAIN_STATE_KEY},
+    storage_keys::CHAIN_STATE_KEY,
     storage_manager::{messages::Put, StorageManager},
 };
 
@@ -51,9 +51,8 @@ use self::data_request::DataRequestPool;
 use self::validations::{validate_merkle_tree, validate_transactions};
 
 use witnet_data_structures::chain::{
-    Block, Blockchain, ChainState, CheckpointBeacon, DataRequestReport, Epoch, Hash, Hashable,
-    InventoryEntry, InventoryItem, OutputPointer, Transaction, TransactionsPool,
-    UnspentOutputsPool,
+    Block, ChainState, CheckpointBeacon, DataRequestReport, Epoch, Hash, Hashable, InventoryEntry,
+    InventoryItem, OutputPointer, Transaction, TransactionsPool, UnspentOutputsPool,
 };
 
 use crate::actors::chain_manager::validations::block_reward;
@@ -94,9 +93,6 @@ impl From<WitnetError<StorageError>> for ChainManagerError {
 pub struct ChainManager {
     /// Blockchain state data structure
     chain_state: ChainState,
-    /// Map that relates an epoch with the hashes of the blocks for that epoch (blocks index)
-    // One epoch can have more than one block
-    block_chain: Blockchain,
     /// Map that stores blocks by their hash
     blocks: HashMap<Hash, Block>,
     /// Map that stores blocks without validation by their hash
@@ -163,31 +159,6 @@ impl ChainManager {
                     Ok(Ok(_)) => debug!("Successfully persisted chain_info into storage"),
                     _ => {
                         error!("Failed to persist chain_info into storage");
-                        // FIXME(#72): handle errors
-                    }
-                }
-                actix::fut::ok(())
-            })
-            .wait(ctx);
-    }
-
-    /// Method to persist `block_chain` into Storage
-    fn persist_block_chain(&self, ctx: &mut Context<Self>) {
-        // Get StorageManager address
-        let storage_manager_addr = System::current().registry().get::<StorageManager>();
-
-        // Persist block_chain into storage. `AsyncContext::wait` registers
-        // future within context, but context waits until this future resolves
-        // before processing any other events.
-        let msg = Put::from_value(BLOCK_CHAIN_KEY, &self.block_chain).unwrap();
-        storage_manager_addr
-            .send(msg)
-            .into_actor(self)
-            .then(|res, _act, _ctx| {
-                match res {
-                    Ok(Ok(_)) => debug!("Successfully persisted block_chain into storage"),
-                    _ => {
-                        error!("Failed to persist block_chain into storage");
                         // FIXME(#72): handle errors
                     }
                 }
@@ -265,19 +236,11 @@ impl ChainManager {
         } else {
             // This is a new block, insert it into the internal maps
             {
-                // Insert the new block into the map that relates epochs to block hashes
                 let beacon = &block.block_header.beacon;
-                let hash_set = &mut self
-                    .block_chain
-                    .entry(beacon.checkpoint)
-                    .or_insert_with(HashSet::new);
-                hash_set.insert(hash);
-
                 info!(
-                    "{} Epoch #{} has {} block candidates now",
+                    "{} Epoch #{} has a new block candidate",
                     Purple.bold().paint("[Chain]"),
                     Purple.bold().paint(beacon.checkpoint.to_string()),
-                    Purple.bold().paint(hash_set.len().to_string())
                 );
             }
 
@@ -559,6 +522,7 @@ impl ChainManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     #[test]
     fn add_block() {
@@ -575,17 +539,8 @@ mod tests {
         assert_eq!(bm.blocks.len(), 1);
         assert_eq!(bm.blocks.get(&hash_a).unwrap(), &block_a);
 
-        // Check the block is added into the epoch-to-hash map
-        assert_eq!(bm.block_chain.get(&checkpoint).unwrap().len(), 1);
-        assert_eq!(
-            bm.block_chain
-                .get(&checkpoint)
-                .unwrap()
-                .iter()
-                .next()
-                .unwrap(),
-            &hash_a
-        );
+        // The block should not be added into the epoch-to-hash map until it is consolidated
+        assert!(bm.chain_state.block_chain.get(&checkpoint).is_none());
     }
 
     #[test]
@@ -599,26 +554,6 @@ mod tests {
         assert!(bm.accept_block(block.clone()).is_ok());
         assert!(bm.accept_block(block).is_err());
         assert_eq!(bm.blocks.len(), 1);
-    }
-
-    #[test]
-    fn add_blocks_same_epoch() {
-        let mut bm = ChainManager::default();
-
-        // Build hardcoded blocks
-        let checkpoint = 2;
-        let block_a = build_hardcoded_block(checkpoint, 99999, Hash::SHA256([111; 32]));
-        let block_b = build_hardcoded_block(checkpoint, 12345, Hash::SHA256([112; 32]));
-
-        // Add blocks to the ChainManager
-        let hash_a = bm.accept_block(block_a).unwrap();
-        let hash_b = bm.accept_block(block_b).unwrap();
-        assert_ne!(hash_a, hash_b);
-
-        // Check that both blocks are stored in the same epoch
-        assert_eq!(bm.block_chain.get(&checkpoint).unwrap().len(), 2);
-        assert!(bm.block_chain.get(&checkpoint).unwrap().contains(&hash_a));
-        assert!(bm.block_chain.get(&checkpoint).unwrap().contains(&hash_b));
     }
 
     #[test]
@@ -1088,6 +1023,7 @@ mod tests {
             }),
             unspent_outputs_pool: UnspentOutputsPool::default(),
             data_request_pool: ActiveDataRequestPool::default(),
+            block_chain: BTreeMap::default(),
         };
 
         assert!(chain_state.to_bytes().is_ok());
@@ -1122,6 +1058,7 @@ mod tests {
             }),
             unspent_outputs_pool: UnspentOutputsPool::default(),
             data_request_pool: ActiveDataRequestPool::default(),
+            block_chain: BTreeMap::default(),
         };
 
         assert!(chain_state.to_bytes().is_ok());
@@ -1171,6 +1108,7 @@ mod tests {
             }),
             unspent_outputs_pool: utxo,
             data_request_pool: ActiveDataRequestPool::default(),
+            block_chain: BTreeMap::default(),
         };
 
         assert!(chain_state.to_bytes().is_ok());

--- a/core/src/actors/storage_keys.rs
+++ b/core/src/actors/storage_keys.rs
@@ -3,6 +3,3 @@ pub static PEERS_KEY: &'static [u8] = b"peers";
 
 /// Constant to specify the chain state key for the storage
 pub static CHAIN_STATE_KEY: &'static [u8] = b"chain";
-
-/// Constant to specify the blocks index key for the storage
-pub static BLOCK_CHAIN_KEY: &'static [u8] = b"block_chain";

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1173,7 +1173,7 @@ pub struct ActiveDataRequestPool {
 
 pub type UnspentOutputsPool = HashMap<OutputPointer, Output>;
 
-pub type Blockchain = BTreeMap<Epoch, HashSet<Hash>>;
+pub type Blockchain = BTreeMap<Epoch, Hash>;
 
 /// Blockchain state (valid at a certain epoch)
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone)]
@@ -1184,6 +1184,8 @@ pub struct ChainState {
     pub unspent_outputs_pool: UnspentOutputsPool,
     /// Collection of state structures for active data requests
     pub data_request_pool: ActiveDataRequestPool,
+    /// List of consolidated blocks by epoch
+    pub block_chain: Blockchain,
 }
 
 impl ChainState {


### PR DESCRIPTION
This fixes the `getBlockChain` cli method, which should only list the consolidated blocks.

Fixes #295
Fixes #294