### PR TITLE
feat(core): limit blocks number sent during sychronization process

### DIFF
--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -66,6 +66,9 @@ mod handlers;
 mod mining;
 mod validations;
 
+/// Maximum blocks number to be sent during synchronization process
+const MAX_BLOCKS_SYNC: usize = 250;
+
 /// Messages for ChainManager
 pub mod messages;
 

--- a/core/src/actors/codec.rs
+++ b/core/src/actors/codec.rs
@@ -5,7 +5,7 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use actix::Message;
 use bytes;
-use log::debug;
+use log::{debug, error};
 use tokio::codec::{Decoder, Encoder};
 
 const HEADER_SIZE: usize = 2; // bytes
@@ -73,6 +73,7 @@ impl Encoder for P2PCodec {
         let mut encoded_msg = vec![];
 
         if bytes.len() > u16::max_value() as usize {
+            error!("Maximum message size exceeded");
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!("Message size {} bytes too big for u16", bytes.len()),


### PR DESCRIPTION
Fixed error produced when the maximum message size had been exceeded. This case appears during INVENTORY_ANNOUNCEMENT when too much block hashes announced. 
Added limit of 500 to this kind of message 