### PR TITLE
Fix data requests when multiple nodes are mining

### DIFF
--- a/core/src/actors/chain_manager/data_request.rs
+++ b/core/src/actors/chain_manager/data_request.rs
@@ -60,13 +60,16 @@ impl DataRequestPool {
         dr_output_pointer: &OutputPointer,
         dr_output: &DataRequestOutput,
         reveal: Vec<u8>,
+        random: u64,
     ) -> Transaction {
-        let commit_transaction = create_commit(dr_output_pointer, dr_output, &reveal);
+        let mut commit_transaction = create_commit(dr_output_pointer, dr_output, &reveal);
+        commit_transaction.signatures[0].public_key[0] = random as u8;
         let commit_pointer = OutputPointer {
             transaction_id: commit_transaction.hash(),
             output_index: 0,
         };
-        let reveal_transaction = create_reveal(commit_pointer, dr_output, reveal);
+        let mut reveal_transaction = create_reveal(commit_pointer, dr_output, reveal);
+        reveal_transaction.signatures[0].public_key[0] = random as u8;
 
         // This function can only fail when reveal transactions is not valid,
         // It can not be due to we are creating just before.

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -179,7 +179,12 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
         }
 
         if self.mining_enabled {
+            // Data race: the data requests should be sent after mining the block, otherwise
+            // it takes 2 epochs to move from one stage to the next one
             self.try_mine_block(ctx);
+            // Data request mining MUST finish BEFORE the block has been mined!!!!
+            // (The transactions must be included into this block, both the transactions from
+            // our node and the transactions from other nodes
             self.try_mine_data_request(ctx);
         }
     }

--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -1,7 +1,7 @@
 use crate::actors::chain_manager::messages::GetOutputResult;
 
 use actix::{Actor, Context, Handler};
-use ansi_term::Color::Purple;
+use ansi_term::Color::{Purple, White};
 
 use crate::actors::chain_manager::{
     messages::{SessionUnitResult, SetNetworkReady},
@@ -144,6 +144,27 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                         "Mint transaction hash: {:?}",
                         candidate.block.txns[0].hash()
                     );
+
+                    {
+                        let info = self.data_request_pool.data_request_pool.iter().fold(
+                            String::new(),
+                            |acc, (k, v)| {
+                                format!(
+                                    "{}\n* {} Stage: {}, Commits: {}, Reveals: {}",
+                                    acc,
+                                    White.bold().paint(k.to_string()),
+                                    White.bold().paint(format!("{:?}", v.stage)),
+                                    v.info.commits.len(),
+                                    v.info.reveals.len()
+                                )
+                            },
+                        );
+                        if info.is_empty() {
+                            debug!("No data requests")
+                        } else {
+                            info!("Data requests:{}", info);
+                        }
+                    }
 
                     // Send block to Inventory Manager
                     self.persist_item(ctx, InventoryItem::Block(candidate.block));

