### PR TITLE
Fix: send inventory blocks in same order as requested

### DIFF
--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -195,6 +195,12 @@ impl Handler<AddTransaction> for ChainManager {
     type Result = SessionUnitResult;
 
     fn handle(&mut self, msg: AddTransaction, _ctx: &mut Context<Self>) {
+        let transaction_hash = &msg.transaction.hash();
+        if self.transactions_pool.contains(transaction_hash) {
+            debug!("Transaction is already in the pool: {}", transaction_hash);
+            return;
+        }
+
         debug!("Adding transaction: {:?}", msg.transaction);
         // FIXME: transaction validation is broken
         //let outputs = &msg.transaction.outputs;
@@ -318,10 +324,10 @@ impl Handler<AddTransaction> for ChainManager {
 
                     // Add valid transaction to transactions_pool
                     self.transactions_pool
-                        .insert(msg.transaction.hash(), msg.transaction); /*
-                                                                              }
-                                                                          }
-                                                                          */
+                        .insert(*transaction_hash, msg.transaction); /*
+                                                                         }
+                                                                     }
+                                                                     */
                 } else {
                     warn!("Input OutputPointer not in pool");
                 }

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -86,12 +86,13 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                     };
 
                     chain_info.highest_block_checkpoint = beacon;
+                    let previous_epoch = candidate.block.block_header.beacon.checkpoint;
 
                     info!(
                         "{} Block {} consolidated for epoch #{}",
                         Purple.bold().paint("[Chain]"),
                         Purple.bold().paint(candidate.block.hash().to_string()),
-                        Purple.bold().paint(beacon.checkpoint.to_string()),
+                        Purple.bold().paint(previous_epoch.to_string()),
                     );
 
                     debug!("{:?}", candidate.block);

--- a/core/src/actors/chain_manager/messages.rs
+++ b/core/src/actors/chain_manager/messages.rs
@@ -12,6 +12,16 @@ use witnet_data_structures::{
 /// Message result of unit
 pub type SessionUnitResult = ();
 
+/// Set `network_ready` flag
+pub struct SetNetworkReady {
+    /// Block
+    pub network_ready: bool,
+}
+
+impl Message for SetNetworkReady {
+    type Result = SessionUnitResult;
+}
+
 /// Message to obtain the highest block checkpoint managed by the `ChainManager`
 /// actor.
 pub struct GetHighestCheckpointBeacon;

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -421,13 +421,16 @@ impl ChainManager {
                         );
                     }
                 } else if hash_prev_block != self.genesis_block_hash && !self.blocks.contains_key(&hash_prev_block) {
+//                } else if hash_prev_block != self.genesis_block_hash &&
+//                    !self.block_chain.get(&block_epoch).map(|x| x.contains(&hash_prev_block)).unwrap_or(false) {
+
                     // Request the lost block with the hash_prev_block indicated in this block
                     // Except when that block is the genesis block
                     self.request_block(hash_prev_block);
 
                     match self.keep_block_without_validation(block) {
                         Ok(hash) => warn!(
-                            "Block [{}] has a previous hash [{}] not known",
+                            "Block [{:?}] has a previous hash [{:?}] not known",
                             hash, hash_prev_block
                         ),
                         Err(ChainManagerError::BlockAlreadyExists) => {

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -92,6 +92,8 @@ impl From<WitnetError<StorageError>> for ChainManagerError {
 /// ChainManager actor
 #[derive(Default)]
 pub struct ChainManager {
+    /// Flag indicating if network is ready
+    network_ready: bool,
     /// Blockchain state data structure
     chain_state: ChainState,
     /// Map that relates an epoch with the hashes of the blocks for that epoch (blocks index)

--- a/core/src/actors/inventory_manager/handlers.rs
+++ b/core/src/actors/inventory_manager/handlers.rs
@@ -1,9 +1,8 @@
-use actix::{ActorFuture, Context, Handler, ResponseActFuture, System, WrapFuture};
-
 use crate::actors::inventory_manager::{
     messages::{AddItem, GetItem},
     InventoryManager, InventoryManagerError,
 };
+use actix::{ActorFuture, Context, Handler, ResponseActFuture, System, WrapFuture};
 use witnet_data_structures::chain::{Hash, Hashable, InventoryItem};
 
 use crate::actors::storage_manager::{messages::Get, messages::Put, StorageManager};

--- a/core/src/actors/session/messages.rs
+++ b/core/src/actors/session/messages.rs
@@ -58,3 +58,13 @@ impl fmt::Display for RequestBlock {
         write!(f, "RequestBlock")
     }
 }
+
+/// Message to indicate that the session needs start an inventory exchange
+#[derive(Clone, Debug, Message)]
+pub struct InventoryExchange;
+
+impl fmt::Display for InventoryExchange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "InventoryExchange")
+    }
+}

--- a/core/src/actors/sessions_manager/handlers.rs
+++ b/core/src/actors/sessions_manager/handlers.rs
@@ -203,7 +203,6 @@ where
             .get_all_consolidated_sessions()
             .for_each(|session_addr| {
                 // Send message to session and ignore errors
-                debug!("Broadcasting to peer {:?}", session_addr);
                 session_addr.do_send(msg.command.clone());
             });
     }

--- a/core/src/actors/sessions_manager/handlers.rs
+++ b/core/src/actors/sessions_manager/handlers.rs
@@ -200,9 +200,10 @@ where
         );
 
         self.sessions
-            .get_all_consolidated_outbound_sessions()
+            .get_all_consolidated_sessions()
             .for_each(|session_addr| {
                 // Send message to session and ignore errors
+                debug!("Broadcasting to peer {:?}", session_addr);
                 session_addr.do_send(msg.command.clone());
             });
     }


### PR DESCRIPTION
When requesting blocks with an `InventoryRequest` message, the node was sending the blocks in inverse order causing a bit of trouble. This fix makes the node send the blocks in the requested order.

This PR supersedes #361 