### PR TITLE
Support cross compilation for common ARM targets

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -50,3 +50,24 @@ travis:
     cargo fmt --all -- --check
     just clippy
     cargo test --all --verbose
+
+# build docker images for all cross compilation targets
+docker-image-build-all:
+    find ./docker -type d -ls | tail -n +2 | sed -En "s/^(.*)\.\/docker\/(.*)/\2/p" | xargs -n1 just docker-build
+
+# build docker image for a specific compilation target
+docker-image-build target:
+    docker build -t witnet-rust/{{target}} -f docker/{{target}}/Dockerfile docker
+
+# cross compile witnet-rust for all cross compilation targets
+cross-compile-all:
+    find ./docker -type d -ls | tail -n +2 | sed -En "s/^(.*)\.\/docker\/(.*)/\2/p" | xargs -n1 just cross-compile
+
+# cross compile witnet-rust for a specific compilation target
+cross-compile target profile="release":
+    docker run \
+    -v $(pwd):/project:ro \
+    -v $(pwd)/target:/target \
+    -w /project \
+    -i witnet-rust/{{target}} \
+    bash -c "cargo build --{{profile}} --target={{target}} --target-dir=/target && \$STRIP /target/{{target}}/{{profile}}/witnet"

--- a/Justfile
+++ b/Justfile
@@ -64,10 +64,14 @@ cross-compile-all:
     find ./docker -type d -ls | tail -n +2 | sed -En "s/^(.*)\.\/docker\/(.*)/\2/p" | xargs -n1 just cross-compile
 
 # cross compile witnet-rust for a specific compilation target
-cross-compile target profile="release":
+# - this assumes the container to set the `$STRIP` variable to be the path for binutils `strip` tool
+# - if `$STRIP` is unset, the binary will not be stripped and will retain all its symbols
+cross-compile target profile="debug":
     docker run \
     -v $(pwd):/project:ro \
     -v $(pwd)/target:/target \
     -w /project \
     -i witnet-rust/{{target}} \
-    bash -c "cargo build --{{profile}} --target={{target}} --target-dir=/target && \$STRIP /target/{{target}}/{{profile}}/witnet"
+    bash -c "cargo build `[[ {{profile}} == "release" ]] && echo "--release"` \--target={{target}} --target-dir=/target \
+    && [ -z "\$STRIP" ] \
+    && \$STRIP /target/{{target}}/{{profile}}/witnet"

--- a/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:latest
+
+# Install basic environment dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --verbose
+ENV PATH=/root/.cargo/bin:$PATH
+RUN rustc -vV && cargo -V
+
+# Install the arm target for Rust
+RUN rustup target add aarch64-unknown-linux-gnu
+
+# Install cross compilation dependencies
+RUN apt-get install -y --no-install-recommends \
+    binutils-aarch64-linux-gnu \
+    gcc-aarch64-linux-gnu \
+    libc6-dev-arm64-cross \
+    libc6-dev-i386 \
+    g++ \
+    g++-aarch64-linux-gnu
+
+# Compile and install OpenSSL for arm
+COPY openssl.sh /
+RUN bash /openssl.sh linux-aarch64 aarch64-linux-gnu-
+
+# Install common witnet-rust dependencies
+RUN apt-get install -y --no-install-recommends \
+    clang \
+    libssl-dev \
+    protobuf-compiler
+
+# Clean up apt packages so the docker image is as compact as possible
+RUN apt-get clean && apt-get autoremove
+
+# Set needed environment variables
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+    CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
+    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include \
+    OPENSSL_LIB_DIR=/openssl/lib \
+    PKG_CONFIG_ALLOW_CROSS=1 \
+    RUST_BACKTRACE=1 \
+    STRIP=aarch64-linux-gnu-strip