--- a/core/src/actors/chain_manager/mining.rs
+++ b/core/src/actors/chain_manager/mining.rs
@@ -179,6 +179,7 @@ impl ChainManager {
                                         &dr_output_pointer,
                                         &data_request_output,
                                         reveal_value,
+                                        act.random,
                                     );
 
                                 info!(

--- a/core/src/actors/chain_manager/mining.rs
+++ b/core/src/actors/chain_manager/mining.rs
@@ -291,8 +291,16 @@ fn build_block(
         info!("Pushing transaction into block: {:?}", transaction);
         // Currently, 1 weight unit is equivalent to 1 byte
         let transaction_weight = transaction.size();
-        // FIXME (anler): Remove unwrap and handle error correctly
-        let transaction_fee = transaction.fee(unspent_outputs_pool).unwrap();
+        let transaction_fee = match transaction.fee(unspent_outputs_pool) {
+            Ok(x) => x,
+            Err(e) => {
+                debug!(
+                    "Error when calculating transaction fee for transaction: {}",
+                    e
+                );
+                continue;
+            }
+        };
         let new_block_weight = block_weight + transaction_weight;
 
         if new_block_weight <= max_block_weight {

--- a/core/src/actors/json_rpc/json_rpc_methods.rs
+++ b/core/src/actors/json_rpc/json_rpc_methods.rs
@@ -625,4 +625,16 @@ mod tests {
             version: 0,
         }
     }
+
+    #[test]
+    fn hash_str_format() {
+        use witnet_data_structures::chain::Hash;
+        let h = Hash::SHA256([0; 32]);
+        let hash_array = serde_json::to_string(&h).unwrap();
+        let h2 = serde_json::from_str(&hash_array).unwrap();
+        assert_eq!(h, h2);
+        let hash_str = r#""0000000000000000000000000000000000000000000000000000000000000000""#;
+        let h3 = serde_json::from_str(hash_str).unwrap();
+        assert_eq!(h, h3);
+    }
 }

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -255,7 +255,7 @@ pub struct Secp256k1Signature {
 }
 
 /// Hash
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Serialize, Deserialize, Hash)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Serialize, Deserialize, Hash)]
 pub enum Hash {
     /// SHA-256 Hash
     SHA256(SHA256),
@@ -284,6 +284,12 @@ impl fmt::Display for Hash {
         };
 
         Ok(())
+    }
+}
+
+impl fmt::Debug for Hash {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 
@@ -923,7 +929,7 @@ impl TransactionsPool {
 
 /// Unspent output data structure (equivalent of Bitcoin's UTXO)
 /// It is used to locate the output by its transaction identifier and its position
-#[derive(Debug, Default, Hash, Clone, Eq, PartialEq)]
+#[derive(Default, Hash, Clone, Eq, PartialEq)]
 pub struct OutputPointer {
     pub transaction_id: Hash,
     pub output_index: u32,
@@ -940,6 +946,12 @@ pub enum OutputPointerParseError {
 impl fmt::Display for OutputPointer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(&format!("{}:{}", &self.transaction_id, &self.output_index))
+    }
+}
+
+impl fmt::Debug for OutputPointer {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/data_structures/src/serializers/decoders.rs
+++ b/data_structures/src/serializers/decoders.rs
@@ -388,12 +388,7 @@ fn create_input(ftb_input: protocol::Input) -> Input {
                         Hash::SHA256(transaction_id)
                     },
                     output_index: commit_input.output_index(),
-                    reveal: {
-                        let mut reveal = [0; 32];
-                        reveal.copy_from_slice(&commit_input.reveal()[0..32]);
-
-                        reveal.to_vec()
-                    },
+                    reveal: commit_input.reveal().to_vec(),
                     nonce: commit_input.nonce(),
                 })
             })
