### PR TITLE
feat(signature_mngr): add signature manager

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -180,10 +180,9 @@ pub struct BlockInChain {
     pub data_request_pool: DataRequestPool,
 }
 
-/// Any reference to a Hashable type is also Hashable
-impl<'a, T: Hashable> Hashable for &'a T {
+impl<T: AsRef<[u8]>> Hashable for T {
     fn hash(&self) -> Hash {
-        (*self).hash()
+        calculate_sha256(self.as_ref()).into()
     }
 }
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -13,5 +13,7 @@ pub mod actors;
 /// Config Manager Actor API
 pub mod config_mngr;
 
+pub mod signature_mngr;
+
 /// Utilities for actor behaviour
 pub mod utils;

--- a/node/src/signature_mngr.rs
+++ b/node/src/signature_mngr.rs
@@ -1,0 +1,89 @@
+//! # Signature Manager
+//!
+//! This module provides a Signature Manager, which, after being
+//! initialized with a key, can be used repeatedly to sign data with
+//! that key.
+use actix::prelude::*;
+use failure;
+use failure::bail;
+use futures::future::Future;
+
+use witnet_data_structures::chain::{Hash, Hashable};
+use witnet_wallet::{key::SK, signature};
+
+/// Start the signature manager
+pub fn start() {
+    let addr = SignatureManager::start_default();
+    actix::System::current().registry().set(addr);
+}
+
+/// Set the key used to sign
+pub fn set_key(key: SK) -> impl Future<Item = (), Error = failure::Error> {
+    let addr = actix::System::current()
+        .registry()
+        .get::<SignatureManager>();
+    addr.send(SetKey(key)).flatten()
+}
+
+/// Sign a piece of data with the stored key.
+///
+/// This might fail if the manager has not been initialized with a key
+pub fn sign<T>(data: &T) -> impl Future<Item = signature::Signature, Error = failure::Error>
+where
+    T: Hashable,
+{
+    let addr = actix::System::current()
+        .registry()
+        .get::<SignatureManager>();
+    let Hash::SHA256(data_hash) = data.hash();
+
+    addr.send(Sign(data_hash.to_vec())).flatten()
+}
+
+#[derive(Debug, Default)]
+struct SignatureManager {
+    key: Option<SK>,
+}
+
+struct SetKey(SK);
+struct Sign(Vec<u8>);
+
+impl Actor for SignatureManager {
+    type Context = Context<Self>;
+
+    fn started(&mut self, _ctx: &mut Self::Context) {
+        log::debug!("Signature Manager actor has been started!");
+    }
+}
+
+impl Supervised for SignatureManager {}
+
+impl SystemService for SignatureManager {}
+
+impl Message for SetKey {
+    type Result = Result<(), failure::Error>;
+}
+
+impl Message for Sign {
+    type Result = Result<signature::Signature, failure::Error>;
+}
+
+impl Handler<SetKey> for SignatureManager {
+    type Result = <SetKey as Message>::Result;
+
+    fn handle(&mut self, SetKey(key): SetKey, _ctx: &mut Self::Context) -> Self::Result {
+        self.key = Some(key);
+        Ok(())
+    }
+}
+
+impl Handler<Sign> for SignatureManager {
+    type Result = <Sign as Message>::Result;
+
+    fn handle(&mut self, Sign(data): Sign, _ctx: &mut Self::Context) -> Self::Result {
+        match self.key {
+            Some(key) => Ok(signature::sign(key, &data)),
+            None => bail!("Signature Manager cannot sign because it contains no key"),
+        }
+    }
+}

--- a/node/tests/signature_test.rs
+++ b/node/tests/signature_test.rs
@@ -1,0 +1,52 @@
+use actix;
+use futures::Future;
+
+use witnet_node::signature_mngr;
+use witnet_wallet::key::SK;
+
+fn ignore<T>(_: T) {}
+
+#[test]
+fn test_sign_without_key() {
+    actix::System::run(|| {
+        signature_mngr::start();
+
+        let data = [0 as u8; 32];
+
+        let fut = signature_mngr::sign(&data)
+            .and_then(|_| Ok(()))
+            .then(|result| {
+                assert!(result.is_err());
+
+                actix::System::current().stop();
+                futures::future::result(result)
+            });
+
+        actix::Arbiter::spawn(fut.map_err(ignore));
+    });
+}
+
+#[test]
+fn test_sign_with_key() {
+    actix::System::run(|| {
+        signature_mngr::start();
+
+        let key = SK::from_slice(&[1 as u8; 32]).unwrap();
+
+        let fut = signature_mngr::set_key(key)
+            .and_then(|_| {
+                let data = [0 as u8; 32];
+                signature_mngr::sign(&data)
+            })
+            .and_then(|signature| {
+                assert_eq!(144, signature.to_string().len());
+                Ok(())
+            })
+            .then(|r| {
+                actix::System::current().stop();
+                futures::future::result(r)
+            });
+
+        actix::Arbiter::spawn(fut.map_err(ignore));
+    });
+}

--- a/wallet/src/key.rs
+++ b/wallet/src/key.rs
@@ -98,11 +98,14 @@ pub enum KeyDerivationError {
     Secp256k1Error(secp256k1::Error),
 }
 
+/// Secret Key
+pub type SK = SecretKey;
+
 /// Extended Key is just a Key with a Chain Code
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ExtendedSK {
     /// Secret key
-    pub secret_key: SecretKey,
+    pub secret_key: SK,
     /// Chain code
     pub chain_code: [u8; 32],
 }

--- a/wallet/src/signature.rs
+++ b/wallet/src/signature.rs
@@ -1,6 +1,10 @@
 //! Signature module
 
-use secp256k1::{Error, Message, PublicKey, Secp256k1, SecretKey, Signature};
+use secp256k1::{Error, Message, PublicKey, Secp256k1, SecretKey};
+
+/// Signature
+pub type Signature = secp256k1::Signature;
+
 /// Sign data with provided secret key
 pub fn sign(secret_key: SecretKey, data: &[u8]) -> Signature {
     let msg = Message::from_slice(data).unwrap();


### PR DESCRIPTION
The Signature Manager is in charge of storing a secret key and sign data.

The API consists of three functions:

- `start`: Starts the manager with no key
- `set_key`: Sets the key the manager is going to use to sign data
- `sign`: Signs the given data

Example:

```rust
use witnet_node::signature_mngr;

signature_mngr::start();

let key = SK::from_slice(&[1 as u8; 32]).unwrap();

signature_mngr.set_key(key).and_then(|_| {
  let data = [0xab; 32];
  signature_mngr::sign(&data)
})
//...
```