### PR TITLE
fix(core): fix lagging 1 block behind the tip

### DIFF
--- a/core/src/actors/chain_manager/handlers.rs
+++ b/core/src/actors/chain_manager/handlers.rs
@@ -465,7 +465,13 @@ impl Handler<PeerLastEpoch> for ChainManager {
                 .map(|x| x.highest_block_checkpoint.checkpoint)
                 .unwrap_or(0)
         {
-            self.mine = true;
+            info!("Blockchain synced");
+            self.synced = true;
+        } else {
+            warn!("Mine flag disabled");
+            self.synced = false;
+            self.mine = false;
+            self.best_candidate = None;
         }
     }
 }

--- a/core/src/actors/sessions_manager/mod.rs
+++ b/core/src/actors/sessions_manager/mod.rs
@@ -8,6 +8,7 @@ use actix::{
 
 use ansi_term::Color::Cyan;
 
+use crate::actors::chain_manager::messages::PeerLastEpoch;
 use crate::actors::{
     chain_manager::{messages::SetNetworkReady, ChainManager},
     connections_manager::{messages::OutboundTcpConnect, ConnectionsManager},
@@ -53,6 +54,11 @@ impl SessionsManager {
 
             // Check if bootstrap is needed
             if act.sessions.is_outbound_bootstrap_needed() {
+                // TODO: Use a properly synchronization process
+                // Disable mining if we lost the minimum outbounds required
+                act.network_ready = false;
+                ChainManager::from_registry().do_send(PeerLastEpoch { epoch: 0 });
+
                 // Get peers manager address
                 let peers_manager_addr = System::current().registry().get::<PeersManager>();
 

--- a/data_structures/src/types.rs
+++ b/data_structures/src/types.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::chain::{Block, CheckpointBeacon, InventoryEntry, Transaction};
+use crate::chain::{Block, CheckpointBeacon, Hashable, InventoryEntry, Transaction};
 
 /// Witnet's protocol messages
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -34,23 +34,19 @@ pub enum Command {
 
 impl fmt::Display for Command {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Command::GetPeers(_) => "GET_PEERS",
-                Command::Peers(_) => "PEERS",
-                Command::Ping(_) => "PING",
-                Command::Pong(_) => "PONG",
-                Command::Verack(_) => "VERACK",
-                Command::Version(_) => "VERSION",
-                Command::Block(_) => "BLOCK",
-                Command::InventoryAnnouncement(_) => "INVENTORY_ANNOUNCEMENT",
-                Command::InventoryRequest(_) => "INVENTORY_REQUEST",
-                Command::LastBeacon(_) => "LAST_BEACON",
-                Command::Transaction(_) => "TRANSACTION",
-            }
-        )
+        match self {
+            Command::GetPeers(_) => f.write_str(&"GET_PEERS".to_string()),
+            Command::Peers(_) => f.write_str(&"PEERS".to_string()),
+            Command::Ping(_) => f.write_str(&"PING".to_string()),
+            Command::Pong(_) => f.write_str(&"PONG".to_string()),
+            Command::Verack(_) => f.write_str(&"VERACK".to_string()),
+            Command::Version(_) => f.write_str(&"VERSION".to_string()),
+            Command::Block(block) => f.write_str(&format!("BLOCK: {}", block.hash())),
+            Command::InventoryAnnouncement(_) => f.write_str(&"INVENTORY_ANNOUNCEMENT".to_string()),
+            Command::InventoryRequest(_) => f.write_str(&"INVENTORY_REQUEST".to_string()),
+            Command::LastBeacon(_) => f.write_str(&"LAST_BEACON".to_string()),
+            Command::Transaction(_) => f.write_str(&"TRANSACTION".to_string()),
+        }
     }
 }
 


### PR DESCRIPTION
Modified Display for Command to add block hash to `Block` message
Divided last_beacon handler in outbound and inbound to send `last_beacon` messages to allow synchronization and reach mine flag enabling
Specified `SYNCED_INTERVAL` to at least 2 epochs to ensure synchronization
Request previous block in case of synced blockchain to do not lose 1 block (no recursive)
Added `candidate_to_validate` to keep the last block candidate to ensure synchronization. It will substitute to `blocks_to_validate`
Added synced flag and modified mine flag enable condition to avoid forks
Added a temporally solution to disable mine flag in case of not have a minimum number of outbounds