### PR TITLE
refactory(clippy): fix clippy warnings

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -21,7 +21,8 @@ versions:
 
 # run clippy
 clippy:
-    cargo clippy --all-targets --all-features -- -D warnings
+    cargo clippy --all --all-features -- -D warnings
+    cargo clippy --all --all-targets --all-features -- -A clippy::cyclomatic_complexity
 
 # run formatter
 fmt:

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -277,11 +277,11 @@ mod tests {
 
         let account = extended_sk
             .derive(vec![
-                ChildNumber(0x8000002c), // purpose: BIP-44
-                ChildNumber(0x80000000), // coin_type: Bitcoin
-                ChildNumber(0x80000000), // account: hardened 0
-                ChildNumber(0),          // change: 0
-                ChildNumber(0),          // address: 0
+                ChildNumber(0x8000_002c), // purpose: BIP-44
+                ChildNumber(0x8000_0000), // coin_type: Bitcoin
+                ChildNumber(0x8000_0000), // account: hardened 0
+                ChildNumber(0),           // change: 0
+                ChildNumber(0),           // address: 0
             ])
             .unwrap();
 

--- a/data_structures/src/builders.rs
+++ b/data_structures/src/builders.rs
@@ -239,7 +239,7 @@ mod tests {
         let socket_addr: SocketAddr = "127.0.0.1:3000".parse().unwrap();
         let witnet_addr: Address = to_address(socket_addr);
 
-        assert_eq!(witnet_addr.ip, IpAddress::Ipv4 { ip: 2130706433 });
+        assert_eq!(witnet_addr.ip, IpAddress::Ipv4 { ip: 2_130_706_433 });
         assert_eq!(witnet_addr.port, 3000);
     }
 
@@ -263,7 +263,7 @@ mod tests {
     #[test]
     fn test_from_address_ipv4() {
         let witnet_addr: Address = Address {
-            ip: IpAddress::Ipv4 { ip: 2130706433 },
+            ip: IpAddress::Ipv4 { ip: 2_130_706_433 },
             port: 3000,
         };
         let socket_addr: SocketAddr = from_address(&witnet_addr);

--- a/data_structures/tests/builders.rs
+++ b/data_structures/tests/builders.rs
@@ -75,7 +75,7 @@ fn builders_build_peers() {
     // Expected message
     let mut addresses = Vec::new();
     let address: Address = Address {
-        ip: IpAddress::Ipv4 { ip: 3232235777 },
+        ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
         port: 8000,
     };
     addresses.push(address);
@@ -105,8 +105,8 @@ fn builders_build_ping() {
     // Check that the build_ping function builds the expected message
     assert_eq!(built_msg.magic, msg.magic);
     match built_msg.kind {
-        Command::Ping(Ping { nonce: _ }) => assert!(true),
-        _ => assert!(false, "Expected ping, found another type"),
+        Command::Ping(Ping { .. }) => (),
+        _ => panic!("Expected ping, found another type"),
     };
 }
 
@@ -128,11 +128,11 @@ fn builders_build_version() {
     // Expected message (except nonce which is random and timestamp which is the current one)
     let hardcoded_last_epoch = 1234;
     let sender_addr = Address {
-        ip: IpAddress::Ipv4 { ip: 3232235777 },
+        ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
         port: 8000,
     };
     let receiver_addr = Address {
-        ip: IpAddress::Ipv4 { ip: 3232235778 },
+        ip: IpAddress::Ipv4 { ip: 3_232_235_778 },
         port: 8001,
     };
     let version_cmd = Command::Version(Version {
@@ -165,23 +165,21 @@ fn builders_build_version() {
     match &built_msg.kind {
         Command::Version(Version {
             version,
-            timestamp: _,
             capabilities,
             sender_address,
             receiver_address,
             user_agent,
             last_epoch,
-            nonce: _,
-        }) if *version == PROTOCOL_VERSION
-            && *capabilities == CAPABILITIES
-            && *sender_address == sender_addr
-            && *receiver_address == receiver_addr
-            && user_agent == USER_AGENT
-            && *last_epoch == hardcoded_last_epoch =>
-        {
-            assert!(true)
-        }
-        _ => assert!(false, "Some field/s do not match the expected value"),
+            ..
+        }) => assert!(
+            *version == PROTOCOL_VERSION
+                && *capabilities == CAPABILITIES
+                && *sender_address == sender_addr
+                && *receiver_address == receiver_addr
+                && user_agent == USER_AGENT
+                && *last_epoch == hardcoded_last_epoch
+        ),
+        _ => panic!("Some field/s do not match the expected value"),
     };
 }
 

--- a/data_structures/tests/proto.rs
+++ b/data_structures/tests/proto.rs
@@ -5,7 +5,7 @@ use witnet_data_structures::{proto::ProtobufConvert, types, types::IpAddress};
 fn address_proto() {
     // Serialize
     let addressv4 = types::Address {
-        ip: IpAddress::Ipv4 { ip: 0x10203040 },
+        ip: IpAddress::Ipv4 { ip: 0x1020_3040 },
         port: 21337,
     };
     let address_bytes = addressv4.to_pb_bytes().unwrap();
@@ -17,10 +17,10 @@ fn address_proto() {
 
     let addressv6 = types::Address {
         ip: IpAddress::Ipv6 {
-            ip0: 0x10203040,
+            ip0: 0x1020_3040,
             ip1: 0xabcd,
             ip2: 0x21,
-            ip3: 0x11111111,
+            ip3: 0x1111_1111,
         },
         port: 21337,
     };

--- a/data_structures/tests/serializers.rs
+++ b/data_structures/tests/serializers.rs
@@ -3,7 +3,7 @@ use witnet_data_structures::{
     {chain::*, types::*},
 };
 
-const EXAMPLE_BLOCK_VECTOR: &'static [u8] = &[
+const EXAMPLE_BLOCK_VECTOR: &[u8] = &[
     8, 1, 18, 146, 6, 58, 143, 6, 10, 74, 18, 36, 18, 34, 10, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 26, 34, 10, 32, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 43, 10,
@@ -181,7 +181,7 @@ fn message_get_peers_encode_decode() {
 fn message_get_peer_to_bytes() {
     let mut addresses = Vec::new();
     let address: Address = Address {
-        ip: IpAddress::Ipv4 { ip: 3232235777 },
+        ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
         port: 8000,
     };
     addresses.push(address);
@@ -199,7 +199,7 @@ fn message_get_peer_to_bytes() {
 fn message_peer_from_bytes() {
     let buf: Vec<u8> = [18, 12, 34, 10, 10, 8, 10, 6, 192, 168, 1, 1, 31, 64].to_vec();
     let address: Address = Address {
-        ip: IpAddress::Ipv4 { ip: 3232235777 },
+        ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
         port: 8000,
     };
     let mut addresses = Vec::new();
@@ -218,15 +218,15 @@ fn message_peer_from_bytes() {
 fn message_get_peer_encode_decode() {
     let mut addresses = Vec::new();
     let address_ipv4: Address = Address {
-        ip: IpAddress::Ipv4 { ip: 3232235777 },
+        ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
         port: 8000,
     };
     let address_ipv6: Address = Address {
         ip: IpAddress::Ipv6 {
-            ip0: 3232235777,
-            ip1: 3232235776,
-            ip2: 3232235778,
-            ip3: 3232235777,
+            ip0: 3_232_235_777,
+            ip1: 3_232_235_776,
+            ip2: 3_232_235_778,
+            ip3: 3_232_235_777,
         },
         port: 8000,
     };
@@ -282,11 +282,11 @@ fn message_verack_encode_decode() {
 #[test]
 fn message_version_to_bytes() {
     let sender_address = Address {
-        ip: IpAddress::Ipv4 { ip: 3232235777 },
+        ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
         port: 8000,
     };
     let receiver_address = Address {
-        ip: IpAddress::Ipv4 { ip: 3232235778 },
+        ip: IpAddress::Ipv4 { ip: 3_232_235_778 },
         port: 8001,
     };
     let msg = Message {
@@ -294,8 +294,8 @@ fn message_version_to_bytes() {
             version: 2,
             timestamp: 123,
             capabilities: 4,
-            sender_address: sender_address,
-            receiver_address: receiver_address,
+            sender_address,
+            receiver_address,
             user_agent: "asdf".to_string(),
             last_epoch: 8,
             nonce: 1,
@@ -316,11 +316,11 @@ fn message_version_to_bytes() {
 #[test]
 fn message_version_from_bytes() {
     let sender_address = Address {
-        ip: IpAddress::Ipv4 { ip: 3232235777 },
+        ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
         port: 8000,
     };
     let receiver_address = Address {
-        ip: IpAddress::Ipv4 { ip: 3232235778 },
+        ip: IpAddress::Ipv4 { ip: 3_232_235_778 },
         port: 8001,
     };
     let expected_msg = Message {
@@ -328,8 +328,8 @@ fn message_version_from_bytes() {
             version: 2,
             timestamp: 123,
             capabilities: 4,
-            sender_address: sender_address,
-            receiver_address: receiver_address,
+            sender_address,
+            receiver_address,
             user_agent: "asdf".to_string(),
             last_epoch: 8,
             nonce: 1,
@@ -350,11 +350,11 @@ fn message_version_from_bytes() {
 #[test]
 fn message_version_encode_decode() {
     let sender_address = Address {
-        ip: IpAddress::Ipv4 { ip: 3232235777 },
+        ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
         port: 8000,
     };
     let receiver_address = Address {
-        ip: IpAddress::Ipv4 { ip: 3232235778 },
+        ip: IpAddress::Ipv4 { ip: 3_232_235_778 },
         port: 8001,
     };
     let msg = Message {
@@ -362,8 +362,8 @@ fn message_version_encode_decode() {
             version: 2,
             timestamp: 123,
             capabilities: 4,
-            sender_address: sender_address,
-            receiver_address: receiver_address,
+            sender_address,
+            receiver_address,
             user_agent: "asdf".to_string(),
             last_epoch: 8,
             nonce: 1,

--- a/p2p/tests/peers.rs
+++ b/p2p/tests/peers.rs
@@ -66,15 +66,12 @@ fn p2p_peers_get_random() {
 
     // Get random address for a "big" number
     let mut diff: i16 = 0;
-    for _ in 0..100000 {
+    for _ in 0..100_000 {
         // Get a random address (there is only 1)
         match peers.get_random().unwrap() {
-            Some(addr) if addr == address1 => diff = diff + 1,
-            Some(addr) if addr == address2 => diff = diff - 1,
-            _ => assert!(
-                false,
-                "Get random function should retrieve a random address"
-            ),
+            Some(addr) if addr == address1 => diff += 1,
+            Some(addr) if addr == address2 => diff -= 1,
+            _ => panic!("Get random function should retrieve a random address"),
         }
     }
 

--- a/p2p/tests/sessions.rs
+++ b/p2p/tests/sessions.rs
@@ -276,15 +276,12 @@ fn p2p_sessions_get_random_anycast_session() {
 
     // Get random session for a "big" number
     let mut diff: i16 = 0;
-    for _ in 0..100000 {
+    for _ in 0..100_000 {
         // Get a random anycast sessions (there are only 2)
         match &sessions.get_random_anycast_session(false) {
-            Some(reference) if reference == "reference1" => diff = diff + 1,
-            Some(reference) if reference == "reference2" => diff = diff - 1,
-            _ => assert!(
-                false,
-                "Get random function should retrieve a random session"
-            ),
+            Some(reference) if reference == "reference1" => diff += 1,
+            Some(reference) if reference == "reference2" => diff -= 1,
+            _ => panic!("Get random function should retrieve a random session"),
         }
     }
 

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -93,8 +93,8 @@ fn test_run_retrieval() {
 fn test_run_consensus_and_aggregation() {
     use crate::types::float::RadonFloat;
 
-    let f_1 = RadonTypes::Float(RadonFloat::from(1f64).into());
-    let f_3 = RadonTypes::Float(RadonFloat::from(3f64).into());
+    let f_1 = RadonTypes::Float(RadonFloat::from(1f64));
+    let f_3 = RadonTypes::Float(RadonFloat::from(3f64));
 
     let radon_types_vec = vec![f_1, f_3];
 

--- a/storage/src/backends/rocksdb.rs
+++ b/storage/src/backends/rocksdb.rs
@@ -61,13 +61,14 @@ mod rocksdb_mock {
 
     pub type Error = failure::Error;
 
+    #[derive(Default)]
     pub struct DB {
         data: Vec<(Vec<u8>, Vec<u8>)>,
     }
 
     impl DB {
         pub fn new() -> Self {
-            DB { data: Vec::new() }
+            DB::default()
         }
 
         fn search<K: AsRef<[u8]>>(&self, key: &K) -> Option<usize> {


### PR DESCRIPTION
I have updated the `clippy` command inside `Justfile` to include `--alll`, and fixed all the errors.

<details><summary>The errors reported by clippy</summary>
<pre>
    Checking witnet_util v0.2.0 (/home/anler/src/public/witnet-rust/util)
    Checking witnet_crypto v0.2.0 (/home/anler/src/public/witnet-rust/crypto)
warning: long literal lacking separators
   --> crypto/src/key.rs:280:29
    |
280 |                 ChildNumber(0x8000002c), // purpose: BIP-44
    |                             ^^^^^^^^^^ help: consider: `0x8000_002c`
    |
    = note: #[warn(clippy::unreadable_literal)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> crypto/src/key.rs:281:29
    |
281 |                 ChildNumber(0x80000000), // coin_type: Bitcoin
    |                             ^^^^^^^^^^ help: consider: `0x8000_0000`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> crypto/src/key.rs:282:29
    |
282 |                 ChildNumber(0x80000000), // account: hardened 0
    |                             ^^^^^^^^^^ help: consider: `0x8000_0000`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

    Checking witnet_p2p v0.2.0 (/home/anler/src/public/witnet-rust/p2p)
    Checking witnet_data_structures v0.2.0 (/home/anler/src/public/witnet-rust/data_structures)
warning: long literal lacking separators
   --> data_structures/src/builders.rs:242:58
    |
242 |         assert_eq!(witnet_addr.ip, IpAddress::Ipv4 { ip: 2130706433 });
    |                                                          ^^^^^^^^^^ help: consider: `2_130_706_433`
    |
    = note: #[warn(clippy::unreadable_literal)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/src/builders.rs:266:39
    |
266 |             ip: IpAddress::Ipv4 { ip: 2130706433 },
    |                                       ^^^^^^^^^^ help: consider: `2_130_706_433`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: the function has a cyclomatic complexity of 31
    --> data_structures/src/data_request.rs:1203:5
     |
1203 | /     fn update_multiple_times() {
1204 | |         // Only the first consecutive call to update_data_request_stages should change the state
1205 | |         let fake_block_hash = Hash::SHA256([1; 32]);
1206 | |         let epoch = 0;
...    |
1381 | |         assert_eq!(p.to_be_stored[0].0, dr_pointer);
1382 | |     }
     | |_____^
     |
     = note: #[warn(clippy::cyclomatic_complexity)] on by default
     = help: you could split it up into multiple smaller functions
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cyclomatic_complexity

warning: long literal lacking separators
   --> p2p/tests/sessions.rs:279:17
    |
279 |     for _ in 0..100000 {
    |                 ^^^^^^ help: consider: `100_000`
    |
    = note: #[warn(clippy::unreadable_literal)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: manual implementation of an assign operation
   --> p2p/tests/sessions.rs:282:61
    |
282 |             Some(reference) if reference == "reference1" => diff = diff + 1,
    |                                                             ^^^^^^^^^^^^^^^ help: replace it with: `diff += 1`
    |
    = note: #[warn(clippy::assign_op_pattern)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern

warning: manual implementation of an assign operation
   --> p2p/tests/sessions.rs:283:61
    |
283 |             Some(reference) if reference == "reference2" => diff = diff - 1,
    |                                                             ^^^^^^^^^^^^^^^ help: replace it with: `diff -= 1`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern

warning: assert!(false) should probably be replaced
   --> p2p/tests/sessions.rs:284:18
    |
284 |               _ => assert!(
    |  __________________^
285 | |                 false,
286 | |                 "Get random function should retrieve a random session"
287 | |             ),
    | |_____________^
    |
    = note: #[warn(clippy::assertions_on_constants)] on by default
    = help: use panic!() or unreachable!()
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants

warning: the function has a cyclomatic complexity of 26
   --> p2p/tests/sessions.rs:448:1
    |
448 | / fn p2p_sessions_consensus() {
449 | |     // Create sessions struct
450 | |     let mut sessions = Sessions::<String>::default();
451 | |
...   |
520 | |     assert!(sessions.unconsensus_session(outbound_address).is_err());
521 | | }
    | |_^
    |
    = note: #[warn(clippy::cyclomatic_complexity)] on by default
    = help: you could split it up into multiple smaller functions
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cyclomatic_complexity

warning: long literal lacking separators
  --> p2p/tests/peers.rs:69:17
   |
69 |     for _ in 0..100000 {
   |                 ^^^^^^ help: consider: `100_000`
   |
   = note: #[warn(clippy::unreadable_literal)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> p2p/tests/sessions.rs:279:17
    |
279 |     for _ in 0..100000 {
    |                 ^^^^^^ help: consider: `100_000`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: manual implementation of an assign operation
  --> p2p/tests/peers.rs:72:47
   |
72 |             Some(addr) if addr == address1 => diff = diff + 1,
   |                                               ^^^^^^^^^^^^^^^ help: replace it with: `diff += 1`
   |
   = note: #[warn(clippy::assign_op_pattern)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern

warning: manual implementation of an assign operation
  --> p2p/tests/peers.rs:73:47
   |
73 |             Some(addr) if addr == address2 => diff = diff - 1,
   |                                               ^^^^^^^^^^^^^^^ help: replace it with: `diff -= 1`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern

warning: assert!(false) should probably be replaced
  --> p2p/tests/peers.rs:74:18
   |
74 |               _ => assert!(
   |  __________________^
75 | |                 false,
76 | |                 "Get random function should retrieve a random address"
77 | |             ),
   | |_____________^
   |
   = note: #[warn(clippy::assertions_on_constants)] on by default
   = help: use panic!() or unreachable!()
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants

warning: manual implementation of an assign operation
   --> p2p/tests/sessions.rs:282:61
    |
282 |             Some(reference) if reference == "reference1" => diff = diff + 1,
    |                                                             ^^^^^^^^^^^^^^^ help: replace it with: `diff += 1`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern

warning: manual implementation of an assign operation
   --> p2p/tests/sessions.rs:283:61
    |
283 |             Some(reference) if reference == "reference2" => diff = diff - 1,
    |                                                             ^^^^^^^^^^^^^^^ help: replace it with: `diff -= 1`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern

warning: assert!(false) should probably be replaced
   --> p2p/tests/sessions.rs:284:18
    |
284 |               _ => assert!(
    |  __________________^
285 | |                 false,
286 | |                 "Get random function should retrieve a random session"
287 | |             ),
    | |_____________^
    |
    = help: use panic!() or unreachable!()
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants

warning: the function has a cyclomatic complexity of 26
   --> p2p/tests/sessions.rs:448:1
    |
448 | / fn p2p_sessions_consensus() {
449 | |     // Create sessions struct
450 | |     let mut sessions = Sessions::<String>::default();
451 | |
...   |
520 | |     assert!(sessions.unconsensus_session(outbound_address).is_err());
521 | | }
    | |_^
    |
    = note: #[warn(clippy::cyclomatic_complexity)] on by default
    = help: you could split it up into multiple smaller functions
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cyclomatic_complexity

warning: long literal lacking separators
  --> p2p/tests/peers.rs:69:17
   |
69 |     for _ in 0..100000 {
   |                 ^^^^^^ help: consider: `100_000`
   |
   = note: #[warn(clippy::unreadable_literal)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: manual implementation of an assign operation
  --> p2p/tests/peers.rs:72:47
   |
72 |             Some(addr) if addr == address1 => diff = diff + 1,
   |                                               ^^^^^^^^^^^^^^^ help: replace it with: `diff += 1`
   |
   = note: #[warn(clippy::assign_op_pattern)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern

warning: manual implementation of an assign operation
  --> p2p/tests/peers.rs:73:47
   |
73 |             Some(addr) if addr == address2 => diff = diff - 1,
   |                                               ^^^^^^^^^^^^^^^ help: replace it with: `diff -= 1`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern

warning: assert!(false) should probably be replaced
  --> p2p/tests/peers.rs:74:18
   |
74 |               _ => assert!(
   |  __________________^
75 | |                 false,
76 | |                 "Get random function should retrieve a random address"
77 | |             ),
   | |_____________^
   |
   = note: #[warn(clippy::assertions_on_constants)] on by default
   = help: use panic!() or unreachable!()
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants

    Checking witnet_rad v0.2.0 (/home/anler/src/public/witnet-rust/rad)
    Checking witnet_config v0.2.0 (/home/anler/src/public/witnet-rust/config)
warning: long literal lacking separators
 --> data_structures/tests/proto.rs:8:35
  |
8 |         ip: IpAddress::Ipv4 { ip: 0x10203040 },
  |                                   ^^^^^^^^^^ help: consider: `0x1020_3040`
  |
  = note: #[warn(clippy::unreadable_literal)] on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
  --> data_structures/tests/proto.rs:20:18
   |
20 |             ip0: 0x10203040,
   |                  ^^^^^^^^^^ help: consider: `0x1020_3040`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
  --> data_structures/tests/proto.rs:23:18
   |
23 |             ip3: 0x11111111,
   |                  ^^^^^^^^^^ help: consider: `0x1111_1111`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: redundant field names in struct initialization
   --> data_structures/tests/serializers.rs:297:13
    |
297 |             sender_address: sender_address,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `sender_address`
    |
    = note: #[warn(clippy::redundant_field_names)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> data_structures/tests/serializers.rs:298:13
    |
298 |             receiver_address: receiver_address,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `receiver_address`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> data_structures/tests/serializers.rs:331:13
    |
331 |             sender_address: sender_address,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `sender_address`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> data_structures/tests/serializers.rs:332:13
    |
332 |             receiver_address: receiver_address,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `receiver_address`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> data_structures/tests/serializers.rs:365:13
    |
365 |             sender_address: sender_address,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `sender_address`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> data_structures/tests/serializers.rs:366:13
    |
366 |             receiver_address: receiver_address,
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `receiver_address`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: Constants have by default a `'static` lifetime
 --> data_structures/tests/serializers.rs:6:30
  |
6 | const EXAMPLE_BLOCK_VECTOR: &'static [u8] = &[
  |                             -^^^^^^^----- help: consider removing `'static`: `&[u8]`
  |
  = note: #[warn(clippy::const_static_lifetime)] on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#const_static_lifetime

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:184:35
    |
184 |         ip: IpAddress::Ipv4 { ip: 3232235777 },
    |                                   ^^^^^^^^^^ help: consider: `3_232_235_777`
    |
    = note: #[warn(clippy::unreadable_literal)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:202:35
    |
202 |         ip: IpAddress::Ipv4 { ip: 3232235777 },
    |                                   ^^^^^^^^^^ help: consider: `3_232_235_777`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:221:35
    |
221 |         ip: IpAddress::Ipv4 { ip: 3232235777 },
    |                                   ^^^^^^^^^^ help: consider: `3_232_235_777`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:226:18
    |
226 |             ip0: 3232235777,
    |                  ^^^^^^^^^^ help: consider: `3_232_235_777`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:227:18
    |
227 |             ip1: 3232235776,
    |                  ^^^^^^^^^^ help: consider: `3_232_235_776`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:228:18
    |
228 |             ip2: 3232235778,
    |                  ^^^^^^^^^^ help: consider: `3_232_235_778`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:229:18
    |
229 |             ip3: 3232235777,
    |                  ^^^^^^^^^^ help: consider: `3_232_235_777`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:285:35
    |
285 |         ip: IpAddress::Ipv4 { ip: 3232235777 },
    |                                   ^^^^^^^^^^ help: consider: `3_232_235_777`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:289:35
    |
289 |         ip: IpAddress::Ipv4 { ip: 3232235778 },
    |                                   ^^^^^^^^^^ help: consider: `3_232_235_778`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:319:35
    |
319 |         ip: IpAddress::Ipv4 { ip: 3232235777 },
    |                                   ^^^^^^^^^^ help: consider: `3_232_235_777`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:323:35
    |
323 |         ip: IpAddress::Ipv4 { ip: 3232235778 },
    |                                   ^^^^^^^^^^ help: consider: `3_232_235_778`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:353:35
    |
353 |         ip: IpAddress::Ipv4 { ip: 3232235777 },
    |                                   ^^^^^^^^^^ help: consider: `3_232_235_777`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/serializers.rs:357:35
    |
357 |         ip: IpAddress::Ipv4 { ip: 3232235778 },
    |                                   ^^^^^^^^^^ help: consider: `3_232_235_778`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
  --> data_structures/tests/builders.rs:78:35
   |
78 |         ip: IpAddress::Ipv4 { ip: 3232235777 },
   |                                   ^^^^^^^^^^ help: consider: `3_232_235_777`
   |
   = note: #[warn(clippy::unreadable_literal)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: All the struct fields are matched to a wildcard pattern, consider using `..`.
   --> data_structures/tests/builders.rs:108:23
    |
108 |         Command::Ping(Ping { nonce: _ }) => assert!(true),
    |                       ^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(clippy::unneeded_field_pattern)] on by default
    = help: Try with `Ping { .. }` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_field_pattern

warning: long literal lacking separators
   --> data_structures/tests/builders.rs:131:35
    |
131 |         ip: IpAddress::Ipv4 { ip: 3232235777 },
    |                                   ^^^^^^^^^^ help: consider: `3_232_235_777`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: long literal lacking separators
   --> data_structures/tests/builders.rs:135:35
    |
135 |         ip: IpAddress::Ipv4 { ip: 3232235778 },
    |                                   ^^^^^^^^^^ help: consider: `3_232_235_778`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unreadable_literal

warning: You matched a field with a wildcard pattern. Consider using `..` instead
   --> data_structures/tests/builders.rs:168:13
    |
168 |             timestamp: _,
    |             ^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_field_pattern

warning: You matched a field with a wildcard pattern. Consider using `..` instead
   --> data_structures/tests/builders.rs:174:13
    |
174 |             nonce: _,
    |             ^^^^^^^^
    |
    = help: Try with `Version { version, capabilities, sender_address, receiver_address, user_agent, last_epoch, .. }`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_field_pattern

warning: assert!(true) will be optimized out by the compiler
   --> data_structures/tests/builders.rs:108:45
    |
108 |         Command::Ping(Ping { nonce: _ }) => assert!(true),
    |                                             ^^^^^^^^^^^^^
    |
    = note: #[warn(clippy::assertions_on_constants)] on by default
    = help: remove it
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants

warning: assert!(false) should probably be replaced
   --> data_structures/tests/builders.rs:109:14
    |
109 |         _ => assert!(false, "Expected ping, found another type"),
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use panic!() or unreachable!()
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants

warning: assert!(true) will be optimized out by the compiler
   --> data_structures/tests/builders.rs:182:13
    |
182 |             assert!(true)
    |             ^^^^^^^^^^^^^
    |
    = help: remove it
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants

warning: assert!(false) should probably be replaced
   --> data_structures/tests/builders.rs:184:14
    |
184 |         _ => assert!(false, "Some field/s do not match the expected value"),
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use panic!() or unreachable!()
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants

warning: identical conversion
  --> rad/src/lib.rs:96:33
   |
96 |     let f_1 = RadonTypes::Float(RadonFloat::from(1f64).into());
   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `RadonFloat::from(1f64)`
   |
   = note: #[warn(clippy::identity_conversion)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion

warning: identical conversion
  --> rad/src/lib.rs:97:33
   |
97 |     let f_3 = RadonTypes::Float(RadonFloat::from(3f64).into());
   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `RadonFloat::from(3f64)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion

    Checking witnet_validations v0.2.0 (/home/anler/src/public/witnet-rust/validations)
    Checking witnet_storage v0.2.0 (/home/anler/src/public/witnet-rust/storage)
warning: you should consider deriving a `Default` implementation for `backends::rocksdb::rocksdb_mock::DB`
  --> storage/src/backends/rocksdb.rs:69:9
   |
69 | /         pub fn new() -> Self {
70 | |             DB { data: Vec::new() }
71 | |         }
   | |_________^
   |
   = note: #[warn(clippy::new_without_default)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
help: try this
   |
64 |     #[derive(Default)]
65 |     pub struct DB {
   |

    Checking witnet_node v0.2.0 (/home/anler/src/public/witnet-rust/node)
    Checking witnet v0.2.0 (/home/anler/src/public/witnet-rust)
    Finished dev [unoptimized + debuginfo] target(s) in 39.96s
</pre>
</details>

<details><summary>Warnings not fixed in this PR due to oto much effort (cyclomatic complexity)</summary>
<pre>
Checking witnet_data_structures v0.2.0 (/home/anler/src/public/witnet-rust/data_structures)
warning: the function has a cyclomatic complexity of 31
    --> data_structures/src/data_request.rs:1203:5
     |
1203 | /     fn update_multiple_times() {
1204 | |         // Only the first consecutive call to update_data_request_stages should change the state
1205 | |         let fake_block_hash = Hash::SHA256([1; 32]);
1206 | |         let epoch = 0;
...    |
1381 | |         assert_eq!(p.to_be_stored[0].0, dr_pointer);
1382 | |     }
     | |_____^
     |
     = note: #[warn(clippy::cyclomatic_complexity)] on by default
     = help: you could split it up into multiple smaller functions
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cyclomatic_complexity

warning: the function has a cyclomatic complexity of 26
   --> p2p/tests/sessions.rs:445:1
    |
445 | / fn p2p_sessions_consensus() {
446 | |     // Create sessions struct
447 | |     let mut sessions = Sessions::<String>::default();
448 | |
...   |
517 | |     assert!(sessions.unconsensus_session(outbound_address).is_err());
518 | | }
    | |_^
    |
    = note: #[warn(clippy::cyclomatic_complexity)] on by default
    = help: you could split it up into multiple smaller functions
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cyclomatic_complexity

warning: the function has a cyclomatic complexity of 26
   --> p2p/tests/sessions.rs:445:1
    |
445 | / fn p2p_sessions_consensus() {
446 | |     // Create sessions struct
447 | |     let mut sessions = Sessions::<String>::default();
448 | |
...   |
517 | |     assert!(sessions.unconsensus_session(outbound_address).is_err());
518 | | }
    | |_^
    |
    = note: #[warn(clippy::cyclomatic_complexity)] on by default
    = help: you could split it up into multiple smaller functions
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cyclomatic_complexity
</pre>
</summary>