### PR TITLE
Get blockchain from height

### DIFF
--- a/docs/interface/cli.md
+++ b/docs/interface/cli.md
@@ -91,6 +91,20 @@ Block for epoch #46924 had digest e706995269bfc4fb5f4ab9082765a1bdb48fc6e58cdf5f
 Block for epoch #46925 had digest 2dc469691916a862154eb92473278ea8591ace910ec7ecb560797cbb91fdc01e
 ```
 
+There are two optional arguments: `epoch` and `limit`. For example, to get the
+blocks for epochs `100-104`, use `epoch 100` and `limit 5`:
+
+```sh
+$ witnet cli getBlockChain -c witnet_01.toml 100 5
+```
+
+If a negative epoch is supplied, it is interpreted as "the last N epochs".
+For instance, to get the block for the last epoch:
+
+```sh
+$ witnet cli getBlockChain -c witnet_01.toml -1
+```
+
 #### getOutput
 
 Returns the output of the transaction that matches the provided output pointer.

--- a/docs/interface/json-rpc.md
+++ b/docs/interface/json-rpc.md
@@ -73,6 +73,26 @@ Get the list of all the known block hashes.
 
 Returns a list of `(epoch, block_hash)` pairs.
 
+These parameters can be used to limit to some epoch range.
+There are two optional parameters: epoch and limit. For example, to get the
+blocks for epochs `100-104`, use `"epoch" 100` and `"limit": 5`:
+
+```json
+"params": {
+    "epoch": 100,
+    "limit": 5,
+}
+```
+
+If a negative epoch is supplied, it is interpreted as "the last N epochs".
+For instance, to get the block for the last epoch:
+
+```json
+"params": {
+    "epoch": -1,
+}
+```
+
 Example:
 
 ```

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -31,6 +31,14 @@ pub fn jsonrpc_io_handler() -> IoHandler<()> {
     io
 }
 
+fn internal_error<T: std::fmt::Debug>(e: T) -> jsonrpc_core::Error {
+    jsonrpc_core::Error {
+        code: jsonrpc_core::ErrorCode::InternalError,
+        message: format!("{:?}", e),
+        data: None,
+    }
+}
+
 /// Inventory element: block, transaction, etc
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum InventoryItem {
@@ -135,30 +143,18 @@ pub fn get_block_chain(
                 let value = match serde_json::to_value(epoch_and_hash) {
                     Ok(x) => x,
                     Err(e) => {
-                        let err = jsonrpc_core::Error {
-                            code: jsonrpc_core::ErrorCode::InternalError,
-                            message: format!("{}", e),
-                            data: None,
-                        };
+                        let err = internal_error(e);
                         return futures::failed(err);
                     }
                 };
                 futures::finished(value)
             }
             Ok(Err(e)) => {
-                let err = jsonrpc_core::Error {
-                    code: jsonrpc_core::ErrorCode::InternalError,
-                    message: format!("{:?}", e),
-                    data: None,
-                };
+                let err = internal_error(e);
                 futures::failed(err)
             }
             Err(e) => {
-                let err = jsonrpc_core::Error {
-                    code: jsonrpc_core::ErrorCode::InternalError,
-                    message: format!("{:?}", e),
-                    data: None,
-                };
+                let err = internal_error(e);
                 futures::failed(err)
             }
         }
@@ -189,19 +185,11 @@ pub fn get_block_chain(
                     futures::finished(epoch)
                 }
                 Ok(Err(e)) => {
-                    let err = jsonrpc_core::Error {
-                        code: jsonrpc_core::ErrorCode::InternalError,
-                        message: format!("{:?}", e),
-                        data: None,
-                    };
+                    let err = internal_error(e);
                     futures::failed(err)
                 }
                 Err(e) => {
-                    let err = jsonrpc_core::Error {
-                        code: jsonrpc_core::ErrorCode::InternalError,
-                        message: format!("{:?}", e),
-                        data: None,
-                    };
+                    let err = internal_error(e);
                     futures::failed(err)
                 }
             })
@@ -220,11 +208,7 @@ pub fn get_output(output_pointer: Result<(String,), jsonrpc_core::Error>) -> Jso
         Ok(x) => match OutputPointer::from_str(&x.0) {
             Ok(x) => x,
             Err(e) => {
-                let err = jsonrpc_core::Error {
-                    code: jsonrpc_core::ErrorCode::InternalError,
-                    message: format!("{:?}", e),
-                    data: None,
-                };
+                let err = internal_error(e);
                 return Box::new(futures::failed(err));
             }
         },
@@ -241,30 +225,18 @@ pub fn get_output(output_pointer: Result<(String,), jsonrpc_core::Error>) -> Jso
                     let value = match serde_json::to_value(output) {
                         Ok(x) => x,
                         Err(e) => {
-                            let err = jsonrpc_core::Error {
-                                code: jsonrpc_core::ErrorCode::InternalError,
-                                message: format!("{}", e),
-                                data: None,
-                            };
+                            let err = internal_error(e);
                             return futures::failed(err);
                         }
                     };
                     futures::finished(value)
                 }
                 Ok(Err(e)) => {
-                    let err = jsonrpc_core::Error {
-                        code: jsonrpc_core::ErrorCode::InternalError,
-                        message: format!("{:?}", e),
-                        data: None,
-                    };
+                    let err = internal_error(e);
                     futures::failed(err)
                 }
                 Err(e) => {
-                    let err = jsonrpc_core::Error {
-                        code: jsonrpc_core::ErrorCode::InternalError,
-                        message: format!("{:?}", e),
-                        data: None,
-                    };
+                    let err = internal_error(e);
                     futures::failed(err)
                 }
             }),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,13 +11,14 @@ use std::result::Result;
 use ctrlc;
 use directories;
 use failure;
-use structopt::StructOpt;
+use structopt::{clap::AppSettings, StructOpt};
 
 use super::json_rpc_client;
 use crate::node::actors;
 
 /// Witnet network
 #[derive(Debug, StructOpt)]
+#[structopt(raw(global_settings = "&[AppSettings::AllowNegativeNumbers]"))]
 pub(crate) struct Cli {
     /// `witnet cmd ...`
     #[structopt(subcommand)]
@@ -94,6 +95,10 @@ pub(crate) enum CliCommand {
         )]
         #[structopt(parse(from_os_str))]
         config: Option<PathBuf>,
+        // Positional argument 1: first epoch for which to show block hashes
+        epoch: Option<i64>,
+        // Positional argument 2: max number of epochs for which to show block hashes
+        limit: Option<u32>,
     },
     #[structopt(name = "getOutput", about = "Get an output of a transaction")]
     GetOutput {


### PR DESCRIPTION
(copying the documentation):

There are two optional arguments: epoch and limit. For example, to get the
blocks from epochs 100-104, use epoch 100 and limit 5:

```sh
$ witnet cli getBlockChain -c witnet_01.toml 100 5
```

If a negative epoch is supplied, it is interpreted as "the last N epochs".
For instance, to get the blocks from the last epoch:

```sh
$ witnet cli getBlockChain -c witnet_01.toml -1
```
Close #495 