### PR TITLE
feat(core): disable communication between nodes with different consensus constants

### DIFF
--- a/core/src/actors/chain_manager/actor.rs
+++ b/core/src/actors/chain_manager/actor.rs
@@ -132,22 +132,22 @@ impl ChainManager {
                                 };
                                 debug!("ChainInfo successfully obtained from storage");
                             } else {
-                                // Mismatching environment names between config and storage
+                                // Mismatching consensus constants between config and storage
                                 panic!(
-                                    "Mismatching environments: tried to run a node on environment \
-                                     \"{:?}\" with a chain that was initialized with environment \
-                                     \"{:?}\".",
-                                    environment, chain_info_from_storage.environment
-                                );
-                            }
-                        } else {
-                            // Mismatching consensus constants between config and storage
-                            panic!(
-                                "Mismatching consensus constants: tried to run a node using \
+                                    "Mismatching consensus constants: tried to run a node using \
                                  different consensus constants than the ones that were used when \
                                  the local chain was initialized.\nNode constants: {:#?}\nChain \
                                  constants: {:#?}",
-                                consensus_constants, chain_info_from_storage.consensus_constants
+                                    consensus_constants, chain_info_from_storage.consensus_constants
+                                );
+                            }
+                        } else {
+                            // Mismatching environment names between config and storage
+                            panic!(
+                                "Mismatching environments: tried to run a node on environment \
+                                 \"{:?}\" with a chain that was initialized with environment \
+                                 \"{:?}\".",
+                                environment, chain_info_from_storage.environment
                             );
                         }
                     } else {

--- a/core/src/actors/session/actor.rs
+++ b/core/src/actors/session/actor.rs
@@ -71,8 +71,12 @@ impl Actor for Session {
                 // Send version if outbound session
                 if let SessionType::Outbound = act.session_type {
                     // FIXME(#142): include the checkpoint of the current tip of the local blockchain
-                    let version_msg =
-                        WitnetMessage::build_version(act.server_addr, act.remote_addr, 0);
+                    let version_msg = WitnetMessage::build_version(
+                        act.magic_number,
+                        act.server_addr,
+                        act.remote_addr,
+                        0,
+                    );
                     act.send_message(version_msg);
                     // Set HandshakeFlag of sent version message
                     act.handshake_flags.version_tx = true;

--- a/core/src/actors/session/handlers.rs
+++ b/core/src/actors/session/handlers.rs
@@ -60,6 +60,20 @@ impl StreamHandler<BytesMut, Error> for Session {
                     self.remote_addr,
                 );
                 trace!("\t{:?}", msg);
+
+                // Consensus constants validation between nodes
+                if msg.magic != self.magic_number {
+                    error!(
+                        "Mismatching consensus constants. \
+                         Magic number received: {}, Ours: {}",
+                        msg.magic, self.magic_number
+                    );
+
+                    // Stop this session
+                    ctx.stop();
+                    return;
+                }
+
                 match (self.session_type, self.status, msg.kind) {
                     ////////////////////
                     //   HANDSHAKE    //

--- a/core/src/actors/session/mod.rs
+++ b/core/src/actors/session/mod.rs
@@ -66,6 +66,9 @@ pub struct Session {
 
     /// Remote sender address
     remote_sender_addr: Option<SocketAddr>,
+
+    /// Magic number
+    magic_number: u16,
 }
 
 /// Session helper methods
@@ -77,6 +80,7 @@ impl Session {
         session_type: SessionType,
         framed: FramedWrite<WriteHalf<TcpStream>, P2PCodec>,
         handshake_timeout: Duration,
+        magic_number: u16,
     ) -> Session {
         Session {
             server_addr,
@@ -87,6 +91,7 @@ impl Session {
             status: SessionStatus::Unconsolidated,
             handshake_flags: HandshakeFlags::default(),
             remote_sender_addr: None,
+            magic_number,
         }
     }
     /// Method to send a Witnet message to the remote peer

--- a/core/src/actors/sessions_manager/handlers.rs
+++ b/core/src/actors/sessions_manager/handlers.rs
@@ -32,6 +32,9 @@ impl Handler<Create> for SessionsManager {
         // Get server address
         let server_addr = self.sessions.server_address;
 
+        // Get magic number
+        let magic_number = self.sessions.magic_number;
+
         // Create a Session actor
         Session::create(move |ctx| {
             // Get server address (if not present, send local address instead)
@@ -53,6 +56,7 @@ impl Handler<Create> for SessionsManager {
                 msg.session_type,
                 FramedWrite::new(w, P2PCodec, ctx),
                 handshake_timeout,
+                magic_number,
             )
         });
     }

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -47,8 +47,9 @@ impl Default for Environment {
 }
 
 /// Consensus-critical configuration
-#[derive(PartialStruct, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(PartialStruct, Debug, Clone, PartialEq, Serialize, Deserialize, ProtobufConvert)]
 #[partial_struct(derive(Deserialize, Default, Debug, Clone, PartialEq))]
+#[protobuf_convert(pb = "witnet::ConsensusConstants")]
 pub struct ConsensusConstants {
     /// Timestamp at checkpoint 0 (the start of epoch 0)
     pub checkpoint_zero_timestamp: i64,

--- a/data_structures/src/types.rs
+++ b/data_structures/src/types.rs
@@ -98,7 +98,6 @@ pub struct Version {
     pub receiver_address: Address,
     pub user_agent: String,
     pub last_epoch: u32,
-    pub genesis: u64,
     pub nonce: u64,
 }
 

--- a/data_structures/tests/builders.rs
+++ b/data_structures/tests/builders.rs
@@ -13,9 +13,12 @@ fn builders_build_last_beacon() {
         kind: Command::LastBeacon(LastBeacon {
             highest_block_checkpoint,
         }),
-        magic: MAGIC,
+        magic: 0xABCD,
     };
-    assert_eq!(msg, Message::build_last_beacon(highest_block_checkpoint));
+    assert_eq!(
+        msg,
+        Message::build_last_beacon(0xABCD, highest_block_checkpoint)
+    );
 }
 
 #[test]
@@ -151,11 +154,11 @@ fn builders_build_block() {
             },
             txns: txns.clone(),
         }),
-        magic: MAGIC,
+        magic: 0xABCD,
     };
 
     // Check that the build_block function builds the expected message
-    assert_eq!(msg, Message::build_block(block_header, proof, txns));
+    assert_eq!(msg, Message::build_block(0xABCD, block_header, proof, txns));
 }
 
 #[test]
@@ -268,11 +271,11 @@ fn builders_build_transaction() {
     // Expected message
     let msg = Message {
         kind: Command::Transaction(txn.clone()),
-        magic: MAGIC,
+        magic: 0xABCD,
     };
 
     // Check that the build_transaction function builds the expected message
-    assert_eq!(msg, Message::build_transaction(txn));
+    assert_eq!(msg, Message::build_transaction(0xABCD, txn));
 }
 
 #[test]
@@ -280,11 +283,11 @@ fn builders_build_get_peers() {
     // Expected message
     let msg = Message {
         kind: Command::GetPeers(GetPeers),
-        magic: MAGIC,
+        magic: 0xABCD,
     };
 
     // Check that the build_get_peers function builds the expected message
-    assert_eq!(msg, Message::build_get_peers());
+    assert_eq!(msg, Message::build_get_peers(0xABCD));
 }
 
 #[test]
@@ -298,14 +301,14 @@ fn builders_build_peers() {
     addresses.push(address);
     let msg = Message {
         kind: Command::Peers(Peers { peers: addresses }),
-        magic: MAGIC,
+        magic: 0xABCD,
     };
 
     // Build vector of socket addresses
     let sock_addresses: Vec<SocketAddr> = vec!["192.168.1.1:8000".parse().unwrap()];
 
     // Check that the build_peers function builds the expected message
-    assert_eq!(msg, Message::build_peers(&sock_addresses));
+    assert_eq!(msg, Message::build_peers(0xABCD, &sock_addresses));
 }
 
 #[test]
@@ -313,11 +316,11 @@ fn builders_build_ping() {
     // Expected message (except nonce which is random)
     let msg = Message {
         kind: Command::Ping(Ping { nonce: 1234 }),
-        magic: MAGIC,
+        magic: 0xABCD,
     };
 
     // Build message
-    let built_msg = Message::build_ping();
+    let built_msg = Message::build_ping(0xABCD);
 
     // Check that the build_ping function builds the expected message
     assert_eq!(built_msg.magic, msg.magic);
@@ -333,11 +336,11 @@ fn builders_build_pong() {
     let nonce = 1234;
     let msg = Message {
         kind: Command::Pong(Pong { nonce }),
-        magic: MAGIC,
+        magic: 0xABCD,
     };
 
     // Check that the build_pong function builds the expected message
-    assert_eq!(msg, Message::build_pong(nonce));
+    assert_eq!(msg, Message::build_pong(0xABCD, nonce));
 }
 
 #[test]
@@ -360,19 +363,22 @@ fn builders_build_version() {
         receiver_address: receiver_addr,
         user_agent: USER_AGENT.to_string(),
         last_epoch: hardcoded_last_epoch,
-        genesis: GENESIS,
         nonce: 1234,
     });
     let msg = Message {
         kind: version_cmd,
-        magic: MAGIC,
+        magic: 0xABCD,
     };
 
     // Build message
     let sender_sock_addr = "192.168.1.1:8000".parse().unwrap();
     let receiver_sock_addr = "192.168.1.2:8001".parse().unwrap();
-    let built_msg =
-        Message::build_version(sender_sock_addr, receiver_sock_addr, hardcoded_last_epoch);
+    let built_msg = Message::build_version(
+        0xABCD,
+        sender_sock_addr,
+        receiver_sock_addr,
+        hardcoded_last_epoch,
+    );
 
     // Check that the build_version function builds the expected message
     assert_eq!(built_msg.magic, msg.magic);
@@ -385,15 +391,13 @@ fn builders_build_version() {
             receiver_address,
             user_agent,
             last_epoch,
-            genesis,
             nonce: _,
         }) if *version == PROTOCOL_VERSION
             && *capabilities == CAPABILITIES
             && *sender_address == sender_addr
             && *receiver_address == receiver_addr
             && user_agent == USER_AGENT