--- a/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:latest
+
+# Install basic environment dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    unzip \
+    wget
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --verbose
+ENV PATH=/root/.cargo/bin:$PATH
+RUN rustc -vV && cargo -V
+
+# Install the arm target for Rust
+RUN rustup target add arm-unknown-linux-gnueabihf
+
+# Install cross compilation dependencies
+# This part is based on https://github.com/tiziano88/rust-raspberry-pi
+ARG RASPBERRY_PI_TOOLS_COMMIT_ID=5caa7046982f0539cf5380f94da04b31129ed521
+RUN wget https://github.com/raspberrypi/tools/archive/$RASPBERRY_PI_TOOLS_COMMIT_ID.zip -O /root/pi-tools.zip
+RUN unzip /root/pi-tools.zip -d /root
+RUN mv /root/tools-$RASPBERRY_PI_TOOLS_COMMIT_ID /root/pi-tools
+ENV PATH=/root/pi-tools/arm-bcm2708/arm-linux-gnueabihf/bin:$PATH
+ENV PATH=/root/pi-tools/arm-bcm2708/arm-linux-gnueabihf/libexec/gcc/arm-linux-gnueabihf/4.8.3:$PATH
+RUN apt-get install -y --no-install-recommends \
+    libc6-dev-armhf-cross \
+    libc6-dev-i386 \
+    g++
+
+# Compile and install OpenSSL for arm
+COPY openssl.sh /
+RUN bash /openssl.sh linux-armv4 arm-linux-gnueabihf-
+
+# Install common witnet-rust dependencies
+RUN apt-get install -y --no-install-recommends \
+    clang \
+    libssl-dev \
+    protobuf-compiler
+
+# Clean up apt packages so the docker image is as compact as possible
+RUN apt-get clean && apt-get autoremove
+
+# Set needed environment variables
+ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+    CC_arm_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
+    CXX_arm_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++ \
+    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include \
+    OPENSSL_LIB_DIR=/openssl/lib \
+    PKG_CONFIG_ALLOW_CROSS=1 \
+    RUST_BACKTRACE=1 \
+    STRIP=arm-linux-gnueabihf-strip

--- a/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:latest
+
+# Install basic environment dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --verbose
+ENV PATH=/root/.cargo/bin:$PATH
+RUN rustc -vV && cargo -V
+
+# Install the arm target for Rust
+RUN rustup target add armv7-unknown-linux-gnueabihf
+
+# Install cross compilation dependencies
+RUN apt-get install -y --no-install-recommends \
+    binutils-arm-linux-gnueabihf \
+    gcc-arm-linux-gnueabihf \
+    libc6-dev-armhf-cross \
+    libc6-dev-i386 \
+    g++ \
+    g++-arm-linux-gnueabihf
+
+# Compile and install OpenSSL for arm
+COPY openssl.sh /
+RUN bash /openssl.sh linux-armv4 arm-linux-gnueabihf-
+
+# Install common witnet-rust dependencies
+RUN apt-get install -y --no-install-recommends \
+    clang \
+    libssl-dev \
+    protobuf-compiler
+
+# Clean up apt packages so the docker image is as compact as possible
+RUN apt-get clean && apt-get autoremove
+
+# Set needed environment variables
+ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+    CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
+    CXX_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++ \
+    OPENSSL_DIR=/openssl \
+    OPENSSL_INCLUDE_DIR=/openssl/include \
+    OPENSSL_LIB_DIR=/openssl/lib \
+    PKG_CONFIG_ALLOW_CROSS=1 \
+    RUST_BACKTRACE=1 \
+    STRIP=arm-linux-gnueabihf-strip

--- a/docker/openssl.sh
+++ b/docker/openssl.sh
@@ -1,0 +1,65 @@
+# Copyright 2016-2019 Jorge Aparicio, Marco A L Barbosa & bgermann.
+# 
+# https://github.com/rust-embedded/cross/blob/master/docker/openssl.sh
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# 	http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+main() {
+    local version=1.0.2p
+    local os=$1 \
+          triple=$2
+
+    local dependencies=(
+        ca-certificates
+        curl
+        m4
+        make
+        perl
+    )
+
+    # NOTE cross toolchain must be already installed
+    apt-get update
+    local purge_list=()
+    for dep in ${dependencies[@]}; do
+        if ! dpkg -L $dep; then
+            apt-get install --no-install-recommends -y $dep
+            purge_list+=( $dep )
+        fi
+    done
+
+    td=$(mktemp -d)
+
+    pushd $td
+    curl https://www.openssl.org/source/openssl-$version.tar.gz | \
+        tar --strip-components=1 -xz
+    AR=${triple}ar CC=${triple}gcc ./Configure \
+      --prefix=/openssl \
+      no-dso \
+      $os \
+      -fPIC \
+      ${@:3}
+    nice make -j$(nproc)
+    make install
+
+    # clean up
+    apt-get purge --auto-remove -y ${purge_list[@]}
+
+    popd
+
+    rm -rf $td
+    rm $0
+}
+
+main "${@}"

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,10 +7,11 @@
 
 We have installation guides for several operating systems:
 
-- [Installing Witnet-rust on GNU/Linux][install-gnu-linux]
-- [Installing Witnet-rust on macOS][install-macos]
-- [Installing Witnet-rust on Windows][install-windows]
-- [Compiling Witnet-rust on from source code][install-from-source]
+- [Installing `witnet-rust` on GNU/Linux][install-gnu-linux]
+- [Installing `witnet-rust` on macOS][install-macos]
+- [Installing `witnet-rust` on Windows][install-windows]
+- [Compiling `witnet-rust` on from source code][install-from-source]
+- [Cross compiling `witnet-rust`][cross-compilation]
 
 
 ## Running the CLI
