### PR TITLE
docs(radon): fix array flatten signature

### DIFF
--- a/docs/protocol/data-requests/radon/types/array.md
+++ b/docs/protocol/data-requests/radon/types/array.md
@@ -49,7 +49,7 @@ The supplied `(input: T): O` function can be either be a valid [subscript] over 
 
 ## `Array.flatten()`
 ```ts
-flatten(depth: Int): Array<T>
+flatten(depth?: Int): Array<T>
 ```
 ```ts
 ARRAY_FLATTEN


### PR DESCRIPTION
This PR fixes the definition of array flatten method as pointed out in #539 