-            && *last_epoch == hardcoded_last_epoch
-            && *genesis == GENESIS =>
+            && *last_epoch == hardcoded_last_epoch =>
         {
             assert!(true)
         }
@@ -406,11 +410,11 @@ fn builders_build_verack() {
     // Expected message
     let msg = Message {
         kind: Command::Verack(Verack),
-        magic: MAGIC,
+        magic: 0xABCD,
     };
 
     // Check that the build_verack function builds the expected message
-    assert_eq!(msg, Message::build_verack());
+    assert_eq!(msg, Message::build_verack(0xABCD));
 }
 
 #[test]
@@ -428,13 +432,13 @@ fn builders_build_inventory_announcement() {
     // InventoryAnnouncement message
     let msg = Message {
         kind: inv_cmd,
-        magic: MAGIC,
+        magic: 0xABCD,
     };
 
     // Check that the build_inventory_announcement function builds the expected message
     assert_eq!(
         msg,
-        Message::build_inventory_announcement(inventory).unwrap()
+        Message::build_inventory_announcement(0xABCD, inventory).unwrap()
     );
 }
 
@@ -453,9 +457,12 @@ fn builders_build_inventory_request() {
     // Inventory message
     let msg = Message {
         kind: inv_req_cmd,
-        magic: MAGIC,
+        magic: 0xABCD,
     };
 
     // Check that the build_inv function builds the expected message
-    assert_eq!(msg, Message::build_inventory_request(inventory).unwrap());
+    assert_eq!(
+        msg,
+        Message::build_inventory_request(0xABCD, inventory).unwrap()
+    );
 }