@@ -487,12 +482,7 @@ fn create_output(ftb_output: protocol::Output) -> Output {
             .map(|reveal_output| {
                 Output::Reveal(RevealOutput {
                     pkh: create_pkh(reveal_output.pkh()),
-                    reveal: {
-                        let mut reveal = [0; 32];
-                        reveal.copy_from_slice(&reveal_output.reveal()[0..32]);
-
-                        reveal.to_vec()
-                    },
+                    reveal: reveal_output.reveal().to_vec(),
                     value: reveal_output.value(),
                 })
             })
@@ -503,12 +493,8 @@ fn create_output(ftb_output: protocol::Output) -> Output {
             .map(|tally_output| {
                 Output::Tally(TallyOutput {
                     pkh: create_pkh(tally_output.pkh()),
-                    result: {
-                        let mut result = [0; 32];
-                        result.copy_from_slice(&tally_output.result()[0..32]);
+                    result: tally_output.result().to_vec(),
 
-                        result.to_vec()
-                    },
                     value: tally_output.value(),
                 })
             })

--- a/data_structures/tests/serializers.rs
+++ b/data_structures/tests/serializers.rs
@@ -1085,3 +1085,116 @@ fn message_get_data_encode_decode() {
 
     assert_eq!(cloned_msg, Message::try_from(result).unwrap());
 }
+
+#[test]
+fn message_transaction_encode_decode() {
+    let signature = Signature::Secp256k1(Secp256k1Signature {
+        r: [0; 32],
+        s: [0; 32],
+        v: 0,
+    });
+    let keyed_signature = vec![KeyedSignature {
+        public_key: [0; 32],
+        signature,
+    }];
+
+    let commit_input = Input::Commit(CommitInput {
+        nonce: 0,
+        output_index: 0,
+        reveal: [0; 32].to_vec(),
+        transaction_id: Hash::SHA256([0; 32]),
+    });
+    let data_request_input = Input::DataRequest(DataRequestInput {
+        output_index: 0,
+        poe: [0; 32],
+        transaction_id: Hash::SHA256([0; 32]),
+    });
+    let reveal_input = Input::Reveal(RevealInput {
+        output_index: 0,
+        transaction_id: Hash::SHA256([0; 32]),
+    });
+    let value_transfer_output = Output::ValueTransfer(ValueTransferOutput {
+        pkh: [0; 20],
+        value: 0,
+    });
+
+    let rad_aggregate = RADAggregate { script: vec![0] };
+
+    let rad_retrieve_1 = RADRetrieve {
+kind: RADType::HttpGet,
+url: "https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22".to_string(),
+script: vec![0],
+};
+
+    let rad_retrieve_2 = RADRetrieve {
+kind: RADType::HttpGet,
+url: "https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22".to_string(),
+script: vec![0],
+};
+
+    let rad_consensus = RADConsensus { script: vec![0] };
+
+    let rad_deliver_1 = RADDeliver {
+        kind: RADType::HttpGet,
+        url: "https://hooks.zapier.com/hooks/catch/3860543/l2awcd/".to_string(),
+    };
+
+    let rad_deliver_2 = RADDeliver {
+        kind: RADType::HttpGet,
+        url: "https://hooks.zapier.com/hooks/catch/3860543/l1awcw/".to_string(),
+    };
+
+    let rad_request = RADRequest {
+        aggregate: rad_aggregate,
+        not_before: 0,
+        retrieve: vec![rad_retrieve_1, rad_retrieve_2],
+        consensus: rad_consensus,
+        deliver: vec![rad_deliver_1, rad_deliver_2],
+    };
+    let data_request_output = Output::DataRequest(DataRequestOutput {
+        backup_witnesses: 0,
+        commit_fee: 0,
+        data_request: rad_request,
+        pkh: [0; 20],
+        reveal_fee: 0,
+        tally_fee: 0,
+        time_lock: 0,
+        value: 0,
+        witnesses: 0,
+    });
+    let commit_output = Output::Commit(CommitOutput {
+        commitment: Hash::SHA256([0; 32]),
+        value: 0,
+    });
+    let reveal_output = Output::Reveal(RevealOutput {
+        pkh: [0; 20],
+        reveal: vec![],
+        value: 0,
+    });
+    let consensus_output = Output::Tally(TallyOutput {
+        pkh: [0; 20],
+        result: vec![0; 1024], // The maximum size is not defined
+        value: 0,
+    });
+    let inputs = vec![data_request_input, reveal_input, commit_input];
+    let outputs = vec![
+        value_transfer_output,
+        data_request_output,
+        commit_output,
+        reveal_output,
+        consensus_output,
+    ];
+    let msg = Message {
+        kind: Command::Transaction(Transaction {
+            version: 0,
+            inputs,
+            outputs,
+            signatures: keyed_signature,
+        }),
+        magic: 1,
+    };
+    let cloned_msg = msg.clone();
+    let result: Vec<u8> = msg.into();
+
+    assert_eq!(cloned_msg, Message::try_from(result).unwrap());
+}


### PR DESCRIPTION
Example data request:

```json
{"jsonrpc":"2.0","method":"inventory","params":{"transaction":{"version":0,"inputs":[{"ValueTransfer":{"transaction_id":"bf4b7d5f1b4ed859a8de5815ab8b2caa7f788b8e62d181811034003e2b7443f5","output_index":0}}],"outputs":[{"DataRequest":{"pkh":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"data_request":{"not_before":0,"retrieve":[{"kind":"HTTP-GET","url":"https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22","script":[0]},{"kind":"HTTP-GET","url":"https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22","script":[0]}],"aggregate":{"script":[0]},"consensus":{"script":[0]},"deliver":[{"kind":"HTTP-GET","url":"https://hooks.zapier.com/hooks/catch/3860543/l2awcd/"},{"kind":"HTTP-GET","url":"https://hooks.zapier.com/hooks/catch/3860543/l1awcw/"}]},"value":0,"witnesses":1,"backup_witnesses":1,"commit_fee":0,"reveal_fee":0,"tally_fee":0,"time_lock":0}}],"signatures":[{"signature":{"Secp256k1":{"r":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"s":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"v":0}},"public_key":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}]}},"id":"1"}
```

The ValueTransfer input must be an unspent output, for example the mint transaction.

The number of witnesses determines the amount of accepted commitments for this data requests. However we only check for the maximum: a data request with "witnesses: 4" can enter into reveal stage with 1,2,3, or 4 commitments (this is a bug).
