### PR TITLE
fix(data_structures): block hash should only depend on block header

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -175,7 +175,7 @@ impl<'a, T: Hashable> Hashable for &'a T {
 
 impl Hashable for Block {
     fn hash(&self) -> Hash {
-        calculate_sha256(&self.to_pb_bytes().unwrap()).into()
+        calculate_sha256(&self.block_header.to_pb_bytes().unwrap()).into()
     }
 }
 
@@ -1428,7 +1428,7 @@ mod tests {
             proof,
             txns,
         };
-        let expected = "2972d0fb3e40ecfc8c771aadfb68070b4b1f7f2c2b371b628d58b5634d1ce2c4";
+        let expected = "41d36ff16318f17350b0f0a74afb907bda00b89035d12ccede8ca404a4afb1c0";
         assert_eq!(block.hash().to_string(), expected);
     }
 

--- a/data_structures/src/tests.rs
+++ b/data_structures/src/tests.rs
@@ -123,7 +123,7 @@ fn test_block_hashable_trait() {
         proof,
         txns,
     };
-    let expected = "2972d0fb3e40ecfc8c771aadfb68070b4b1f7f2c2b371b628d58b5634d1ce2c4";
+    let expected = "41d36ff16318f17350b0f0a74afb907bda00b89035d12ccede8ca404a4afb1c0";
     assert_eq!(block.hash().to_string(), expected);
 }
 

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -72,6 +72,9 @@ impl ChainManager {
         let sign = |x, _k| match x {
             Hash::SHA256(mut x) => {
                 // Add some randomness to the signature
+                // TODO: since the hash of the block depends only on the block header,
+                // this does not change the hash. Therefore, until we implement signatures,
+                // all the nodes will always mine blocks with the same hash.
                 x[0] = self.random as u8;
                 x
             }


### PR DESCRIPTION
Fix #462 