### PR TITLE
fix(serde): update serde dependencies in data_structures and node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,7 +2655,6 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_crypto 0.2.1",
  "witnet_util 0.2.1",

--- a/data_structures/Cargo.toml
+++ b/data_structures/Cargo.toml
@@ -12,8 +12,6 @@ failure = "0.1.5"
 protobuf = { version = "2.3.0", features = ["with-serde"] }
 protobuf-convert = "0.1.1"
 rand = "0.6.5"
-serde = "1.0.88"
-serde_derive = "1.0.88"
 toml = "0.4.10"
 log = "0.4.6"
 secp256k1 = "0.12.2"
@@ -29,3 +27,7 @@ path = "../util"
 
 [build-dependencies]
 exonum-build = "0.10.0"
+
+[dependencies.serde]
+features = ["derive"]
+version = "1.0.88"

--- a/data_structures/src/lib.rs
+++ b/data_structures/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
 
-extern crate serde_derive;
 #[macro_use]
 extern crate protobuf_convert;
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,7 +18,6 @@ jsonrpc-pubsub = "10.1.0"
 log = "0.4.6"
 rand = "0.6.5"
 rust-crypto = "0.2.36"
-serde = "1.0.88"
 serde_json = "1.0.38"
 tokio = "0.1.15"
 secp256k1 = "0.12.2"
@@ -36,3 +35,7 @@ witnet_validations = { path = "../validations" }
 [dependencies.actix]
 git = "https://github.com/actix/actix.git"
 rev = "d28d286ac652f81e72c2aa413e7c0d3fc6c6099c"
+
+[dependencies.serde]
+features = ["derive"]
+version = "1.0.88"


### PR DESCRIPTION
Updated old serde dependencies in data_structures and node to solve that if we do a cargo check in witnet-rust/data_strutctures instead of witnet-rust we load the older serde version and fail
