### PR TITLE
feat(rad): implement to_float and to_map to RadonMixed

### DIFF
--- a/rad/src/operators/mixed.rs
+++ b/rad/src/operators/mixed.rs
@@ -1,14 +1,14 @@
-use crate::error::*;
-use crate::types::{float::RadonFloat, mixed::RadonMixed, RadonType};
+use witnet_data_structures::serializers::decoders::TryFrom;
 
-pub fn as_float(input: RadonMixed) -> Result<RadonFloat, RadError> {
-    match input.value().as_f64() {
-        Some(value) => Ok(RadonFloat::from(value)),
-        None => Err(RadError::new(
-            RadErrorKind::EncodeDecode,
-            String::from("Failed to encode a RadonFloat from RadonMixed"),
-        )),
-    }
+use crate::error::*;
+use crate::types::{float::RadonFloat, map::RadonMap, mixed::RadonMixed, RadonType};
+
+pub fn to_float(input: RadonMixed) -> Result<RadonFloat, RadError> {
+    RadonFloat::try_from(input.value())
+}
+
+pub fn to_map(input: RadonMixed) -> Result<RadonMap, RadError> {
+    RadonMap::try_from(input.value())
 }
 
 #[test]
@@ -18,10 +18,10 @@ fn test_as_float() {
     let radon_float = RadonFloat::from(std::f64::consts::PI);
     let radon_mixed_error = RadonMixed::from(Value::from(String::from("Hello world!")));
     let radon_mixed = RadonMixed::from(Value::from(std::f64::consts::PI));
-    let radon_error = RadError::new(
-        RadErrorKind::EncodeDecode,
-        String::from("Failed to encode a RadonFloat from RadonMixed"),
+
+    assert_eq!(to_float(radon_mixed).unwrap(), radon_float);
+    assert_eq!(
+        to_float(radon_mixed_error).unwrap_err().kind(),
+        &RadErrorKind::EncodeDecode
     );
-    assert_eq!(radon_float, as_float(radon_mixed).unwrap());
-    assert_eq!(radon_error, as_float(radon_mixed_error).unwrap_err());
 }

--- a/rad/src/operators/mod.rs
+++ b/rad/src/operators/mod.rs
@@ -33,6 +33,8 @@ pub enum RadonOpCodes {
     Reduce = 0x66,
     // Map operator codes start at 0x70
     // Mixed operator codes start at 0x80
+    ToFloat = 0x82,
+    ToMap = 0x84,
     // Result operator codes start at 0x90
 }
 

--- a/rad/src/types/mixed.rs
+++ b/rad/src/types/mixed.rs
@@ -1,5 +1,5 @@
 use crate::error::*;
-use crate::operators::{identity, Operable, RadonOpCodes};
+use crate::operators::{identity, mixed as mixed_operators, Operable, RadonOpCodes};
 use crate::script::RadonCall;
 use crate::types::{RadonType, RadonTypes};
 
@@ -45,6 +45,14 @@ impl Operable for RadonMixed {
         match call {
             // Identity
             (RadonOpCodes::Identity, None) => identity(RadonTypes::Mixed(self)),
+            // To Float
+            (RadonOpCodes::ToFloat, None) => mixed_operators::to_float(self)
+                .map(RadonTypes::from)
+                .map_err(Into::into),
+            // To Map
+            (RadonOpCodes::ToMap, None) => mixed_operators::to_map(self)
+                .map(RadonTypes::from)
+                .map_err(Into::into),
             // Unsupported / unimplemented
             (op_code, args) => Err(WitnetError::from(RadError::new(
                 RadErrorKind::UnsupportedOperator,


### PR DESCRIPTION
Implement the operators `to_float` and `to_map` to the `RadonMixed` type.