@@ -63,7 +64,8 @@ There are some useful scripts to run with the `just` tool:
 
 [rust]: https://rust-lang.org
 [rust-2018]: https://rust-lang-nursery.github.io/edition-guide/introduction.html
-[install-gnu-linux]: get-started/installation/gnu-linux
-[install-macos]: get-started/installation/macos
-[install-windows]: get-started/installation/windows
-[install-from-source]: get-started/installation/from-source
+[install-gnu-linux]: /get-started/installation/gnu-linux
+[install-macos]: /get-started/installation/macos
+[install-windows]: /get-started/installation/windows
+[install-from-source]: /get-started/installation/from-source
+[cross-compilation]: /get-started/installation/cross-compilation

--- a/docs/get-started/installation/cross-compilation.md
+++ b/docs/get-started/installation/cross-compilation.md
@@ -1,0 +1,96 @@
+# Cross compiling `witnet-rust`
+
+`witnet-rust` supports cross compilation to different architectures and targets.
+
+For the sake of easing up the process of having a working cross compilation environment, we provide multiple [Dockerfiles] for quickly setting up [Docker] containers with Ubuntu 18.04 and all the dependencies already in place.
+
+## Supported hosts
+
+Cross compilation only supports by `x86_64` hosts, i.e. GNU/Linux or macOS running on the typical Intel or AMD 64 bit processors found in most desktop and laptop computers.
+
+## Supported targets
+
+- `aarch-unknown-linux-gnu`: 64 bit GNU/Linux distributions on ARMv8 processors, like the Raspberry Pi 3
+- `armv7-unknown-linux-gnueabihf`: 32 bit GNU/Linux distributions on ARMv7/8 processors, like the Raspberry Pi 2 and 3
+- `arm-unknown-linux-gnueabihf`: 32 bit GNU/Linux distributions on ARMv6 processors, like the Raspberry Pi 1 and Zero
+
+## Requirements
+
+The only requirements for cross compilation are:
+
+- A `x86_64` host running either a 64 bit GNU/Linux distribution or a recent version of macOS.
+- Docker. Note that on GNU/Linux non-sudo users need to be in the `docker` group. Read the [official post-installation steps][docker-postinstall-linux].
+- The `just` command runner tool.
+
+!!! tip "Installing the `just` tool"
+
+    `just` is a command runner tool widely used in the Rust ecosystem. You can install it with a single line:
+
+    ```console
+    cargo install just
+    ```
+
+## Building the Docker images
+
+We provide a one-liner command that will build a Docker image ready to cross compile the specified target:
+
+```console
+just docker-image-build <target>
+```
+
+!!! tip
+
+    For example, to generate a Docker image for cross compiling `armv7-unknown-linux-gnueabihf` binaries, just run:
+
+    ```console
+    just docker-image-build armv7-unknown-linux-gnueabihf
+    ```
+
+We also provide another command for conveniently generating Docker images for all the supported cross compilation targets:
+
+```console
+just docker-image-build-all
+``` 
+
+## Running the cross compilation process
+
+Once you have built a Docker image for one of the targets, running the cross compilation process inside it is extremely easy:
+
+```console
+just cross-compile <target> <profile=release>
+```
+
+The second argument of `just cross-compile` allows to customize the [release profile] for the compilation. If not specified, it will use the `release` profile by default. 
+
+!!! tip
+
+    For example, to cross-compile `witnet-rust` for `armv7-unknown-linux-gnueabihf`, just run:
+
+    ```console
+    just cross-compile armv7-unknown-linux-gnueabihf
+    ```
+
+The resulting binary should be located at `./target/<target>/<profile>/witnet`.
+
+We also provide another command for conveniently cross compiling all the supported targets at once:
+
+```console
+just cross-compile-all
+```
+
+## Supporting more targets
+
+Adding support for additional targets is extremely easy as long as the target platform is in turn [supported by Rust][Rust-platforms].
+
+1. Write a Dockerfile capable of producing binaries for the target of your choice.
+2. Copy the Dockerfile to `./docker/<target>/Dockerfile`.
+3. Try it with `just docker-image-build <target>` and `just cross-compile <target>`.
+4. Make a Pull Request to our [GitHub repository] so that others can also build binaries for the target platform.
+
+
+[Dockerfiles]: https://github.com/witnet/witnet-rust/tree/master/docker
+[Docker]: https://www.docker.com/why-docker
+[docker-postinstall-linux]: https://docs.docker.com/install/linux/linux-postinstall/
+[release profile]: https://doc.rust-lang.org/1.30.0/book/second-edition/ch14-01-release-profiles.html
+[Rust-platforms]: https://forge.rust-lang.org/platform-support.html
+[GitHub repository]: https://github.com/witnet/witnet-rust

