### PR TITLE
Make witnet-rad module use Failure properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@ name = "MacTypes-sys"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -13,12 +13,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "actix_derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -42,12 +42,12 @@ source = "git+https://github.com/actix/actix.git?rev=d28d286ac652f81e72c2aa413e7
 dependencies = [
  "actix_derive 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -71,7 +71,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -141,7 +141,7 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -158,8 +158,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -170,7 +170,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -188,22 +188,23 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.43.2"
+version = "0.47.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -284,7 +285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -309,7 +310,7 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -328,7 +329,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -365,7 +366,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -373,15 +374,15 @@ name = "core-foundation-sys"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -417,7 +418,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -431,7 +432,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -451,7 +452,7 @@ name = "crossbeam-utils"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -459,7 +460,7 @@ name = "crossbeam-utils"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -511,7 +512,7 @@ name = "directories"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -545,7 +546,7 @@ name = "encoding_rs"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -562,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -593,7 +594,7 @@ name = "exonum-build"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protoc-rust 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-rust 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -613,7 +614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -718,7 +719,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -745,6 +746,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hmac"
@@ -780,7 +786,7 @@ name = "hostname"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -789,7 +795,7 @@ name = "http"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -812,7 +818,7 @@ name = "hyper"
 version = "0.12.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -839,7 +845,7 @@ name = "hyper-tls"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -866,7 +872,7 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -917,7 +923,7 @@ name = "jsonrpc-server-utils"
 version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "globset 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -925,7 +931,7 @@ dependencies = [
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -958,7 +964,7 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "target 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -987,17 +993,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.49"
+version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libflate"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1011,14 +1017,13 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "5.14.3"
+version = "5.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bindgen 0.43.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bindgen 0.47.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
- "make-cmd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1053,7 +1058,7 @@ name = "log"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1063,11 +1068,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "make-cmd"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "matches"
@@ -1089,7 +1089,7 @@ name = "mime"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1113,7 +1113,7 @@ dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1138,7 +1138,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1159,7 +1159,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1175,8 +1175,8 @@ name = "net2"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1187,8 +1187,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1213,7 +1213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1242,7 +1242,7 @@ name = "num_cpus"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1264,10 +1264,10 @@ version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1282,7 +1282,7 @@ version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1302,7 +1302,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1327,7 +1327,7 @@ name = "parking_lot_core"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1340,7 +1340,7 @@ version = "0.1.2"
 dependencies = [
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1405,14 +1405,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1421,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1430,10 +1422,10 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1443,12 +1435,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "protoc"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1456,12 +1448,12 @@ dependencies = [
 
 [[package]]
 name = "protoc-rust"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf-codegen 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1469,14 +1461,6 @@ dependencies = [
 name = "quick-error"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "quote"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "quote"
@@ -1491,7 +1475,7 @@ name = "rand"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1501,7 +1485,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1514,7 +1498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1525,13 +1509,13 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1580,19 +1564,19 @@ name = "rand_jitter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_os"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1632,7 +1616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1687,17 +1671,17 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libflate 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libflate 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1746,8 +1730,8 @@ name = "rocksdb"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb-sys 5.14.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "librocksdb-sys 5.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1756,7 +1740,7 @@ version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1818,7 +1802,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1828,7 +1812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1839,7 +1823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "MacTypes-sys 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1870,7 +1854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1928,7 +1912,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1951,8 +1935,8 @@ name = "socket2"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1974,22 +1958,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "structopt"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt-derive 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "structopt-derive"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1999,7 +1983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.27"
+version = "0.15.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2014,7 +1998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2037,8 +2021,8 @@ name = "tempfile"
 version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2058,7 +2042,7 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2084,7 +2068,7 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2105,7 +2089,7 @@ name = "tokio"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2128,7 +2112,7 @@ name = "tokio-codec"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2138,7 +2122,7 @@ name = "tokio-core"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2184,7 +2168,7 @@ name = "tokio-io"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2213,7 +2197,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2237,7 +2221,7 @@ name = "tokio-tcp"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2277,7 +2261,7 @@ name = "tokio-udp"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2291,10 +2275,10 @@ name = "tokio-uds"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2362,7 +2346,7 @@ name = "trust-dns-resolver"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipconfig 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2400,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2502,10 +2486,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "1.0.5"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2582,13 +2567,13 @@ dependencies = [
  "bytecount 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "just 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_config 0.1.2",
  "witnet_crypto 0.1.2",
@@ -2628,7 +2613,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "partial_struct 0.1.2",
- "protobuf 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-convert 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2645,7 +2630,7 @@ dependencies = [
  "actix 0.7.10 (git+https://github.com/actix/actix.git?rev=d28d286ac652f81e72c2aa413e7c0d3fc6c6099c)",
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2679,13 +2664,15 @@ name = "witnet_rad"
 version = "0.1.2"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.11.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmpv 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_crypto 0.1.2",
  "witnet_data_structures 0.1.2",
  "witnet_util 0.1.2",
@@ -2695,7 +2682,7 @@ dependencies = [
 name = "witnet_storage"
 version = "0.1.2"
 dependencies = [
- "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2719,7 +2706,7 @@ dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-jsonrpc-client 0.1.0 (git+https://github.com/witnet/async-jsonrpc-client)",
  "bip39 0.6.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2760,7 +2747,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum bindgen 0.43.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d52d263eacd15d26cbcf215d254b410bd58212aaa2d3c453a04b2d3b3adcf41"
+"checksum bindgen 0.47.3 (registry+https://github.com/rust-lang/crates.io-index)" = "df683a55b54b41d5ea8ebfaebb5aa7e6b84e3f3006a78f010dadc9ca88469260"
 "checksum bip39 0.6.0-beta.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7059804e226b3ac116519a252d7f5fb985a5ccc0e93255e036a5f7e7283323f4"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block-buffer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1339a1042f5d9f295737ad4d9a6ab6bf81c84a933dba110b9200cd6d1448b814"
@@ -2771,10 +2758,10 @@ dependencies = [
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum bytecount 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be0fdd54b507df8f22012890aadd099979befdba27713c767993f8380112ca7c"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
-"checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
+"checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cc 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)" = "d01c69d08ff207f231f07196e30f84c70f1c815b04f980f8b7b01ff01f05eb92"
 "checksum cexpr 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "644d693ecfa91955ed32dcc7eda4914e1be97a641fb6f0645a37348e20b230da"
-"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ef0c1bcf2e99c649104bd7a7012d8f8802684400e03db0ec0af48583c6fa0e4"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
@@ -2782,7 +2769,7 @@ dependencies = [
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
-"checksum crc32fast 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e91d5240c6975ef33aeb5f148f35275c25eda8e8a5f95abe421978b05b8bf192"
+"checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0f0ed1a4de2235cabda8558ff5840bffb97fcb64c97827f354a451307df5f72b"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
@@ -2803,7 +2790,7 @@ dependencies = [
 "checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
-"checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
+"checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
 "checksum exonum-build 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9347df5a2daa4bef24658c6a84cfd33dddca0ffb27647bd281fcc96c5810a09a"
@@ -2826,6 +2813,7 @@ dependencies = [
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+"checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hmac 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a13f4163aa0c5ca1be584aace0e2212b2e41be5478218d4f657f5f778b2ae2a"
 "checksum hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f127a908633569f208325f86f71255d3363c79721d7f9fe31cd5569908819771"
 "checksum hmac-drbg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fe727d41d2eec0a6574d887914347e5ff96a3b87177817e2a9820c5c87fecc2"
@@ -2849,16 +2837,15 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
-"checksum libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)" = "413f3dfc802c5dc91dc570b05125b6cda9855edfaa9825c9849807876376e70e"
-"checksum libflate 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "54d1ddf9c52870243c5689d7638d888331c1116aa5b398f3ba1acfa7d8758ca1"
+"checksum libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1"
+"checksum libflate 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "7346a83e8a2c3958d44d24225d905385dc31fc16e89dffb356c457b278914d20"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
-"checksum librocksdb-sys 5.14.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b9024327233e7fac7982440f73301c00046d438c5b1011e8f4e394226ce19007"
+"checksum librocksdb-sys 5.17.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfb546562f9b450237bb8df7a31961849ee9fb1186d9e356db1d7a6b7609ff2"
 "checksum libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "688e8d65e495567c2c35ea0001b26b9debf0b4ea11f8cccc954233b75fc3428a"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
-"checksum make-cmd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8ca8afbe8af1785e09636acb5a41e08a765f5f0340568716c18a8700ba3c0d3"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
@@ -2895,15 +2882,13 @@ dependencies = [
 "checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
-"checksum proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "77997c53ae6edd6d187fec07ec41b207063b5ee6f33680e9fa86d405cdd313d4"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
-"checksum protobuf 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d82d117bc7565ce6be0150159251c9b1eeec7b129f5a2aa86e10acb5970de1cb"
-"checksum protobuf-codegen 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f25bf531a031dd128d4e7285401caed1038d4f732b56bb1d99f02bdad4ad125"
+"checksum protobuf 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24d5d73d2b88fddb8b8141f2730d950d88772c940ac4f8f3e93230b9a99d92df"
+"checksum protobuf-codegen 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc1ef231350d13cb261717a1223ac43c1e93c9b3180535920c1a9cc51f80567"
 "checksum protobuf-convert 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "19a91378966251c8437a559fad7a8c0d5356d5633e79dc68b912e98347644378"
-"checksum protoc 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6762f5a05f41eb6252606fc6553262a025e72c51a0227717990998fd9c2ac81"
-"checksum protoc-rust 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dad6667dc189ae21a1f650ba07ce512dda5f6ba78e494decf40455c9644c170f"
+"checksum protoc 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8b83cbfb699626e2670de2aab558c34a51bd9bd25a2d3e79b4b09d05b660e8"
+"checksum protoc-rust 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0da864ed371444d5d162a8666f8f3e49afdff6e0cccfd2fc8c201d703652f0e9"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -2915,7 +2900,7 @@ dependencies = [
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
 "checksum rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"
-"checksum rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7c690732391ae0abafced5015ffb53656abfaec61b342290e5eb56b286a679d"
+"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473"
@@ -2926,7 +2911,7 @@ dependencies = [
 "checksum regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53ee8cfdddb2e0291adfb9f13d31d3bbe0a03c9a402c01b1e24188d86c35b24f"
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum reqwest 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "f205a95638627fc0d21c53901671b06f439dc2830311ff11ecdff34ae2d839a8"
+"checksum reqwest 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e542d9f077c126af32536b6aacc75bb7325400eab8cd0743543be5d91660780d"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
 "checksum rmpv 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29af0205707de955a396a1d3c657677c65f791ebabb63c0596c0b2fec0bf6325"
@@ -2960,10 +2945,10 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "670ad348dc73012fcf78c71f06f9d942232cdd4c859d4b6975e27836c3efc0c3"
-"checksum structopt-derive 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ef98172b1a00b0bec738508d3726540edcbd186d50dfd326f2b1febbb3559f04"
+"checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
+"checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-"checksum syn 0.15.27 (registry+https://github.com/rust-lang/crates.io-index)" = "525bd55255f03c816e5d7f615587bd13030c7103354fadb104993dcee6a788ec"
+"checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum target 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "10000465bb0cc031c87a44668991b284fd84c0e6bd945f62d4af04e9e52a222a"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
@@ -2997,7 +2982,7 @@ dependencies = [
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-"checksum unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90"
+"checksum unicase 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41d17211f887da8e4a70a45b9536f26fc5de166b81e2d5d80de4a17fd22553bd"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
@@ -3012,7 +2997,7 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
-"checksum which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"
+"checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -21,7 +21,7 @@ use witnet_p2p::{
     peers::error::PeersResult,
     sessions::{error::SessionsResult, SessionStatus, SessionType},
 };
-use witnet_rad::error::RadResult;
+use witnet_rad::error::RadError;
 use witnet_storage::{error::StorageResult, storage::Storable};
 
 use super::{
@@ -347,11 +347,11 @@ pub struct RunConsensus {
 }
 
 impl Message for ResolveRA {
-    type Result = RadResult<Vec<u8>>;
+    type Result = Result<Vec<u8>, RadError>;
 }
 
 impl Message for RunConsensus {
-    type Result = RadResult<Vec<u8>>;
+    type Result = Result<Vec<u8>, RadError>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/rad/Cargo.toml
+++ b/rad/Cargo.toml
@@ -8,6 +8,7 @@ description = "RAD component"
 
 [dependencies]
 failure = "0.1.5"
+hex = "0.3.2"
 json = "0.11.13"
 log = "0.4.6"
 num-derive = "0.2.4"
@@ -15,6 +16,7 @@ num-traits = "0.2.6"
 reqwest = "0.9.10"
 rmp = "0.8.7"
 rmpv = "0.4.0"
+rust-crypto = "0.2.36"
 witnet_crypto = { path = "../crypto" }
 witnet_data_structures = { path = "../data_structures" }
 witnet_util = { path = "../util" }

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -57,6 +57,8 @@ pub enum RadErrorKind {
     ScriptNotArray,
     /// The given operator code is unknown
     UnknownOperator,
+    /// The given hash function is not implemented
+    UnsupportedHashFunction,
     /// The given operator is not implemented for the input type
     UnsupportedOperator,
     /// The given reducer is not implemented for the type of the input Array

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -8,16 +8,10 @@ use rmpv::{Integer, Value};
 pub enum RadError {
     /// Failed to decode a type from other
     #[fail(display = "Failed to decode {} from {}", to, from)]
-    Decode {
-        from: &'static str,
-        to: &'static str,
-    },
+    Decode { from: String, to: String },
     /// Failed to encode a type into other
     #[fail(display = "Failed to encode {} into {}", from, to)]
-    Encode {
-        from: &'static str,
-        to: &'static str,
-    },
+    Encode { from: String, to: String },
     /// Failed to calculate the hash of a RADON value or structure
     #[fail(display = "Failed to calculate the hash of a RADON value or structure")]
     Hash,

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -1,89 +1,100 @@
 //! Error type definitions for the RAD module.
 
-use reqwest;
+use failure::{self, Fail};
+use rmpv::{Integer, Value};
 
-use failure::Fail;
-use std::fmt;
-pub use witnet_util::error::{WitnetError, WitnetResult};
-
-/// RAD Error
+/// RAD errors.
 #[derive(Debug, PartialEq, Fail)]
-#[fail(display = "{} : {}", kind, msg)]
-pub struct RadError {
-    /// Error kind.
-    kind: RadErrorKind,
-    /// Error message (likely passed from the originating exception).
-    msg: String,
-}
-
-impl RadError {
-    /// Create a RAD error based on error kind, context and message.
-    pub fn new(kind: RadErrorKind, msg: String) -> Self {
-        Self { kind, msg }
-    }
-
-    /// Query the specific RadErrorKind case for a RadError
-    pub fn kind(&self) -> &RadErrorKind {
-        &self.kind
-    }
+pub enum RadError {
+    /// Failed to decode a type from other
+    #[fail(display = "Failed to decode {} from {}", from, to)]
+    Decode {
+        from: &'static str,
+        to: &'static str,
+    },
+    /// Failed to encode a type into other
+    #[fail(display = "Failed to encode {} into {}", from, to)]
+    Encode {
+        from: &'static str,
+        to: &'static str,
+    },
+    /// Failed to calculate the hash of a RADON value or structure
+    #[fail(display = "Failed to calculate the hash of a RADON value or structure")]
+    Hash,
+    /// Failed to parse an object from a JSON buffer
+    #[fail(
+        display = "Failed to parse an object from a JSON buffer: {:?}",
+        description
+    )]
+    JsonParse { description: String },
+    /// The given key is not present in a RadonMap
+    #[fail(display = "Failed to get key `{}` from RadonMap", key)]
+    MapKeyNotFound { key: String },
+    /// Failed to parse a Value from a MessagePack buffer
+    #[fail(
+        display = "Failed to parse a Value from a MessagePack buffer. Error message: {}",
+        description
+    )]
+    MessagePack { description: String },
+    /// No operator found in compound call
+    #[fail(display = "No operator found in compound call")]
+    NoOperatorInCompoundCall,
+    /// The given operator code is not a valid Integer
+    #[fail(display = "Operator code `{}` is not a valid Integer", code)]
+    NotIntegerOperator { code: Box<Value> },
+    /// The given operator code is not a valid natural number
+    #[fail(display = "Operator code `{}` is not a valid natural number", code)]
+    NotNaturalOperator { code: Integer },
+    /// The parsed value was expected to be a script but is not even an Array
+    #[fail(
+        display = "The parsed value was expected to be a script but is not even an Array (it was a `{}`)",
+        input_type
+    )]
+    ScriptNotArray { input_type: String },
+    /// The given operator code is unknown
+    #[fail(display = "Operator code `{}` is unknown", code)]
+    UnknownOperator { code: u64 },
+    /// The given hash function is not implemented
+    #[fail(display = "Hash function `{}` is not implemented", function)]
+    UnsupportedHashFunction { function: String },
+    /// The given operator is not implemented for the input type
+    #[fail(
+        display = "Call to operator `{}` with args `{:?}` is not supported for input type `{}`",
+        input_type, args, operator
+    )]
+    UnsupportedOperator {
+        input_type: String,
+        operator: String,
+        args: Option<Vec<Value>>,
+    },
+    /// The given reducer is not implemented for the type of the input Array
+    #[fail(
+        display = "Reducer `{}` is not implemented for Array with inner type `{}`",
+        reducer, inner_type
+    )]
+    UnsupportedReducer { inner_type: String, reducer: String },
+    /// The given arguments are not valid for the given operator
+    #[fail(
+        display = "Wrong `{}::{}()` arguments: `{:?}`",
+        input_type, operator, args
+    )]
+    WrongArguments {
+        input_type: String,
+        operator: String,
+        args: Vec<Value>,
+    },
+    /// Failed to execute HTTP request
+    #[fail(
+        display = "Failed to execute HTTP request with error message: {}",
+        message
+    )]
+    Http { message: String },
 }
 
 impl From<reqwest::Error> for RadError {
-    fn from(x: reqwest::Error) -> RadError {
-        RadError::new(RadErrorKind::Http, x.to_string())
+    fn from(err: reqwest::Error) -> RadError {
+        RadError::Http {
+            message: err.to_string(),
+        }
     }
 }
-
-/// RAD errors.
-#[derive(Debug, PartialEq)]
-pub enum RadErrorKind {
-    /// Failed to encode or decode a RADON type into / from bytes
-    EncodeDecode,
-    /// Failed to calculate the hash of a RADON value or structure
-    Hash,
-    /// Failed to parse an object from a JSON buffer
-    JsonParse,
-    /// The given key is not present in a RadonMap
-    MapKeyNotFound,
-    /// Failed to parse a Value from a MessagePack buffer
-    MessagePack,
-    /// No operator found in compound call
-    NoOperatorInCompoundCall,
-    /// The given operator code is not a valid Integer
-    NotIntegerOperator,
-    /// The given operator code is not a valid natural number
-    NotNaturalOperator,
-    /// The parsed value was expected to be a script but is not even an Array
-    ScriptNotArray,
-    /// The given operator code is unknown
-    UnknownOperator,
-    /// The given hash function is not implemented
-    UnsupportedHashFunction,
-    /// The given operator is not implemented for the input type
-    UnsupportedOperator,
-    /// The given reducer is not implemented for the type of the input Array
-    UnsupportedReducer,
-    /// The given arguments are not valid for the given operator
-    WrongArguments,
-    /// Failed to execute HTTP request
-    Http,
-}
-
-impl fmt::Display for RadErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "RadError::{:?}", self)
-    }
-}
-
-/// Result type for the RAD module.
-/// This is the only return type acceptable for any public method in a storage backend.
-pub type RadResult<T> = WitnetResult<T, RadError>;
-
-//impl From<std::option::NoneError> for WitnetError<RadError> {
-//    fn from(error: std::option::NoneError) -> WitnetError<RadError> {
-//        RadError::new(
-//            RadErrorKind::NoneError,
-//            String::from("An Option turned out to be None"),
-//        ).into()
-//    }
-//}

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -7,7 +7,7 @@ use rmpv::{Integer, Value};
 #[derive(Debug, PartialEq, Fail)]
 pub enum RadError {
     /// Failed to decode a type from other
-    #[fail(display = "Failed to decode {} from {}", from, to)]
+    #[fail(display = "Failed to decode {} from {}", to, from)]
     Decode {
         from: &'static str,
         to: &'static str,

--- a/rad/src/hash_functions/mod.rs
+++ b/rad/src/hash_functions/mod.rs
@@ -3,7 +3,7 @@
 
 mod sha2;
 
-use crate::error::*;
+use crate::error::RadError;
 use crate::hash_functions::sha2::sha2_256;
 
 use num_derive::FromPrimitive;
@@ -38,16 +38,12 @@ impl fmt::Display for RadonHashFunctions {
     }
 }
 
-pub fn hash(input: &[u8], hash_function_code: RadonHashFunctions) -> RadResult<Vec<u8>> {
+pub fn hash(input: &[u8], hash_function_code: RadonHashFunctions) -> Result<Vec<u8>, RadError> {
     match hash_function_code {
         RadonHashFunctions::SHA2_256 => sha2_256(input),
-        _ => Err(WitnetError::from(RadError::new(
-            RadErrorKind::UnsupportedHashFunction,
-            format!(
-                "HashFunction {:} is not yet implemented",
-                hash_function_code
-            ),
-        ))),
+        _ => Err(RadError::UnsupportedHashFunction {
+            function: hash_function_code.to_string(),
+        }),
     }
 }
 

--- a/rad/src/hash_functions/mod.rs
+++ b/rad/src/hash_functions/mod.rs
@@ -1,0 +1,65 @@
+// FIXME: https://github.com/rust-num/num-derive/issues/20
+#![allow(clippy::useless_attribute)]
+
+mod sha2;
+
+use crate::error::*;
+use crate::hash_functions::sha2::sha2_256;
+
+use num_derive::FromPrimitive;
+use std::fmt;
+
+#[derive(Debug, FromPrimitive, PartialEq)]
+pub enum RadonHashFunctions {
+    Fail = -1,
+    Blake256 = 0x00,
+    Blake512 = 0x01,
+    Blake2s256 = 0x02,
+    Blake2b512 = 0x03,
+    MD5_128 = 0x04,
+    Ripemd128 = 0x05,
+    Ripemd160 = 0x06,
+    Ripemd320 = 0x07,
+    SHA1_160 = 0x08,
+    SHA2_224 = 0x09,
+    SHA2_256 = 0x0A,
+    SHA2_384 = 0x0B,
+    SHA2_512 = 0x0C,
+    SHA3_224 = 0x0D,
+    SHA3_256 = 0x0E,
+    SHA3_384 = 0x0F,
+    SHA3_512 = 0x10,
+    Whirlpool512 = 0x11,
+}
+
+impl fmt::Display for RadonHashFunctions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RadonHashFunctions::{:?}", self)
+    }
+}
+
+pub fn hash(input: &[u8], hash_function_code: RadonHashFunctions) -> RadResult<Vec<u8>> {
+    match hash_function_code {
+        RadonHashFunctions::SHA2_256 => sha2_256(input),
+        _ => Err(WitnetError::from(RadError::new(
+            RadErrorKind::UnsupportedHashFunction,
+            format!(
+                "HashFunction {:} is not yet implemented",
+                hash_function_code
+            ),
+        ))),
+    }
+}
+
+#[test]
+fn test_hash() {
+    let input = [72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33];
+    let output_vec = hash(&input, RadonHashFunctions::SHA2_256).unwrap();
+    let output_slice = output_vec.as_slice();
+    let expected = &[
+        223, 253, 96, 33, 187, 43, 213, 176, 175, 103, 98, 144, 128, 158, 195, 165, 49, 145, 221,
+        129, 199, 247, 10, 75, 40, 104, 138, 54, 33, 130, 152, 111,
+    ];
+
+    assert_eq!(output_slice, expected);
+}

--- a/rad/src/hash_functions/sha2.rs
+++ b/rad/src/hash_functions/sha2.rs
@@ -1,8 +1,8 @@
-use crate::error::RadResult;
+use crate::error::RadError;
 
 use crypto::{digest::Digest, sha2};
 
-pub fn sha2_256(input: &[u8]) -> RadResult<Vec<u8>> {
+pub fn sha2_256(input: &[u8]) -> Result<Vec<u8>, RadError> {
     let mut hash_function = sha2::Sha256::new();
     hash_function.input(input);
     let mut digest = [0; 32];

--- a/rad/src/hash_functions/sha2.rs
+++ b/rad/src/hash_functions/sha2.rs
@@ -1,0 +1,25 @@
+use crate::error::RadResult;
+
+use crypto::{digest::Digest, sha2};
+
+pub fn sha2_256(input: &[u8]) -> RadResult<Vec<u8>> {
+    let mut hash_function = sha2::Sha256::new();
+    hash_function.input(input);
+    let mut digest = [0; 32];
+    hash_function.result(&mut digest);
+
+    Ok(digest.to_vec())
+}
+
+#[test]
+fn test_sha2_256() {
+    let input = [72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33];
+    let output_vec = sha2_256(&input).unwrap();
+    let output_slice = output_vec.as_slice();
+    let expected = &[
+        223, 253, 96, 33, 187, 43, 213, 176, 175, 103, 98, 144, 128, 158, 195, 165, 49, 145, 221,
+        129, 199, 247, 10, 75, 40, 104, 138, 54, 33, 130, 152, 111,
+    ];
+
+    assert_eq!(output_slice, expected);
+}

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -7,7 +7,7 @@ use witnet_data_structures::{
     serializers::decoders::TryInto,
 };
 
-use crate::error::{RadError, RadResult, WitnetError};
+use crate::error::RadError;
 use crate::script::{execute_radon_script, unpack_radon_script};
 use crate::types::{array::RadonArray, string::RadonString, RadonTypes};
 
@@ -19,13 +19,13 @@ pub mod script;
 pub mod types;
 
 /// Run retrieval stage of a data request.
-pub fn run_retrieval(retrieve: RADRetrieve) -> RadResult<RadonTypes> {
+pub fn run_retrieval(retrieve: RADRetrieve) -> Result<RadonTypes, RadError> {
     match retrieve.kind {
         RADType::HttpGet => {
             let response = reqwest::get(&retrieve.url)
-                .map_err(|err| WitnetError::from(RadError::from(err)))?
+                .map_err(RadError::from)?
                 .text()
-                .map_err(|err| WitnetError::from(RadError::from(err)))?;
+                .map_err(RadError::from)?;
 
             let input = RadonTypes::from(RadonString::from(response));
             let radon_script = unpack_radon_script(&retrieve.script)?;
@@ -36,7 +36,10 @@ pub fn run_retrieval(retrieve: RADRetrieve) -> RadResult<RadonTypes> {
 }
 
 /// Run aggregate stage of a data request.
-pub fn run_aggregation(radon_types_vec: Vec<RadonTypes>, script: Vec<u8>) -> RadResult<Vec<u8>> {
+pub fn run_aggregation(
+    radon_types_vec: Vec<RadonTypes>,
+    script: Vec<u8>,
+) -> Result<Vec<u8>, RadError> {
     let radon_script = unpack_radon_script(&script)?;
 
     let radon_array = RadonArray::from(radon_types_vec);
@@ -48,7 +51,10 @@ pub fn run_aggregation(radon_types_vec: Vec<RadonTypes>, script: Vec<u8>) -> Rad
 }
 
 /// Run consensus stage of a data request.
-pub fn run_consensus(radon_types_vec: Vec<RadonTypes>, script: Vec<u8>) -> RadResult<Vec<u8>> {
+pub fn run_consensus(
+    radon_types_vec: Vec<RadonTypes>,
+    script: Vec<u8>,
+) -> Result<Vec<u8>, RadError> {
     let radon_script = unpack_radon_script(&script)?;
 
     let radon_array = RadonArray::from(radon_types_vec);

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -12,6 +12,7 @@ use crate::script::{execute_radon_script, unpack_radon_script};
 use crate::types::{array::RadonArray, string::RadonString, RadonTypes};
 
 pub mod error;
+pub mod hash_functions;
 pub mod operators;
 pub mod reducers;
 pub mod script;

--- a/rad/src/operators/array.rs
+++ b/rad/src/operators/array.rs
@@ -1,16 +1,15 @@
-use crate::error::*;
+use crate::error::RadError;
 use crate::reducers::{self, RadonReducers};
 use crate::types::{array::RadonArray, RadonTypes};
 
 use num_traits::FromPrimitive;
 use rmpv::Value;
 
-pub fn reduce(input: &RadonArray, args: &[Value]) -> RadResult<RadonTypes> {
-    let error = || {
-        WitnetError::from(RadError::new(
-            RadErrorKind::WrongArguments,
-            format!("Wrong RadonArray reducer arguments: {:?}", args),
-        ))
+pub fn reduce(input: &RadonArray, args: &[Value]) -> Result<RadonTypes, RadError> {
+    let error = || RadError::WrongArguments {
+        input_type: input.to_string(),
+        operator: "Reduce".to_string(),
+        args: args.to_vec(),
     };
 
     let reducer_integer = args.first().ok_or_else(error)?.as_i64().ok_or_else(error)?;
@@ -30,7 +29,7 @@ fn test_reduce_no_args() {
     let args = &[];
 
     let correctness = if let Err(err) = reduce(input, args) {
-        err.inner().kind() == &RadErrorKind::WrongArguments
+        err.inner().kind() == &RadError::WrongArguments
     } else {
         false
     };
@@ -49,7 +48,7 @@ fn test_reduce_wrong_args() {
     let args = &[Value::from("wrong")]; // This is RadonReducers::AverageMean
 
     let correctness = if let Err(err) = reduce(input, args) {
-        err.inner().kind() == &RadErrorKind::WrongArguments
+        err.inner().kind() == &RadError::WrongArguments
     } else {
         false
     };
@@ -68,7 +67,7 @@ fn test_reduce_unknown_reducer() {
     let args = &[Value::from(-1)]; // This doesn't match any reducer code in RadonReducers
 
     let correctness = if let Err(err) = reduce(input, args) {
-        err.inner().kind() == &RadErrorKind::WrongArguments
+        err.inner().kind() == &RadError::WrongArguments
     } else {
         false
     };

--- a/rad/src/operators/array.rs
+++ b/rad/src/operators/array.rs
@@ -28,13 +28,12 @@ fn test_reduce_no_args() {
     ]);
     let args = &[];
 
-    let correctness = if let Err(err) = reduce(input, args) {
-        err.inner().kind() == &RadError::WrongArguments
-    } else {
-        false
-    };
+    let result = reduce(input, args);
 
-    assert!(correctness);
+    assert_eq!(
+        &result.unwrap_err().to_string(),
+        "Wrong `RadonArray::Reduce()` arguments: `[]`"
+    );
 }
 
 #[test]
@@ -47,13 +46,12 @@ fn test_reduce_wrong_args() {
     ]);
     let args = &[Value::from("wrong")]; // This is RadonReducers::AverageMean
 
-    let correctness = if let Err(err) = reduce(input, args) {
-        err.inner().kind() == &RadError::WrongArguments
-    } else {
-        false
-    };
+    let result = reduce(input, args);
 
-    assert!(correctness);
+    assert_eq!(
+        &result.unwrap_err().to_string(),
+        "Wrong `RadonArray::Reduce()` arguments: `[String(Utf8String { s: Ok(\"wrong\") })]`"
+    );
 }
 
 #[test]
@@ -66,13 +64,12 @@ fn test_reduce_unknown_reducer() {
     ]);
     let args = &[Value::from(-1)]; // This doesn't match any reducer code in RadonReducers
 
-    let correctness = if let Err(err) = reduce(input, args) {
-        err.inner().kind() == &RadError::WrongArguments
-    } else {
-        false
-    };
+    let result = reduce(input, args);
 
-    assert!(correctness);
+    assert_eq!(
+        &result.unwrap_err().to_string(),
+        "Wrong `RadonArray::Reduce()` arguments: `[Integer(NegInt(-1))]`"
+    );
 }
 
 #[test]

--- a/rad/src/operators/array.rs
+++ b/rad/src/operators/array.rs
@@ -7,7 +7,7 @@ use rmpv::Value;
 
 pub fn reduce(input: &RadonArray, args: &[Value]) -> Result<RadonTypes, RadError> {
     let error = || RadError::WrongArguments {
-        input_type: input.to_string(),
+        input_type: "RadonArray".to_string(),
         operator: "Reduce".to_string(),
         args: args.to_vec(),
     };

--- a/rad/src/operators/map.rs
+++ b/rad/src/operators/map.rs
@@ -1,28 +1,22 @@
-use crate::error::*;
-use crate::operators::RadonOpCodes;
-use crate::types::map::RadonMap;
-use crate::types::{mixed::RadonMixed, RadonType};
+use crate::error::RadError;
+use crate::types::{map::RadonMap, mixed::RadonMixed, RadonType};
 
 use rmpv::Value;
 
-pub fn get(input: &RadonMap, args: &[Value]) -> RadResult<RadonMixed> {
+pub fn get(input: &RadonMap, args: &[Value]) -> Result<RadonMixed, RadError> {
     let key = args.first().map(|ref value| value.as_str()).unwrap_or(None);
     match key {
         Some(key_str) => match input.value().get(key_str) {
             Some(value) => Ok(value.clone()),
-            None => Err(WitnetError::from(RadError::new(
-                RadErrorKind::MapKeyNotFound,
-                String::from("Failed to get key from RadonMap"),
-            ))),
+            None => Err(RadError::MapKeyNotFound {
+                key: key_str.to_string(),
+            }),
         },
-        None => Err(WitnetError::from(RadError::new(
-            RadErrorKind::WrongArguments,
-            format!(
-                "Call to {:?} with args {:?} is not supported on type RadonString",
-                RadonOpCodes::Get,
-                args
-            ),
-        ))),
+        None => Err(RadError::WrongArguments {
+            input_type: input.to_string(),
+            operator: "Get".to_string(),
+            args: args.to_vec(),
+        }),
     }
 }
 

--- a/rad/src/operators/mixed.rs
+++ b/rad/src/operators/mixed.rs
@@ -1,13 +1,13 @@
 use witnet_data_structures::serializers::decoders::TryFrom;
 
-use crate::error::*;
+use crate::error::RadError;
 use crate::types::{float::RadonFloat, map::RadonMap, mixed::RadonMixed, RadonType};
 
-pub fn to_float(input: RadonMixed) -> Result<RadonFloat, RadError> {
+pub fn to_float<'a>(input: RadonMixed) -> Result<RadonFloat, RadError> {
     RadonFloat::try_from(input.value())
 }
 
-pub fn to_map(input: RadonMixed) -> Result<RadonMap, RadError> {
+pub fn to_map<'a>(input: RadonMixed) -> Result<RadonMap, RadError> {
     RadonMap::try_from(input.value())
 }
 
@@ -22,6 +22,6 @@ fn test_as_float() {
     assert_eq!(to_float(radon_mixed).unwrap(), radon_float);
     assert_eq!(
         to_float(radon_mixed_error).unwrap_err().kind(),
-        &RadErrorKind::EncodeDecode
+        &RadError::EncodeDecode
     );
 }

--- a/rad/src/operators/mixed.rs
+++ b/rad/src/operators/mixed.rs
@@ -21,7 +21,7 @@ fn test_as_float() {
 
     assert_eq!(to_float(radon_mixed).unwrap(), radon_float);
     assert_eq!(
-        to_float(radon_mixed_error).unwrap_err().kind(),
-        &RadError::EncodeDecode
+        &to_float(radon_mixed_error).unwrap_err().to_string(),
+        "Failed to decode rmpv::Value from RadonFloat"
     );
 }

--- a/rad/src/operators/mixed.rs
+++ b/rad/src/operators/mixed.rs
@@ -22,6 +22,6 @@ fn test_as_float() {
     assert_eq!(to_float(radon_mixed).unwrap(), radon_float);
     assert_eq!(
         &to_float(radon_mixed_error).unwrap_err().to_string(),
-        "Failed to decode rmpv::Value from RadonFloat"
+        "Failed to decode RadonFloat from rmpv::Value"
     );
 }

--- a/rad/src/operators/mixed.rs
+++ b/rad/src/operators/mixed.rs
@@ -3,11 +3,11 @@ use witnet_data_structures::serializers::decoders::TryFrom;
 use crate::error::RadError;
 use crate::types::{float::RadonFloat, map::RadonMap, mixed::RadonMixed, RadonType};
 
-pub fn to_float<'a>(input: RadonMixed) -> Result<RadonFloat, RadError> {
+pub fn to_float(input: RadonMixed) -> Result<RadonFloat, RadError> {
     RadonFloat::try_from(input.value())
 }
 
-pub fn to_map<'a>(input: RadonMixed) -> Result<RadonMap, RadError> {
+pub fn to_map(input: RadonMixed) -> Result<RadonMap, RadError> {
     RadonMap::try_from(input.value())
 }
 

--- a/rad/src/operators/mod.rs
+++ b/rad/src/operators/mod.rs
@@ -60,7 +60,7 @@ pub fn operate(input: RadonTypes, call: &RadonCall) -> Result<RadonTypes, RadErr
     }
 }
 
-pub fn identity<'a>(input: RadonTypes) -> Result<RadonTypes, RadError> {
+pub fn identity(input: RadonTypes) -> Result<RadonTypes, RadError> {
     Ok(input)
 }
 

--- a/rad/src/operators/mod.rs
+++ b/rad/src/operators/mod.rs
@@ -1,7 +1,7 @@
 // FIXME: https://github.com/rust-num/num-derive/issues/20
 #![allow(clippy::useless_attribute)]
 
-use crate::error::RadResult;
+use crate::error::RadError;
 use crate::script::RadonCall;
 use crate::types::RadonTypes;
 
@@ -27,6 +27,8 @@ pub enum RadonOpCodes {
     // Float operator codes start at 0x30
     // Null operator codes start at 0x40
     // String operator codes start at 0x50
+    /// Compute the hash of a string
+    Hash = 0x50,
     /// Parse Mixed from JSON string
     ParseJson = 0x53,
     // Array operator codes start at 0x60
@@ -40,15 +42,15 @@ pub enum RadonOpCodes {
 
 impl fmt::Display for RadonOpCodes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "RadonOpCodes::{:?}", self)
+        write!(f, "{:?}", self)
     }
 }
 
 pub trait Operable {
-    fn operate(self, call: &RadonCall) -> RadResult<RadonTypes>;
+    fn operate(self, call: &RadonCall) -> Result<RadonTypes, RadError>;
 }
 
-pub fn operate(input: RadonTypes, call: &RadonCall) -> RadResult<RadonTypes> {
+pub fn operate(input: RadonTypes, call: &RadonCall) -> Result<RadonTypes, RadError> {
     match input {
         RadonTypes::Array(radon_array) => radon_array.operate(call),
         RadonTypes::Float(radon_float) => radon_float.operate(call),
@@ -58,7 +60,7 @@ pub fn operate(input: RadonTypes, call: &RadonCall) -> RadResult<RadonTypes> {
     }
 }
 
-pub fn identity(input: RadonTypes) -> RadResult<RadonTypes> {
+pub fn identity<'a>(input: RadonTypes) -> Result<RadonTypes, RadError> {
     Ok(input)
 }
 

--- a/rad/src/operators/string.rs
+++ b/rad/src/operators/string.rs
@@ -19,7 +19,7 @@ pub fn parse_json(input: &RadonString) -> Result<RadonMixed, RadError> {
     }
 }
 
-pub fn hash(input: &RadonString, args: &'static [Value]) -> Result<RadonString, RadError> {
+pub fn hash(input: &RadonString, args: &[Value]) -> Result<RadonString, RadError> {
     let error = || RadError::WrongArguments {
         input_type: input.to_string(),
         operator: "Hash".to_string(),

--- a/rad/src/operators/string.rs
+++ b/rad/src/operators/string.rs
@@ -101,16 +101,12 @@ fn test_hash() {
         RadonString::from("dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f");
 
     assert_eq!(valid_output, valid_expected);
-
-    assert!(if let Err(err) = wrong_output {
-        err.inner().kind() == &RadError::WrongArguments
-    } else {
-        false
-    });
-
-    assert!(if let Err(err) = unsupported_output {
-        err.inner().kind() == &RadError::UnsupportedHashFunction
-    } else {
-        false
-    });
+    assert_eq!(
+        &wrong_output.unwrap_err().to_string(),
+        "Wrong `RadonString::Hash()` arguments: `[Integer(PosInt(255))]`"
+    );
+    assert_eq!(
+        &unsupported_output.unwrap_err().to_string(),
+        "Hash function `RadonHashFunctions::Fail` is not implemented"
+    );
 }

--- a/rad/src/operators/string.rs
+++ b/rad/src/operators/string.rs
@@ -21,7 +21,7 @@ pub fn parse_json(input: &RadonString) -> Result<RadonMixed, RadError> {
 
 pub fn hash(input: &RadonString, args: &[Value]) -> Result<RadonString, RadError> {
     let error = || RadError::WrongArguments {
-        input_type: input.to_string(),
+        input_type: "RadonString".to_string(),
         operator: "Hash".to_string(),
         args: args.to_vec(),
     };

--- a/rad/src/reducers/average.rs
+++ b/rad/src/reducers/average.rs
@@ -1,9 +1,9 @@
-use crate::error::RadResult;
+use crate::error::RadError;
 use crate::types::{array::RadonArray, float::RadonFloat, RadonType, RadonTypes};
 
 use std::ops::Div;
 
-pub fn mean(input: &RadonArray) -> RadResult<RadonTypes> {
+pub fn mean(input: &RadonArray) -> Result<RadonTypes, RadError> {
     let value = input.value();
 
     // Sum all numeric values

--- a/rad/src/reducers/mod.rs
+++ b/rad/src/reducers/mod.rs
@@ -1,7 +1,7 @@
 // FIXME: https://github.com/rust-num/num-derive/issues/20
 #![allow(clippy::useless_attribute)]
 
-use crate::error::*;
+use crate::error::RadError;
 use crate::types::{array::RadonArray, RadonTypes};
 
 mod average;
@@ -29,19 +29,20 @@ impl fmt::Display for RadonReducers {
     }
 }
 
-pub fn reduce(input: &RadonArray, reducer_code: RadonReducers) -> RadResult<RadonTypes> {
+pub fn reduce(input: &RadonArray, reducer_code: RadonReducers) -> Result<RadonTypes, RadError> {
+    let error = || {
+        Err(RadError::UnsupportedReducer {
+            inner_type: format!("{:?}", input.inner_type()),
+            reducer: reducer_code.to_string(),
+        })
+    };
+
     if input.is_homogeneous() {
         match reducer_code {
             RadonReducers::AverageMean => average::mean(input),
-            _ => Err(WitnetError::from(RadError::new(
-                RadErrorKind::UnsupportedReducer,
-                format!("Reducer {:} is not yet implemented", reducer_code),
-            ))),
+            _ => error(),
         }
     } else {
-        Err(WitnetError::from(RadError::new(
-            RadErrorKind::UnsupportedReducer,
-            String::from("Heterogeneous arrays (RadonArray<Mixed>) can not be reduced"),
-        )))
+        error()
     }
 }

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -93,7 +93,7 @@ impl TryInto<Value> for RadonArray {
 
 impl fmt::Display for RadonArray {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RadonArray")
+        write!(f, "RadonArray({:?})", self.value)
     }
 }
 
@@ -103,7 +103,7 @@ impl Operable for RadonArray {
             (RadonOpCodes::Identity, None) => identity(self.into()),
             (RadonOpCodes::Reduce, Some(args)) => array_operators::reduce(&self, args.as_slice()),
             (op_code, args) => Err(RadError::UnsupportedOperator {
-                input_type: self.to_string(),
+                input_type: "RadonArray".to_string(),
                 operator: op_code.to_string(),
                 args: args.to_owned(),
             }),

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -28,7 +28,7 @@ impl RadonArray {
     }
 }
 
-impl<'a> RadonType<'a, Vec<RadonTypes>> for RadonArray {
+impl RadonType<Vec<RadonTypes>> for RadonArray {
     fn value(&self) -> Vec<RadonTypes> {
         self.value.clone()
     }

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -12,6 +12,8 @@ fn mixed_discriminant() -> Discriminant<RadonTypes> {
     discriminant(&RadonTypes::from(RadonMixed::from(Value::Nil)))
 }
 
+pub const RADON_ARRAY_TYPE_NAME: &str = "RadonArray";
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct RadonArray {
     value: Vec<RadonTypes>,
@@ -31,6 +33,10 @@ impl RadonArray {
 impl RadonType<Vec<RadonTypes>> for RadonArray {
     fn value(&self) -> Vec<RadonTypes> {
         self.value.clone()
+    }
+
+    fn radon_type_name() -> String {
+        RADON_ARRAY_TYPE_NAME.to_string()
     }
 }
 
@@ -72,8 +78,8 @@ impl TryFrom<Value> for RadonArray {
                     .collect::<Vec<RadonTypes>>()
             })
             .ok_or_else(|| RadError::Decode {
-                from: "rmpv::Value",
-                to: "RadonTypes::Array",
+                from: "rmpv::Value".to_string(),
+                to: RADON_ARRAY_TYPE_NAME.to_string(),
             })
             .map(Self::from)
     }
@@ -93,7 +99,7 @@ impl TryInto<Value> for RadonArray {
 
 impl fmt::Display for RadonArray {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RadonArray({:?})", self.value)
+        write!(f, "{}({:?})", RADON_ARRAY_TYPE_NAME, self.value)
     }
 }
 
@@ -103,7 +109,7 @@ impl Operable for RadonArray {
             (RadonOpCodes::Identity, None) => identity(self.into()),
             (RadonOpCodes::Reduce, Some(args)) => array_operators::reduce(&self, args.as_slice()),
             (op_code, args) => Err(RadError::UnsupportedOperator {
-                input_type: "RadonArray".to_string(),
+                input_type: RADON_ARRAY_TYPE_NAME.to_string(),
                 operator: op_code.to_string(),
                 args: args.to_owned(),
             }),

--- a/rad/src/types/float.rs
+++ b/rad/src/types/float.rs
@@ -58,7 +58,7 @@ impl<'a> Operable for RadonFloat {
             (RadonOpCodes::Identity, None) => identity(RadonTypes::Float(self)),
             // Unsupported / unimplemented
             (op_code, args) => Err(RadError::UnsupportedOperator {
-                input_type: self.to_string(),
+                input_type: "RadonFloat".to_string(),
                 operator: op_code.to_string(),
                 args: args.to_owned(),
             }),
@@ -68,7 +68,7 @@ impl<'a> Operable for RadonFloat {
 
 impl fmt::Display for RadonFloat {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RadonFloat")
+        write!(f, "RadonFloat({})", self.value)
     }
 }
 

--- a/rad/src/types/float.rs
+++ b/rad/src/types/float.rs
@@ -14,7 +14,7 @@ pub struct RadonFloat {
     value: f64,
 }
 
-impl<'a> RadonType<'a, f64> for RadonFloat {
+impl RadonType<f64> for RadonFloat {
     fn value(&self) -> f64 {
         self.value
     }

--- a/rad/src/types/float.rs
+++ b/rad/src/types/float.rs
@@ -9,6 +9,8 @@ use crate::operators::{identity, Operable, RadonOpCodes};
 use crate::script::RadonCall;
 use crate::types::{RadonType, RadonTypes};
 
+pub const RADON_FLOAT_TYPE_NAME: &str = "RadonFloat";
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct RadonFloat {
     value: f64,
@@ -17,6 +19,10 @@ pub struct RadonFloat {
 impl RadonType<f64> for RadonFloat {
     fn value(&self) -> f64 {
         self.value
+    }
+
+    fn radon_type_name() -> String {
+        RADON_FLOAT_TYPE_NAME.to_string()
     }
 }
 
@@ -31,8 +37,8 @@ impl TryFrom<Value> for RadonFloat {
             _ => None,
         }
         .ok_or_else(|| RadError::Decode {
-            from: "rmpv::Value",
-            to: "RadonFloat",
+            from: "rmpv::Value".to_string(),
+            to: RADON_FLOAT_TYPE_NAME.to_string(),
         })
     }
 }
@@ -58,7 +64,7 @@ impl<'a> Operable for RadonFloat {
             (RadonOpCodes::Identity, None) => identity(RadonTypes::Float(self)),
             // Unsupported / unimplemented
             (op_code, args) => Err(RadError::UnsupportedOperator {
-                input_type: "RadonFloat".to_string(),
+                input_type: RADON_FLOAT_TYPE_NAME.to_string(),
                 operator: op_code.to_string(),
                 args: args.to_owned(),
             }),
@@ -68,7 +74,7 @@ impl<'a> Operable for RadonFloat {
 
 impl fmt::Display for RadonFloat {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RadonFloat({})", self.value)
+        write!(f, "{}({})", RADON_FLOAT_TYPE_NAME, self.value)
     }
 }
 

--- a/rad/src/types/map.rs
+++ b/rad/src/types/map.rs
@@ -16,7 +16,7 @@ pub struct RadonMap {
     value: HashMap<String, RadonMixed>,
 }
 
-impl<'a> RadonType<'a, HashMap<String, RadonMixed>> for RadonMap {
+impl RadonType<HashMap<String, RadonMixed>> for RadonMap {
     fn value(&self) -> HashMap<String, RadonMixed> {
         self.value.clone()
     }

--- a/rad/src/types/map.rs
+++ b/rad/src/types/map.rs
@@ -73,7 +73,7 @@ impl TryInto<Value> for RadonMap {
 
 impl fmt::Display for RadonMap {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RadonMap")
+        write!(f, "RadonMap({:?})", self.value)
     }
 }
 
@@ -85,7 +85,7 @@ impl Operable for RadonMap {
                 map_operators::get(&self, args.as_slice()).map(Into::into)
             }
             (op_code, args) => Err(RadError::UnsupportedOperator {
-                input_type: self.to_string(),
+                input_type: "RadonMixed".to_string(),
                 operator: op_code.to_string(),
                 args: args.to_owned(),
             }),

--- a/rad/src/types/map.rs
+++ b/rad/src/types/map.rs
@@ -11,6 +11,8 @@ use crate::script::RadonCall;
 use crate::types::RadonTypes;
 use crate::types::{mixed::RadonMixed, RadonType};
 
+pub const RADON_MAP_TYPE_NAME: &str = "RadonMap";
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct RadonMap {
     value: HashMap<String, RadonMixed>,
@@ -19,6 +21,10 @@ pub struct RadonMap {
 impl RadonType<HashMap<String, RadonMixed>> for RadonMap {
     fn value(&self) -> HashMap<String, RadonMixed> {
         self.value.clone()
+    }
+
+    fn radon_type_name() -> String {
+        RADON_MAP_TYPE_NAME.to_string()
     }
 }
 
@@ -52,8 +58,8 @@ impl TryFrom<Value> for RadonMap {
             .unwrap_or(None)
             .map(Self::from)
             .ok_or_else(|| RadError::Decode {
-                from: "rmpv::Value",
-                to: "RadonMap",
+                from: "rmpv::Value".to_string(),
+                to: RADON_MAP_TYPE_NAME.to_string(),
             })
     }
 }
@@ -73,7 +79,7 @@ impl TryInto<Value> for RadonMap {
 
 impl fmt::Display for RadonMap {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RadonMap({:?})", self.value)
+        write!(f, "{}({:?})", RADON_MAP_TYPE_NAME, self.value)
     }
 }
 
@@ -85,7 +91,7 @@ impl Operable for RadonMap {
                 map_operators::get(&self, args.as_slice()).map(Into::into)
             }
             (op_code, args) => Err(RadError::UnsupportedOperator {
-                input_type: "RadonMixed".to_string(),
+                input_type: RADON_MAP_TYPE_NAME.to_string(),
                 operator: op_code.to_string(),
                 args: args.to_owned(),
             }),

--- a/rad/src/types/mixed.rs
+++ b/rad/src/types/mixed.rs
@@ -12,7 +12,7 @@ pub struct RadonMixed {
     value: Value,
 }
 
-impl<'a> RadonType<'a, Value> for RadonMixed {
+impl RadonType<Value> for RadonMixed {
     fn value(&self) -> Value {
         self.value.clone()
     }

--- a/rad/src/types/mixed.rs
+++ b/rad/src/types/mixed.rs
@@ -55,7 +55,7 @@ impl Operable for RadonMixed {
                 .map_err(Into::into),
             // Unsupported / unimplemented
             (op_code, args) => Err(RadError::UnsupportedOperator {
-                input_type: self.to_string(),
+                input_type: "RadonMixed".to_string(),
                 operator: op_code.to_string(),
                 args: args.to_owned(),
             }),
@@ -65,7 +65,7 @@ impl Operable for RadonMixed {
 
 impl fmt::Display for RadonMixed {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RadonMixed")
+        write!(f, "RadonMixed({:?})", self.value)
     }
 }
 

--- a/rad/src/types/mixed.rs
+++ b/rad/src/types/mixed.rs
@@ -7,6 +7,8 @@ use rmpv::Value;
 use std::fmt;
 use witnet_data_structures::serializers::decoders::{TryFrom, TryInto};
 
+pub const RADON_MIXED_TYPE_NAME: &str = "RadonMixed";
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct RadonMixed {
     value: Value,
@@ -15,6 +17,10 @@ pub struct RadonMixed {
 impl RadonType<Value> for RadonMixed {
     fn value(&self) -> Value {
         self.value.clone()
+    }
+
+    fn radon_type_name() -> String {
+        RADON_MIXED_TYPE_NAME.to_string()
     }
 }
 
@@ -55,7 +61,7 @@ impl Operable for RadonMixed {
                 .map_err(Into::into),
             // Unsupported / unimplemented
             (op_code, args) => Err(RadError::UnsupportedOperator {
-                input_type: "RadonMixed".to_string(),
+                input_type: RADON_MIXED_TYPE_NAME.to_string(),
                 operator: op_code.to_string(),
                 args: args.to_owned(),
             }),
@@ -65,7 +71,7 @@ impl Operable for RadonMixed {
 
 impl fmt::Display for RadonMixed {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RadonMixed({:?})", self.value)
+        write!(f, "{}({:?})", RADON_MIXED_TYPE_NAME, self.value)
     }
 }
 

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -48,12 +48,11 @@ impl RadonTypes {
 impl fmt::Display for RadonTypes {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RadonTypes::Array(_array) => write!(f, "RadonArray"),
-            RadonTypes::Float(_float) => write!(f, "RadonFloat"),
-            RadonTypes::Map(_map) => write!(f, "RadonMap"),
-            RadonTypes::Mixed(_mixed) => write!(f, "RadonMixed"),
-            RadonTypes::String(_string) => write!(f, "RadonString"),
-            //_ => write!(f, "RadonTypes::{:?}", self),
+            RadonTypes::Array(inner) => write!(f, "RadonTypes::{}", inner),
+            RadonTypes::Float(inner) => write!(f, "RadonTypes::{}", inner),
+            RadonTypes::Map(inner) => write!(f, "RadonTypes::{}", inner),
+            RadonTypes::Mixed(inner) => write!(f, "RadonTypes::{}", inner),
+            RadonTypes::String(inner) => write!(f, "RadonTypes::{}", inner),
         }
     }
 }

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -19,7 +19,7 @@ pub mod map;
 pub mod mixed;
 pub mod string;
 
-pub trait RadonType<'a, T>:
+pub trait RadonType<T>:
     fmt::Display + From<T> + PartialEq + TryFrom<Value> + TryInto<Value>
 where
     T: fmt::Debug,
@@ -37,7 +37,7 @@ pub enum RadonTypes {
 }
 
 impl RadonTypes {
-    pub fn hash<'a>(self) -> Result<Hash, RadError> {
+    pub fn hash(self) -> Result<Hash, RadError> {
         self.try_into()
             .map(|vector: Vec<u8>| calculate_sha256(&*vector))
             .map(Hash::from)

--- a/rad/src/types/string.rs
+++ b/rad/src/types/string.rs
@@ -7,6 +7,8 @@ use rmpv::Value;
 use std::fmt;
 use witnet_data_structures::serializers::decoders::{TryFrom, TryInto};
 
+pub const RADON_STRING_TYPE_NAME: &str = "RadonString";
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct RadonString {
     value: String,
@@ -15,6 +17,10 @@ pub struct RadonString {
 impl RadonType<String> for RadonString {
     fn value(&self) -> String {
         self.value.clone()
+    }
+
+    fn radon_type_name() -> String {
+        RADON_STRING_TYPE_NAME.to_string()
     }
 }
 
@@ -26,8 +32,8 @@ impl TryFrom<Value> for RadonString {
             .as_str()
             .map(Self::from)
             .ok_or_else(|| RadError::Decode {
-                from: "rmpv::Value",
-                to: "RadonString",
+                from: "rmpv::Value".to_string(),
+                to: RADON_STRING_TYPE_NAME.to_string(),
             })
     }
 }
@@ -60,7 +66,7 @@ impl Operable for RadonString {
                 string_operators::parse_json(&self).map(RadonTypes::Mixed)
             }
             (op_code, args) => Err(RadError::UnsupportedOperator {
-                input_type: "RadonString".to_string(),
+                input_type: RADON_STRING_TYPE_NAME.to_string(),
                 operator: op_code.to_string(),
                 args: args.to_owned(),
             }),
@@ -68,9 +74,9 @@ impl Operable for RadonString {
     }
 }
 
-impl<'a> fmt::Display for RadonString {
+impl fmt::Display for RadonString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, r#"RadonString("{}")"#, self.value)
+        write!(f, r#"{}("{}")"#, RADON_STRING_TYPE_NAME, self.value)
     }
 }
 

--- a/rad/src/types/string.rs
+++ b/rad/src/types/string.rs
@@ -60,7 +60,7 @@ impl Operable for RadonString {
                 string_operators::parse_json(&self).map(RadonTypes::Mixed)
             }
             (op_code, args) => Err(RadError::UnsupportedOperator {
-                input_type: self.to_string(),
+                input_type: "RadonString".to_string(),
                 operator: op_code.to_string(),
                 args: args.to_owned(),
             }),
@@ -70,7 +70,7 @@ impl Operable for RadonString {
 
 impl<'a> fmt::Display for RadonString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "RadonString")
+        write!(f, r#"RadonString("{}")"#, self.value)
     }
 }
 

--- a/rad/src/types/string.rs
+++ b/rad/src/types/string.rs
@@ -12,7 +12,7 @@ pub struct RadonString {
     value: String,
 }
 
-impl<'a> RadonType<'a, String> for RadonString {
+impl RadonType<String> for RadonString {
     fn value(&self) -> String {
         self.value.clone()
     }

--- a/rad/tests/lib.rs
+++ b/rad/tests/lib.rs
@@ -1,0 +1,63 @@
+use rmpv::Value;
+use witnet_data_structures::serializers::decoders::TryFrom;
+use witnet_rad::types::RadonTypes;
+
+#[test]
+fn test_radon_types_names() {
+    let radon_array = RadonTypes::try_from(Value::from(vec![Value::from(123)])).unwrap();
+    let radon_array_type_name = radon_array.radon_type_name();
+    assert_eq!(radon_array_type_name, String::from("RadonArray"));
+
+    let radon_float = RadonTypes::try_from(Value::from(std::f64::consts::PI)).unwrap();
+    let radon_float_type_name = radon_float.radon_type_name();
+    assert_eq!(radon_float_type_name, String::from("RadonFloat"));
+
+    let radon_map = RadonTypes::try_from(Value::from(vec![(
+        Value::from("Hello"),
+        Value::from("World"),
+    )]))
+    .unwrap();
+    let radon_map_type_name = radon_map.radon_type_name();
+    assert_eq!(radon_map_type_name, String::from("RadonMap"));
+
+    let radon_mixed = RadonTypes::try_from(Value::Ext(123, vec![1, 2, 3])).unwrap();
+    let radon_mixed_type_name = radon_mixed.radon_type_name();
+    assert_eq!(radon_mixed_type_name, String::from("RadonMixed"));
+
+    let radon_string = RadonTypes::try_from(Value::from("Hello, World!")).unwrap();
+    let radon_string_type_name = radon_string.radon_type_name();
+    assert_eq!(radon_string_type_name, String::from("RadonString"));
+}
+
+#[test]
+fn test_radon_types_display() {
+    let radon_array = RadonTypes::try_from(Value::from(vec![Value::from(123)])).unwrap();
+    let radon_array_type_display = radon_array.to_string();
+    let radon_array_expected =
+        "RadonTypes::RadonArray([Mixed(RadonMixed { value: Integer(PosInt(123)) })])".to_string();
+    assert_eq!(radon_array_type_display, radon_array_expected);
+
+    let radon_float = RadonTypes::try_from(Value::from(std::f64::consts::PI)).unwrap();
+    let radon_float_type_display = radon_float.to_string();
+    let radon_float_expected = "RadonTypes::RadonFloat(3.141592653589793)".to_string();
+    assert_eq!(radon_float_type_display, radon_float_expected);
+
+    let radon_map = RadonTypes::try_from(Value::from(vec![(
+        Value::from("Hello"),
+        Value::from("World"),
+    )]))
+    .unwrap();
+    let radon_map_type_display = radon_map.to_string();
+    let radon_map_expected = r#"RadonTypes::RadonMap({"Hello": RadonMixed { value: String(Utf8String { s: Ok("World") }) }})"#.to_string();
+    assert_eq!(radon_map_type_display, radon_map_expected);
+
+    let radon_mixed = RadonTypes::try_from(Value::Ext(123, vec![1, 2, 3])).unwrap();
+    let radon_mixed_type_display = radon_mixed.to_string();
+    let radon_mixed_expected = "RadonTypes::RadonMixed(Ext(123, [1, 2, 3]))".to_string();
+    assert_eq!(radon_mixed_type_display, radon_mixed_expected);
+
+    let radon_string = RadonTypes::try_from(Value::from("Hello, World!")).unwrap();
+    let radon_string_type_display = radon_string.to_string();
+    let radon_string_expected = r#"RadonTypes::RadonString("Hello, World!")"#.to_string();
+    assert_eq!(radon_string_type_display, radon_string_expected);
+}


### PR DESCRIPTION
This kind of biggie refactor tries to exemplify how we are supposed to use the Failure framework properly.

The benefits of this approach are manyfold:
- Error messages are not created in place but defined in the `RadonError` enum, which prevents inconsistent error reporting and keeps the code cleaner.
- Every usage of `RadonResult<T>` is now `Result<T, RadonError>`, where `Result` is Rust's primitive `Result`. 
- The API for each module can now be uniform and predictable.