### PR TITLE
refactor(chain_manager): remove storing blocks in ChainManager state

### DIFF
--- a/core/src/actors/chain_manager/actor.rs
+++ b/core/src/actors/chain_manager/actor.rs
@@ -19,12 +19,11 @@ use crate::actors::{
 };
 
 use witnet_data_structures::chain::{
-    ActiveDataRequestPool, ChainInfo, ChainState, CheckpointBeacon, UnspentOutputsPool,
+    ActiveDataRequestPool, Blockchain, ChainInfo, ChainState, CheckpointBeacon, UnspentOutputsPool,
 };
 use witnet_util::timestamp::{get_timestamp, pretty_print};
 
 use log::{debug, error, warn};
-use std::collections::BTreeMap;
 
 /// Implement Actor trait for `ChainManager`
 impl Actor for ChainManager {
@@ -165,7 +164,7 @@ impl ChainManager {
                             chain_info: Some(chain_info),
                             unspent_outputs_pool: UnspentOutputsPool::default(),
                             data_request_pool: ActiveDataRequestPool::default(),
-                            block_chain: BTreeMap::default(),
+                            block_chain: Blockchain::default(),
                         };
                     }
                     actix::fut::ok(())

--- a/core/src/actors/chain_manager/mining.rs
+++ b/core/src/actors/chain_manager/mining.rs
@@ -16,10 +16,10 @@ use crate::actors::{
 };
 
 use witnet_crypto::hash::calculate_sha256;
-use witnet_data_structures::chain::UnspentOutputsPool;
 use witnet_data_structures::chain::{
     Block, BlockHeader, CheckpointBeacon, Hash, LeadershipProof, Output, PublicKeyHash,
-    Secp256k1Signature, Signature, Transaction, TransactionsPool, ValueTransferOutput,
+    Secp256k1Signature, Signature, Transaction, TransactionsPool, UnspentOutputsPool,
+    ValueTransferOutput,
 };
 use witnet_storage::storage::Storable;
 

--- a/core/src/actors/storage_keys.rs
+++ b/core/src/actors/storage_keys.rs
@@ -3,6 +3,3 @@ pub static PEERS_KEY: &'static [u8] = b"peers";
 
 /// Constant to specify the chain state key for the storage
 pub static CHAIN_STATE_KEY: &'static [u8] = b"chain";
-
-/// Constant to specify the blocks index key for the storage
-pub static BLOCK_CHAIN_KEY: &'static [u8] = b"block_chain";

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1173,7 +1173,7 @@ pub struct ActiveDataRequestPool {
 
 pub type UnspentOutputsPool = HashMap<OutputPointer, Output>;
 
-pub type Blockchain = BTreeMap<Epoch, HashSet<Hash>>;
+pub type Blockchain = BTreeMap<Epoch, Hash>;
 
 /// Blockchain state (valid at a certain epoch)
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Clone)]
@@ -1184,6 +1184,8 @@ pub struct ChainState {
     pub unspent_outputs_pool: UnspentOutputsPool,
     /// Collection of state structures for active data requests
     pub data_request_pool: ActiveDataRequestPool,
+    /// List of consolidated blocks by epoch
+    pub block_chain: Blockchain,
 }
 
 impl ChainState {


### PR DESCRIPTION
This PR refactors the `ChainManager` state so that the blocks are not longer required to be on memory in order to validate newer blocks. 

This PR supersedes the PR #367 