--- a/data_structures/tests/serializers.rs
+++ b/data_structures/tests/serializers.rs
@@ -270,15 +270,14 @@ fn message_version_to_bytes() {
             receiver_address: receiver_address,
             user_agent: "asdf".to_string(),
             last_epoch: 8,
-            genesis: 2,
             nonce: 1,
         }),
         magic: 1,
     };
     let expected_buf: Vec<u8> = [
-        8, 1, 18, 64, 10, 62, 8, 2, 16, 123, 25, 4, 0, 0, 0, 0, 0, 0, 0, 34, 8, 10, 6, 192, 168, 1,
+        8, 1, 18, 55, 10, 53, 8, 2, 16, 123, 25, 4, 0, 0, 0, 0, 0, 0, 0, 34, 8, 10, 6, 192, 168, 1,
         1, 31, 64, 42, 8, 10, 6, 192, 168, 1, 2, 31, 65, 50, 4, 97, 115, 100, 102, 61, 8, 0, 0, 0,
-        65, 2, 0, 0, 0, 0, 0, 0, 0, 73, 1, 0, 0, 0, 0, 0, 0, 0,
+        65, 1, 0, 0, 0, 0, 0, 0, 0,
     ]
     .to_vec();
     let result: Vec<u8> = msg.to_pb_bytes().unwrap();
