### PR TITLE
Synchronization without cloning pools

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -122,14 +122,6 @@ pub struct Block {
     pub txns: Vec<Transaction>,
 }
 
-/// Struct that keeps a block candidate and its modifications in the blockchain
-#[derive(Debug, Clone)]
-pub struct BlockInChain {
-    pub block: Block,
-    pub utxo_set: UnspentOutputsPool,
-    pub data_request_pool: DataRequestPool,
-}
-
 impl<T: AsRef<[u8]>> Hashable for T {
     fn hash(&self) -> Hash {
         calculate_sha256(self.as_ref()).into()

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -40,7 +40,7 @@ impl Actor for ChainManager {
 impl ChainManager {
     /// Get configuration from ConfigManager and try to initialize ChainManager state from Storage
     /// (initialize to Default values if empty)
-    fn initialize_from_storage(&mut self, ctx: &mut Context<ChainManager>) {
+    pub fn initialize_from_storage(&mut self, ctx: &mut Context<ChainManager>) {
         config_mngr::get().into_actor(self).and_then(|config, act, ctx| {
             // Get environment and consensus_constants parameters from config
             let environment = (&config.environment).clone();

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -190,7 +190,7 @@ impl Handler<AddBlocks> for ChainManager {
             StateMachine::WaitingConsensus => {}
             StateMachine::Synchronizing => {
                 if let Some(target_beacon) = self.target_beacon {
-                    let mut batch_succeded = true;
+                    let mut batch_succeeded = true;
                     for block in msg.blocks.iter() {
                         if let Err(e) = self.process_requested_block(ctx, block) {
                             log::error!("Error processing block: {}", e);

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -205,14 +205,14 @@ impl Handler<AddBlocks> for ChainManager {
                         }
                     }
 
-                    if batch_succeded {
-                        self.persist_chain_state(ctx);
+                    if batch_succeeded {
                         self.persist_blocks_batch(ctx, msg.blocks, target_beacon);
                         let to_be_stored =
                             self.chain_state.data_request_pool.finished_data_requests();
                         to_be_stored.into_iter().for_each(|dr| {
                             self.persist_data_request(ctx, &dr);
                         });
+                        self.persist_chain_state(ctx);
                     }
 
                     let beacon = self.get_chain_beacon();

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -30,6 +30,7 @@ use witnet_data_structures::{
 use witnet_rad::types::RadonTypes;
 use witnet_validations::validations::{
     block_reward, merkle_tree_root, transaction_fee, validate_block, verify_poe_data_request,
+    UtxoDiff,
 };
 
 impl ChainManager {
@@ -110,7 +111,6 @@ impl ChainManager {
                             beacon,
                             act.genesis_block_hash,
                             &act.chain_state.unspent_outputs_pool,
-                            &act.transactions_pool,
                             &act.chain_state.data_request_pool,
                         ) {
                             Ok(_) => {
@@ -328,7 +328,8 @@ fn build_block(
         debug!("Pushing transaction into block: {:?}", transaction);
         // Currently, 1 weight unit is equivalent to 1 byte
         let transaction_weight = transaction.size();
-        let transaction_fee = match transaction_fee(&transaction.body, unspent_outputs_pool) {
+        let utxo_diff = UtxoDiff::new(unspent_outputs_pool);
+        let transaction_fee = match transaction_fee(&transaction.body, &utxo_diff) {
             Ok(x) => x,
             Err(e) => {
                 warn!(

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -1,5 +1,3 @@
-use std::default::Default;
-
 use witnet_crypto::{
     hash::Sha256,
     merkle::{merkle_tree_root as crypto_merkle_tree_root, ProgressiveMerkleTree},


### PR DESCRIPTION
## Changes
`validate_block` function now returns a *diff* of changes to apply to the utxo set instead of cloning the utxo set before validation. This has two implications:

1. When choosing the candidate: Each block candidate keeps its own diff, when one is chosen as the best candidate, its diff is consolidated into the chain state.
2. When synchronizing the chain: Each block in the batch of 500 blocks is validated, if it's valid, its diff is consolidated into the chain state. After the validation of the entire batch the chain is persisted into the storage. If for some reason one block it's not valid, the entire batch is cancelled and the chain state is restored to the last persisted state.