### PR TITLE
Added log::info for block candidates

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -238,7 +238,7 @@ impl Handler<AddCandidates> for ChainManager {
     fn handle(&mut self, msg: AddCandidates, _ctx: &mut Context<Self>) {
         // AddCandidates is needed in all states
         for block in msg.blocks {
-            self.process_candidate(block)
+            self.process_candidate(block);
         }
     }
 }

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -116,6 +116,12 @@ impl ChainManager {
                             Ok(_) => {
                                 // Send AddCandidates message to self
                                 // This will run all the validations again
+
+                                let block_hash = block.hash();
+                                log::info!(
+                                    "Proposed block candidate {}",
+                                    Yellow.bold().paint(block_hash.to_string())
+                                );
                                 act.handle(
                                     AddCandidates {
                                         blocks: vec![block],


### PR DESCRIPTION
Closes #568 

I have added a `log::info` on the Handler for AddCandidate.

Here's how it looks:

![block candidate](https://user-images.githubusercontent.com/34509679/56285915-be23a200-60ee-11e9-8e20-b09af7f3c933.png)