@@ -305,15 +304,15 @@ fn message_version_from_bytes() {
             receiver_address: receiver_address,
             user_agent: "asdf".to_string(),
             last_epoch: 8,
-            genesis: 2,
             nonce: 1,
         }),
         magic: 1,
     };
+
     let buf: Vec<u8> = [
-        8, 1, 18, 64, 10, 62, 8, 2, 16, 123, 25, 4, 0, 0, 0, 0, 0, 0, 0, 34, 8, 10, 6, 192, 168, 1,
+        8, 1, 18, 55, 10, 53, 8, 2, 16, 123, 25, 4, 0, 0, 0, 0, 0, 0, 0, 34, 8, 10, 6, 192, 168, 1,
         1, 31, 64, 42, 8, 10, 6, 192, 168, 1, 2, 31, 65, 50, 4, 97, 115, 100, 102, 61, 8, 0, 0, 0,
-        65, 2, 0, 0, 0, 0, 0, 0, 0, 73, 1, 0, 0, 0, 0, 0, 0, 0,
+        65, 1, 0, 0, 0, 0, 0, 0, 0,
     ]
     .to_vec();
 
@@ -339,7 +338,6 @@ fn message_version_encode_decode() {
             receiver_address: receiver_address,
             user_agent: "asdf".to_string(),
             last_epoch: 8,
-            genesis: 2,
             nonce: 1,
         }),
         magic: 1,

--- a/p2p/src/sessions/mod.rs
+++ b/p2p/src/sessions/mod.rs
@@ -55,6 +55,8 @@ where
     pub outbound_unconsolidated: BoundedSessions<T>,
     /// Handshake timeout
     pub handshake_timeout: Duration,
+    /// Magic number
+    pub magic_number: u16,
 }
 
 /// Default trait implementation
@@ -70,6 +72,7 @@ where
             outbound_consolidated: BoundedSessions::default(),
             outbound_unconsolidated: BoundedSessions::default(),
             handshake_timeout: Duration::default(),
+            magic_number: 0 as u16,
         }
     }
 }
@@ -108,6 +111,10 @@ where
     /// Method to set the handshake timeout
     pub fn set_handshake_timeout(&mut self, handshake_timeout: Duration) {
         self.handshake_timeout = handshake_timeout;
+    }
+    /// Method to set the magic number to build messages
+    pub fn set_magic_number(&mut self, magic_number: u16) {
+        self.magic_number = magic_number;
     }
     /// Method to check if a socket address is eligible as outbound peer
     pub fn is_outbound_address_eligible(&self, candidate_addr: SocketAddr) -> bool {

--- a/partial_struct/src/lib.rs
+++ b/partial_struct/src/lib.rs
@@ -154,6 +154,9 @@ fn get_attributes(orig: &[syn::Attribute]) -> (Vec<syn::Attribute>, Action) {
                     }
                 }
             }
+            Ok(syn::Meta::List(ref meta)) if meta.ident.to_string() == "protobuf_convert" => {
+                // Avoid error that appears when ProtoBuf and PartialStruct are used together
+            }
             _ => attrs.push(attr.clone()),
         }
     }

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -32,8 +32,7 @@ message Version {
     Address receiver_address = 5;
     string user_agent = 6;
     fixed32 last_epoch = 7;
-    fixed64 genesis = 8;
-    fixed64 nonce = 9;
+    fixed64 nonce = 8;
 }
 
 message Verack {

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -233,3 +233,12 @@ message InventoryEntry {
         Hash DataResult = 5;
     }
 }
+
+message ConsensusConstants {
+    int64 checkpoint_zero_timestamp = 1;
+    uint32 checkpoints_period = 2;
+    Hash genesis_hash = 3;
+    double reputation_demurrage = 4;
+    double reputation_punishment = 5;
+    uint32 max_block_weight = 6;
+}


### PR DESCRIPTION
Added a magic number (`u16`) for messages built with the 2 first `u8` of the Sha256 of the `ConsensusConstants`
Added protobuff conversion to `ConsensusConstants`
Added a validation of this number in each message received. Closing communication in case of mismatching magic numbers




Close #307 