### PR TITLE
Add RadonString::hash() operator

### DIFF
--- a/rad/Cargo.toml
+++ b/rad/Cargo.toml
@@ -8,6 +8,7 @@ description = "RAD component"
 
 [dependencies]
 failure = "0.1.5"
+hex = "0.3.2"
 json = "0.11.13"
 log = "0.4.6"
 num-derive = "0.2.4"
@@ -15,6 +16,7 @@ num-traits = "0.2.6"
 reqwest = "0.9.10"
 rmp = "0.8.7"
 rmpv = "0.4.0"
+rust-crypto = "0.2.36"
 witnet_crypto = { path = "../crypto" }
 witnet_data_structures = { path = "../data_structures" }
 witnet_util = { path = "../util" }

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -57,6 +57,8 @@ pub enum RadErrorKind {
     ScriptNotArray,
     /// The given operator code is unknown
     UnknownOperator,
+    /// The given hash function is not implemented
+    UnsupportedHashFunction,
     /// The given operator is not implemented for the input type
     UnsupportedOperator,
     /// The given reducer is not implemented for the type of the input Array

--- a/rad/src/hash_functions/mod.rs
+++ b/rad/src/hash_functions/mod.rs
@@ -1,0 +1,65 @@
+// FIXME: https://github.com/rust-num/num-derive/issues/20
+#![allow(clippy::useless_attribute)]
+
+mod sha2;
+
+use crate::error::*;
+use crate::hash_functions::sha2::sha2_256;
+
+use num_derive::FromPrimitive;
+use std::fmt;
+
+#[derive(Debug, FromPrimitive, PartialEq)]
+pub enum RadonHashFunctions {
+    Fail = -1,
+    Blake256 = 0x00,
+    Blake512 = 0x01,
+    Blake2s256 = 0x02,
+    Blake2b512 = 0x03,
+    MD5_128 = 0x04,
+    Ripemd128 = 0x05,
+    Ripemd160 = 0x06,
+    Ripemd320 = 0x07,
+    SHA1_160 = 0x08,
+    SHA2_224 = 0x09,
+    SHA2_256 = 0x0A,
+    SHA2_384 = 0x0B,
+    SHA2_512 = 0x0C,
+    SHA3_224 = 0x0D,
+    SHA3_256 = 0x0E,
+    SHA3_384 = 0x0F,
+    SHA3_512 = 0x10,
+    Whirlpool512 = 0x11,
+}
+
+impl fmt::Display for RadonHashFunctions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RadonHashFunctions::{:?}", self)
+    }
+}
+
+pub fn hash(input: &[u8], hash_function_code: RadonHashFunctions) -> RadResult<Vec<u8>> {
+    match hash_function_code {
+        RadonHashFunctions::SHA2_256 => sha2_256(input),
+        _ => Err(WitnetError::from(RadError::new(
+            RadErrorKind::UnsupportedHashFunction,
+            format!(
+                "HashFunction {:} is not yet implemented",
+                hash_function_code
+            ),
+        ))),
+    }
+}
+
+#[test]
+fn test_hash() {
+    let input = [72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33];
+    let output_vec = hash(&input, RadonHashFunctions::SHA2_256).unwrap();
+    let output_slice = output_vec.as_slice();
+    let expected = &[
+        223, 253, 96, 33, 187, 43, 213, 176, 175, 103, 98, 144, 128, 158, 195, 165, 49, 145, 221,
+        129, 199, 247, 10, 75, 40, 104, 138, 54, 33, 130, 152, 111,
+    ];
+
+    assert_eq!(output_slice, expected);
+}

--- a/rad/src/hash_functions/sha2.rs
+++ b/rad/src/hash_functions/sha2.rs
@@ -1,0 +1,25 @@
+use crate::error::RadResult;
+
+use crypto::{digest::Digest, sha2};
+
+pub fn sha2_256(input: &[u8]) -> RadResult<Vec<u8>> {
+    let mut hash_function = sha2::Sha256::new();
+    hash_function.input(input);
+    let mut digest = [0; 32];
+    hash_function.result(&mut digest);
+
+    Ok(digest.to_vec())
+}
+
+#[test]
+fn test_sha2_256() {
+    let input = [72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33];
+    let output_vec = sha2_256(&input).unwrap();
+    let output_slice = output_vec.as_slice();
+    let expected = &[
+        223, 253, 96, 33, 187, 43, 213, 176, 175, 103, 98, 144, 128, 158, 195, 165, 49, 145, 221,
+        129, 199, 247, 10, 75, 40, 104, 138, 54, 33, 130, 152, 111,
+    ];
+
+    assert_eq!(output_slice, expected);
+}

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -12,6 +12,7 @@ use crate::script::{execute_radon_script, unpack_radon_script};
 use crate::types::{array::RadonArray, string::RadonString, RadonTypes};
 
 pub mod error;
+pub mod hash_functions;
 pub mod operators;
 pub mod reducers;
 pub mod script;


### PR DESCRIPTION
- Adds a new `hash_functions` module to the RADON engine
- Adds support for `RadonString::hash`, which automatically serializes the digest as hexadecimal lowercase
- Every each of the functions that have been added has its own test
- The only hash function currently implemented is `SHA2_256` (RADON constant `0x0A`)
- In the future we may add support for `RadonArray::hash` or even `RadonBinary::hash` if we decide to support a native bytearray-alike type, which now has started to make more sense to me.