### PR TITLE
fix(core): add latest actix version

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,6 @@ description = "core component"
 edition = "2018"
 
 [dependencies]
-actix = "0.7.4"
 ansi_term = "0.11.0"
 
 byteorder = "1.2.6"
@@ -29,4 +28,6 @@ witnet_util = { path = "../util" }
 witnet_crypto = { path = "../crypto" }
 witnet_rad = { path = "../rad" }
 
-
+[dependencies.actix]
+git = "https://github.com/actix/actix.git"
+rev = "d28d286ac652f81e72c2aa413e7c0d3fc6c6099c"

--- a/core/src/actors/chain_manager/mod.rs
+++ b/core/src/actors/chain_manager/mod.rs
@@ -65,12 +65,12 @@ mod mining;
 mod validations;
 
 /// Maximum blocks number to be sent during synchronization process
-const MAX_BLOCKS_SYNC: usize = 3;
+const MAX_BLOCKS_SYNC: usize = 500;
 
-/// Maximum blocks number to be sent during synchronization process
+/// Synchronization interval while our blockchain is being synchronized
 const SYNCHRONIZING_INTERVAL: Duration = Duration::from_secs(5);
 
-/// Maximum blocks number to be sent during synchronization process
+/// Synchronization interval once our blokchain is considered to be synced
 const SYNCED_INTERVAL: Duration = Duration::from_secs(301);
 
 /// Messages for ChainManager


### PR DESCRIPTION
Due to an issue of an assert  that can only be disabled in the last version, which is not yet merged into master. 