### PR TITLE
feat(signatures): sign blocks in mining manager

### DIFF
--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -11,7 +11,7 @@
 
 use failure::Fail;
 use hmac::{Hmac, Mac};
-use secp256k1::{PublicKey, SecretKey};
+use secp256k1::{PublicKey, Secp256k1, SecretKey};
 use sha2;
 
 const HARDENED_BIT: u32 = 1 << 31;
@@ -99,6 +99,16 @@ pub enum KeyDerivationError {
 
 /// Secret Key
 pub type SK = SecretKey;
+
+/// Public Key
+pub type PK = PublicKey;
+
+/// Signing context for signature operations
+///
+/// `SignContext::new()`: all capabilities
+/// `SignContext::signing_only()`: only be used for signing
+/// `SignContext::verification_only()`: only be used for verification
+pub type SignContext<C> = Secp256k1<C>;
 
 /// Extended Key is just a Key with a Chain Code
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -263,9 +263,9 @@ mod tests {
             9, 200, 145, 160, 101, 238, 73,
         ];
 
-        let master_key = MasterKeyGen::new(&seed[..]).generate().unwrap();
+        let extended_sk = MasterKeyGen::new(&seed[..]).generate().unwrap();
 
-        let secret_key = master_key
+        let account = extended_sk
             .derive(vec![
                 ChildNumber(0x8000002c), // purpose: BIP-44
                 ChildNumber(0x80000000), // coin_type: Bitcoin
@@ -275,14 +275,14 @@ mod tests {
             ])
             .unwrap();
 
-        let expected_secret_key = [
+        let expected_account = [
             137, 174, 230, 121, 4, 190, 53, 238, 47, 181, 52, 226, 109, 68, 153, 170, 112, 150, 84,
             84, 26, 177, 194, 157, 76, 80, 136, 25, 6, 79, 247, 43,
         ];
 
         assert_eq!(
-            expected_secret_key,
-            &secret_key.secret()[..],
+            expected_account,
+            &account.secret()[..],
             "Secret key is invalid"
         );
     }

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -238,8 +238,6 @@ pub struct BlockHeader {
 pub struct LeadershipProof {
     /// An enveloped signature of the block header except the `proof` part
     pub block_sig: Option<Signature>,
-    /// The alleged miner influence as of last checkpoint
-    pub influence: u64,
 }
 
 /// Digital signatures structure (based on supported cryptosystems)
@@ -1491,7 +1489,6 @@ mod tests {
         });
         let proof = LeadershipProof {
             block_sig: Some(signature.clone()),
-            influence: 0,
         };
         let keyed_signatures = vec![KeyedSignature {
             public_key: PublicKey::default(),

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -283,6 +283,12 @@ pub enum Secp256k1ConversionError {
     FailSecretKeyConversion,
 }
 
+impl From<Secp256k1_Signature> for Signature {
+    fn from(secp256k1_signature: Secp256k1_Signature) -> Self {
+        Signature::Secp256k1(Secp256k1Signature::from(secp256k1_signature))
+    }
+}
+
 impl From<Secp256k1_Signature> for Secp256k1Signature {
     fn from(secp256k1_signature: Secp256k1_Signature) -> Self {
         let der = secp256k1_signature.serialize_der();

--- a/data_structures/src/proto/mod.rs
+++ b/data_structures/src/proto/mod.rs
@@ -66,7 +66,6 @@ impl ProtobufConvert for chain::LeadershipProof {
 
     fn to_pb(&self) -> Self::ProtoStruct {
         let mut m = witnet::Block_LeadershipProof::new();
-        m.set_influence(self.influence);
         if let Some(sig) = &self.block_sig {
             m.set_block_sig(sig.to_pb());
         }
@@ -74,17 +73,13 @@ impl ProtobufConvert for chain::LeadershipProof {
     }
 
     fn from_pb(pb: Self::ProtoStruct) -> Result<Self, Error> {
-        let influence = pb.get_influence();
         let block_sig = match pb.optional_block_sig {
             Some(sig) => Some(chain::Signature::from_pb(match sig {
                 witnet::Block_LeadershipProof_oneof_optional_block_sig::block_sig(s) => s,
             })?),
             None => None,
         };
-        Ok(chain::LeadershipProof {
-            block_sig,
-            influence,
-        })
+        Ok(chain::LeadershipProof { block_sig })
     }
 }
 

--- a/data_structures/src/tests.rs
+++ b/data_structures/src/tests.rs
@@ -19,7 +19,6 @@ fn test_block_hashable_trait() {
     });
     let proof = LeadershipProof {
         block_sig: Some(signature.clone()),
-        influence: 0,
     };
     let keyed_signatures = vec![KeyedSignature {
         public_key: PublicKey::default(),
@@ -372,7 +371,6 @@ mod block {
 
     const PROOF: LeadershipProof = LeadershipProof {
         block_sig: None,
-        influence: 123,
     };
 
     #[test]

--- a/data_structures/tests/builders.rs
+++ b/data_structures/tests/builders.rs
@@ -44,7 +44,6 @@ fn builders_build_block() {
     };
     let proof = LeadershipProof {
         block_sig: Some(signature.clone()),
-        influence: 0,
     };
     let keyed_signatures = vec![KeyedSignature {
         public_key: PublicKey::default(),
@@ -147,7 +146,6 @@ fn builders_build_block() {
             block_header: block_header.clone(),
             proof: LeadershipProof {
                 block_sig: Some(signature),
-                influence: 0,
             },
             txns: txns.clone(),
         }),

--- a/data_structures/tests/serializers.rs
+++ b/data_structures/tests/serializers.rs
@@ -365,7 +365,6 @@ fn message_block_to_bytes() {
     });
     let proof = LeadershipProof {
         block_sig: Some(signature.clone()),
-        influence: 0,
     };
     let keyed_signature = vec![KeyedSignature {
         public_key: PublicKey::default(),
@@ -575,7 +574,6 @@ fn message_block_from_bytes() {
     });
     let proof = LeadershipProof {
         block_sig: Some(signature.clone()),
-        influence: 0,
     };
     let keyed_signature = vec![KeyedSignature {
         public_key: PublicKey::default(),
@@ -699,7 +697,6 @@ fn message_block_encode_decode() {
     });
     let proof = LeadershipProof {
         block_sig: Some(signature.clone()),
-        influence: 0,
     };
     let keyed_signature = vec![KeyedSignature {
         public_key: PublicKey::default(),

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -17,7 +17,7 @@ use witnet_data_structures::{
     data_request::DataRequestPool,
 };
 
-use witnet_util::timestamp::{get_timestamp_nanos, pretty_print};
+use witnet_util::timestamp::pretty_print;
 
 use log::{debug, error, warn};
 
@@ -30,10 +30,6 @@ impl Actor for ChainManager {
     // FIXME: Remove all `unwrap()`s
     fn started(&mut self, ctx: &mut Self::Context) {
         debug!("ChainManager actor has been started!");
-
-        // Use the current timestamp as a random value to modify the signature
-        // Make sure to wait at least 1 second before starting each node
-        self.random = u64::from(get_timestamp_nanos().1);
 
         self.initialize_from_storage(ctx);
 

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -91,7 +91,6 @@ impl ChainManager {
                     .and_then(move |(tally_transactions, keyed_signature), act, ctx| {
                         let leadership_proof = LeadershipProof {
                             block_sig: Some(keyed_signature.signature),
-                            influence: 0,
                         };
 
                         // Build the block using the supplied beacon and eligibility proof
@@ -420,10 +419,7 @@ mod tests {
 
         // Fields required to mine a block
         let block_beacon = CheckpointBeacon::default();
-        let block_proof = LeadershipProof {
-            block_sig: None,
-            influence: 0,
-        };
+        let block_proof = LeadershipProof { block_sig: None };
 
         // Build empty block (because max weight is zero)
         let block = build_block(
@@ -530,10 +526,7 @@ mod tests {
 
         // Fields required to mine a block
         let block_beacon = CheckpointBeacon::default();
-        let block_proof = LeadershipProof {
-            block_sig: None,
-            influence: 0,
-        };
+        let block_proof = LeadershipProof { block_sig: None };
 
         // Build block with
         let block = build_block(

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -107,12 +107,6 @@ pub struct ChainManager {
     transactions_pool: TransactionsPool,
     /// Maximum weight each block can have
     max_block_weight: u32,
-    // Random value to help with debugging because there is no signature
-    // and all the mined blocks have the same hash.
-    // This random value helps to distinguish blocks mined on different nodes
-    // To be removed when we implement real signing.
-    // TODO: Remove after create signatures
-    random: u64,
     /// Mining enabled
     mining_enabled: bool,
     /// Hash of the genesis block

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -178,7 +178,7 @@ pub enum InventoryItem {
 ///
 /// Returns a boolean indicating success.
 /* Test string:
-{"jsonrpc": "2.0","method": "inventory","params": {"block": {"block_header":{"version":1,"beacon":{"checkpoint":2,"hash_prev_block": {"SHA256": [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]}},"hash_merkle_root":{"SHA256":[3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3]}},"proof":{"block_sig": null,"influence":99999}"txns":[null]}},"id": 1}
+{"jsonrpc": "2.0","method": "inventory","params": {"block": {"block_header":{"version":1,"beacon":{"checkpoint":2,"hash_prev_block": {"SHA256": [4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]}},"hash_merkle_root":{"SHA256":[3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3]}},"proof":{"block_sig": null}"txns":[null]}},"id": 1}
 */
 pub fn inventory(inv_elem: InventoryItem) -> JsonRpcResult {
     match inv_elem {
@@ -572,10 +572,7 @@ mod tests {
                 },
                 hash_merkle_root: Hash::SHA256([3; 32]),
             },
-            proof: LeadershipProof {
-                block_sig: None,
-                influence: 99999,
-            },
+            proof: LeadershipProof { block_sig: None },
             txns,
         };
 
@@ -796,15 +793,12 @@ mod tests {
                 },
                 hash_merkle_root: Hash::SHA256([3; 32]),
             },
-            proof: LeadershipProof {
-                block_sig: None,
-                influence: 99999,
-            },
+            proof: LeadershipProof { block_sig: None },
             txns,
         };
         let inv_elem = InventoryItem::Block(block);
         let s = serde_json::to_string(&inv_elem);
-        let expected = r#"{"block":{"block_header":{"version":1,"beacon":{"checkpoint":2,"hash_prev_block":{"SHA256":[4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]}},"hash_merkle_root":{"SHA256":[3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3]}},"proof":{"block_sig":null,"influence":99999},"txns":[{"body":{"version":0,"inputs":[{"Commit":{"transaction_id":{"SHA256":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"output_index":0,"nonce":0}},{"DataRequest":{"transaction_id":{"SHA256":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"output_index":0,"poe":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}},{"Reveal":{"transaction_id":{"SHA256":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"output_index":0}}],"outputs":[{"ValueTransfer":{"pkh":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"value":0}},{"DataRequest":{"pkh":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"data_request":{"not_before":0,"retrieve":[{"kind":"HTTP-GET","url":"https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22","script":[0]},{"kind":"HTTP-GET","url":"https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22","script":[0]}],"aggregate":{"script":[0]},"consensus":{"script":[0]},"deliver":[{"kind":"HTTP-GET","url":"https://hooks.zapier.com/hooks/catch/3860543/l2awcd/"},{"kind":"HTTP-GET","url":"https://hooks.zapier.com/hooks/catch/3860543/l1awcw/"}]},"value":0,"witnesses":0,"backup_witnesses":0,"commit_fee":0,"reveal_fee":0,"tally_fee":0,"time_lock":0}},{"Commit":{"commitment":{"SHA256":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"value":0}},{"Reveal":{"reveal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"pkh":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"value":0}},{"Tally":{"result":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"pkh":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"value":0}}],"hash":null},"signatures":[{"signature":{"Secp256k1":{"r":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"s":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"v":0}},"public_key":{"compressed":0,"bytes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}}]}]}}"#;
+        let expected = r#"{"block":{"block_header":{"version":1,"beacon":{"checkpoint":2,"hash_prev_block":{"SHA256":[4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4]}},"hash_merkle_root":{"SHA256":[3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3]}},"proof":{"block_sig":null},"txns":[{"body":{"version":0,"inputs":[{"Commit":{"transaction_id":{"SHA256":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"output_index":0,"nonce":0}},{"DataRequest":{"transaction_id":{"SHA256":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"output_index":0,"poe":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}},{"Reveal":{"transaction_id":{"SHA256":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"output_index":0}}],"outputs":[{"ValueTransfer":{"pkh":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"value":0}},{"DataRequest":{"pkh":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"data_request":{"not_before":0,"retrieve":[{"kind":"HTTP-GET","url":"https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22","script":[0]},{"kind":"HTTP-GET","url":"https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22","script":[0]}],"aggregate":{"script":[0]},"consensus":{"script":[0]},"deliver":[{"kind":"HTTP-GET","url":"https://hooks.zapier.com/hooks/catch/3860543/l2awcd/"},{"kind":"HTTP-GET","url":"https://hooks.zapier.com/hooks/catch/3860543/l1awcw/"}]},"value":0,"witnesses":0,"backup_witnesses":0,"commit_fee":0,"reveal_fee":0,"tally_fee":0,"time_lock":0}},{"Commit":{"commitment":{"SHA256":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]},"value":0}},{"Reveal":{"reveal":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"pkh":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"value":0}},{"Tally":{"result":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"pkh":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"value":0}}],"hash":null},"signatures":[{"signature":{"Secp256k1":{"r":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"s":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"v":0}},"public_key":{"compressed":0,"bytes":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}}]}]}}"#;
         assert_eq!(s.unwrap(), expected);
     }
 

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -66,7 +66,6 @@ message Block {
         oneof optional_block_sig {
             Signature block_sig = 1;
         }
-        uint64 influence = 2;
     }
     BlockHeader block_header = 1;
     LeadershipProof proof = 2;

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -95,8 +95,6 @@ pub fn transaction_fee(
     } else {
         Ok(in_value - out_value)
     }
-
-    // TODO: Add signature validation after signing transactions
 }
 
 /// Returns `true` if the transaction classifies as a _mint


### PR DESCRIPTION
## Highlights

- Signature manager returns a `KeyedSignature` as the result of signing
- Added the conversion `From<secp256k1::Secp256k1> for Signature`
- Signing of: beacon, reveal, commit and tally, in minging manager

## Pending

Start signature manager and give it a key in order to be able to sign

## Issues

Closes #563 #554 