--- a/docs/get-started/installation/from-source.md
+++ b/docs/get-started/installation/from-source.md
@@ -10,61 +10,19 @@ source $HOME/.cargo/env
 rustup default stable
 ```
 
-### OpenSSL / libssl
+### Compilation dependencies
 
 ```console tab="GNU/Linux (apt)"
-apt install libssl-dev
+apt install -y clang git libssl-dev protobuf-compiler
 ```
 
 ```console tab="GNU/Linux (pacman)"
-pacman -S openssl
-```
-
-```console tab="macOS"
-brew install openssl
-```
-
-
-### CLang compiler
-
-```console tab="GNU/Linux (apt)"
-apt install clang
-```
-
-```console tab="GNU/Linux (pacman)"
-pacman -S clang
+pacman -S clang git openssl protobuf
 ```
 
 ```console tab="macOS"
 xcode-select --install
-```
-
-### Protocol Buffers compiler
-
-```console tab="GNU/Linux (apt)"
-apt install protobuf-compiler
-```
-
-```console tab="GNU/Linux (pacman)"
-pacman -S protobuf
-```
-
-```console tab="macOS"
-brew install protobuf
-```
-
-### Git client
-
-```console tab="GNU/Linux (apt)"
-apt install git
-```
-
-```console tab="GNU/Linux (pacman)"
-pacman -S git
-```
-
-```console tab="macOS"
-brew install git
+brew install git openssl protobuf
 ```
 
 ### MkDocs Python packages
@@ -98,4 +56,17 @@ cargo run node
 
 For more `witnet-rust` commands (`cli`, `wallet`, etc.) you can read the [Witnet-rust CLI documentation][CLI].
 
+## Building a release
+
+This one-liner will build a releasable standalone binary compatible with the architecture of your computer's processor:
+
+```console
+cargo build --release
+```
+
+The resulting binary will be located at `./target/release/witnet`.
+
+If you want to produce binaries for other architectures, please read the [cross compilation instructions][cross-compilation].
+
 [CLI]: /development/#cli
+[cross-compilation]: /get-started/installation/cross-compilation

--- a/docs/get-started/installation/gnu-linux.md
+++ b/docs/get-started/installation/gnu-linux.md
@@ -1,10 +1,16 @@
 # Running `witnet-rust` on GNU/Linux
 
 ## Download the `witnet-rust` package
-GNU/Linux packages are available in our GitHub repository:
+GNU/Linux packages [are available in our GitHub repository][release]. Currently supported GNU/Linux architectures are:
 
-- [Witnet-rust for desktop GNU/Linux (x86_64)][release]
-- [Witnet-rust for Raspberry Pi GNU/Linux (armv6l)][release]
+- `x86_64-linux-gnu`: most modern GNU/Linux distributions for the typical Intel or AMD desktop/laptop processors.
+- `aarch-unknown-linux-gnu`: 64 bit GNU/Linux distributions on ARMv8 processors, like the Raspberry Pi 3
+- `armv7-unknown-linux-gnueabihf`: 32 bit GNU/Linux distributions on ARMv7/8 processors, like the Raspberry Pi 2 and 3
+- `arm-unknown-linux-gnueabihf`: 32 bit GNU/Linux distributions on ARMv6 processors, like the Raspberry Pi 1 and Zero
+
+If you want to run `witnet-rust` on a Raspberry Pi, you should try the `armv7-unknown-linux-gnueabihf` binary unless:
+- You positively know you are using a 64 bit distribution. Then use `aarch-unknown-linux-gnu`.
+- You are using Pi model 1, model Zero or Zero W. Then use `arm-unknown-linux-gnueabihf`.
 
 ## Unpacking and granting execution permission
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
       - macOS: get-started/installation/macos.md
       - Windows: get-started/installation/windows.md
       - From source code: get-started/installation/from-source.md
+      - Cross compilation: get-started/installation/cross-compilation.md
   - Protocol:
     - Network:
       - Overview: protocol/network/overview.md


### PR DESCRIPTION
This PR adds support for cross compiling `witnet-rust` for most popular ARM targets, specially those used by the different models of the Raspberry Pi micro computer.

close #552 