### PR TITLE
Continuous integration and Justfile overhaul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
-language: rust
-cache: cargo
-dist: trusty
+dist: xenial
 sudo: false
+language: rust
+
 rust:
   - stable
+
+# https://levans.fr/rust_travis_cache.html
+# Need to cache the whole `.cargo` directory to keep .crates.toml for `cargo update` to work...
+# ...but don't cache the cargo registry
+cache:
+  directories:
+    - /home/travis/.cargo
+before_cache:
+  - rm -rf /home/travis/.cargo/registry
 
 addons:
   apt:
@@ -20,15 +29,15 @@ addons:
       - gcc
       - binutils-dev
       - protobuf-compiler
+      - librocksdb-dev
 
 env:
   global:
+    - ROCKSDB_LIB_DIR=/usr/lib/ # Use dynamically linked RocksDB library to speed up builds
     - RUST_BACKTRACE="1"
 
 before_script:
-    - just || curl -LSfs https://japaric.github.io/trust/install.sh |
-        sh -s -- --git casey/just --target x86_64-unknown-linux-musl --to ~/.cargo/bin
+  - just || curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git casey/just --target x86_64-unknown-linux-musl --to ~/.cargo/bin
 
 script:
-    - just travis
-
+  - just ci


### PR DESCRIPTION
- Speeds up travis builds by improving caching and linking rocksdb dynamically
- Renames `just travis` to `just ci`
- Adds the possibility of passing flags to `just clippy`, `just fmt` and `just node`

Close #583 