### PR TITLE
Do not announce candidate

### DIFF
--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -86,12 +86,13 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                     };
 
                     chain_info.highest_block_checkpoint = beacon;
+                    let previous_epoch = candidate.block.block_header.beacon.checkpoint;
 
                     info!(
                         "{} Block {} consolidated for epoch #{}",
                         Purple.bold().paint("[Chain]"),
                         Purple.bold().paint(candidate.block.hash().to_string()),
-                        Purple.bold().paint(beacon.checkpoint.to_string()),
+                        Purple.bold().paint(previous_epoch.to_string()),
                     );
 
                     debug!("{:?}", candidate.block);

--- a/core/src/actors/chain_manager/messages.rs
+++ b/core/src/actors/chain_manager/messages.rs
@@ -12,6 +12,16 @@ use witnet_data_structures::{
 /// Message result of unit
 pub type SessionUnitResult = ();
 
+/// Set `network_ready` flag
+pub struct SetNetworkReady {
+    /// Block
+    pub network_ready: bool,
+}
+
+impl Message for SetNetworkReady {
+    type Result = SessionUnitResult;
+}
+
 /// Message to obtain the highest block checkpoint managed by the `ChainManager`
 /// actor.
 pub struct GetHighestCheckpointBeacon;

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -421,13 +421,16 @@ impl ChainManager {
                         );
                     }
                 } else if hash_prev_block != self.genesis_block_hash && !self.blocks.contains_key(&hash_prev_block) {
+//                } else if hash_prev_block != self.genesis_block_hash &&
+//                    !self.block_chain.get(&block_epoch).map(|x| x.contains(&hash_prev_block)).unwrap_or(false) {
+
                     // Request the lost block with the hash_prev_block indicated in this block
                     // Except when that block is the genesis block
                     self.request_block(hash_prev_block);
 
                     match self.keep_block_without_validation(block) {
                         Ok(hash) => warn!(
-                            "Block [{}] has a previous hash [{}] not known",
+                            "Block [{:?}] has a previous hash [{:?}] not known",
                             hash, hash_prev_block
                         ),
                         Err(ChainManagerError::BlockAlreadyExists) => {

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -92,6 +92,8 @@ impl From<WitnetError<StorageError>> for ChainManagerError {
 /// ChainManager actor
 #[derive(Default)]
 pub struct ChainManager {
+    /// Flag indicating if network is ready
+    network_ready: bool,
     /// Blockchain state data structure
     chain_state: ChainState,
     /// Map that relates an epoch with the hashes of the blocks for that epoch (blocks index)

--- a/core/src/actors/inventory_manager/handlers.rs
+++ b/core/src/actors/inventory_manager/handlers.rs
@@ -1,9 +1,8 @@
-use actix::{ActorFuture, Context, Handler, ResponseActFuture, System, WrapFuture};
-
 use crate::actors::inventory_manager::{
     messages::{AddItem, GetItem},
     InventoryManager, InventoryManagerError,
 };
+use actix::{ActorFuture, Context, Handler, ResponseActFuture, System, WrapFuture};
 use witnet_data_structures::chain::{Hash, Hashable, InventoryItem};
 
 use crate::actors::storage_manager::{messages::Get, messages::Put, StorageManager};

--- a/core/src/actors/session/handlers.rs
+++ b/core/src/actors/session/handlers.rs
@@ -569,7 +569,7 @@ fn session_getblocks(
                     ..
                 })) => {
                     if highest_checkpoint > received_checkpoint {
-                        let range = (received_checkpoint + 1)..=highest_checkpoint;
+                        let range = (received_checkpoint + 1)..highest_checkpoint;
 
                         chain_manager_addr
                             .send(GetBlocksEpochRange::new(range))

--- a/core/src/actors/session/handlers.rs
+++ b/core/src/actors/session/handlers.rs
@@ -1,10 +1,11 @@
-use std::io::Error;
-
 use actix::io::WriteHandler;
 use actix::{
-    Actor, ActorContext, ActorFuture, AsyncContext, Context, ContextFutureSpawner, Handler,
-    StreamHandler, System, WrapFuture,
+    ActorContext, ActorFuture, Context, ContextFutureSpawner, Handler, StreamHandler, System,
+    WrapFuture,
 };
+
+use futures::future;
+use std::io::Error;
 
 use ansi_term::Color::Green;
 
@@ -33,7 +34,7 @@ use super::{
 };
 use witnet_data_structures::{
     builders::from_address,
-    chain::{Block, CheckpointBeacon, Hash, InventoryEntry, InventoryItem, Transaction},
+    chain::{Block, CheckpointBeacon, InventoryEntry, InventoryItem, Transaction},
     serializers::decoders::TryFrom,
     types::{
         Address, Command, InventoryAnnouncement, InventoryRequest, LastBeacon,
@@ -100,17 +101,31 @@ impl StreamHandler<BytesMut, Error> for Session {
                         SessionStatus::Consolidated,
                         Command::InventoryRequest(InventoryRequest { inventory }),
                     ) => {
-                        for elem in inventory {
-                            match elem {
+                        let inventory_mngr = System::current().registry().get::<InventoryManager>();
+                        let item_requests: Vec<_> = inventory
+                            .iter()
+                            .filter_map(|item| match item {
                                 InventoryEntry::Block(hash) | InventoryEntry::Tx(hash) => {
-                                    send_inventory_item(self, ctx, &hash);
+                                    Some(inventory_mngr.send(GetItem { hash: *hash }))
                                 }
-                                InventoryEntry::DataRequest(_) | InventoryEntry::DataResult(_) => {
-                                    warn!("No block or transaction requested");
+                                _ => None,
+                            })
+                            .collect();
+
+                        future::join_all(item_requests)
+                            .into_actor(self)
+                            .map_err(|e, _, _| error!("Inventory request error: {}", e))
+                            .and_then(|item_responses, session, _| {
+                                for item_response in item_responses {
+                                    match item_response {
+                                        Ok(item) => send_inventory_item_msg(session, item),
+                                        Err(e) => error!("Inventory result is error: {}", e),
+                                    }
                                 }
-                                InventoryEntry::Error(_) => error!("Error InvElem received"),
-                            }
-                        }
+
+                                actix::fut::ok(())
+                            })
+                            .spawn(ctx);
                     }
                     //////////////////////////
                     // TRANSACTION RECEIVED //
@@ -137,7 +152,7 @@ impl StreamHandler<BytesMut, Error> for Session {
                             highest_block_checkpoint,
                         }),
                     ) => {
-                        todo_inbound_session_getblocks(self, ctx, highest_block_checkpoint);
+                        session_getblocks(self, ctx, highest_block_checkpoint);
                     }
                     (
                         SessionType::Outbound,
@@ -146,7 +161,7 @@ impl StreamHandler<BytesMut, Error> for Session {
                             highest_block_checkpoint,
                         }),
                     ) => {
-                        todo_outbound_session_getblocks(self, ctx, highest_block_checkpoint);
+                        session_getblocks(self, ctx, highest_block_checkpoint);
                     }
 
                     ////////////////////
@@ -497,65 +512,6 @@ fn handshake_version(session: &mut Session, sender_address: &Address) -> Vec<Wit
     responses
 }
 
-fn send_get_item_request<T, U: 'static>(
-    act: &mut T,
-    ctx: &mut T::Context,
-    hash: Hash,
-    process_item: U,
-) where
-    T: Actor,
-    T::Context: AsyncContext<T>,
-    U: FnOnce(&mut T, &mut T::Context, InventoryItem),
-{
-    // Get InventoryManager address
-    let inventory_manager_addr = System::current().registry().get::<InventoryManager>();
-
-    // Start chain of actions to send a message to the InventoryManager
-    inventory_manager_addr
-        // Send GetItem message to InventoryManager actor
-        // This returns a Request Future, representing an asynchronous message sending process
-        .send(GetItem { hash })
-        // Convert a normal future into an ActorFuture
-        .into_actor(act)
-        // Process the response from the InventoryManager
-        // This returns a FutureResult containing the socket address if present
-        .then(|res, _act, _ctx| match res {
-            // Process the response from InventoryManager
-            Err(e) => {
-                // Error when sending message
-                error!("Unsuccessful communication with InventoryManager: {}", e);
-                actix::fut::err(())
-            }
-            Ok(res) => match res {
-                Err(e) => {
-                    // InventoryManager error
-                    error!("Error while getting block from InventoryManager: {}", e);
-                    actix::fut::err(())
-                }
-                Ok(res) => actix::fut::ok(res),
-            },
-        })
-        // Process the received config
-        // This returns a FutureResult containing a success
-        .and_then(|item, act, ctx| {
-            // Call function to process item
-            process_item(act, ctx, item);
-
-            actix::fut::ok(())
-        })
-        .wait(ctx);
-}
-
-/// Method to send a GetItem message to the InventoryManager
-fn send_inventory_item(session: &mut Session, ctx: &mut Context<Session>, hash: &Hash) {
-    let hash = *hash;
-
-    // Send message to config manager and process response
-    send_get_item_request(session, ctx, hash, |act, _ctx, item| {
-        send_inventory_item_msg(act, item);
-    });
-}
-
 fn send_inventory_item_msg(session: &mut Session, item: InventoryItem) {
     match item {
         InventoryItem::Block(block) => {
@@ -592,7 +548,7 @@ fn request_block_msg(session: &mut Session, block_entry: InventoryEntry) {
     }
 }
 
-fn todo_inbound_session_getblocks(
+fn session_getblocks(
     session: &Session,
     ctx: &mut Context<Session>,
     CheckpointBeacon {
@@ -665,12 +621,4 @@ fn todo_inbound_session_getblocks(
             }
         })
         .wait(ctx);
-}
-
-fn todo_outbound_session_getblocks(
-    _session: &Session,
-    _ctx: &mut Context<Session>,
-    _checkpoint_beacon: CheckpointBeacon,
-) {
-    unimplemented!();
 }

--- a/core/src/actors/session/messages.rs
+++ b/core/src/actors/session/messages.rs
@@ -58,3 +58,13 @@ impl fmt::Display for RequestBlock {
         write!(f, "RequestBlock")
     }
 }
+
+/// Message to indicate that the session needs start an inventory exchange
+#[derive(Clone, Debug, Message)]
+pub struct InventoryExchange;
+
+impl fmt::Display for InventoryExchange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "InventoryExchange")
+    }
+}

--- a/core/src/actors/sessions_manager/handlers.rs
+++ b/core/src/actors/sessions_manager/handlers.rs
@@ -203,7 +203,6 @@ where
             .get_all_consolidated_sessions()
             .for_each(|session_addr| {
                 // Send message to session and ignore errors
-                debug!("Broadcasting to peer {:?}", session_addr);
                 session_addr.do_send(msg.command.clone());
             });
     }

--- a/core/src/actors/sessions_manager/handlers.rs
+++ b/core/src/actors/sessions_manager/handlers.rs
@@ -200,9 +200,10 @@ where
         );
 
         self.sessions
-            .get_all_consolidated_outbound_sessions()
+            .get_all_consolidated_sessions()
             .for_each(|session_addr| {
                 // Send message to session and ignore errors
+                debug!("Broadcasting to peer {:?}", session_addr);
                 session_addr.do_send(msg.command.clone());
             });
     }


### PR DESCRIPTION
When sending the inventory announcement, do not send block candidate of the current epoch. Right now we are sending it, problem is that it won't be persisted until the next epoch, so when the inventory is requested, that block won't be found in the storage.

This PR supersedes #368 