### PR TITLE
Testnet 3 release candidate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "partial_struct"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "witnet"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bytecount 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2737,34 +2737,34 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_config 0.2.1",
- "witnet_crypto 0.2.1",
- "witnet_data_structures 0.2.1",
- "witnet_node 0.2.1",
- "witnet_p2p 0.2.1",
- "witnet_rad 0.2.1",
- "witnet_storage 0.2.1",
- "witnet_util 0.2.1",
- "witnet_validations 0.2.1",
+ "witnet_config 0.3.0",
+ "witnet_crypto 0.3.0",
+ "witnet_data_structures 0.3.0",
+ "witnet_node 0.3.0",
+ "witnet_p2p 0.3.0",
+ "witnet_rad 0.3.0",
+ "witnet_storage 0.3.0",
+ "witnet_util 0.3.0",
+ "witnet_validations 0.3.0",
 ]
 
 [[package]]
 name = "witnet_config"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "partial_struct 0.2.1",
+ "partial_struct 0.3.0",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_data_structures 0.2.1",
- "witnet_protected 0.2.1",
+ "witnet_data_structures 0.3.0",
+ "witnet_protected 0.3.0",
 ]
 
 [[package]]
 name = "witnet_crypto"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2775,18 +2775,18 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_protected 0.2.1",
+ "witnet_protected 0.3.0",
 ]
 
 [[package]]
 name = "witnet_data_structures"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "exonum-build 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "partial_struct 0.2.1",
+ "partial_struct 0.3.0",
  "protobuf 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-convert 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2794,9 +2794,9 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "vrf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_crypto 0.2.1",
- "witnet_reputation 0.2.0",
- "witnet_util 0.2.1",
+ "witnet_crypto 0.3.0",
+ "witnet_reputation 0.3.0",
+ "witnet_util 0.3.0",
 ]
 
 [[package]]
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "witnet_node"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "actix 0.7.10 (git+https://github.com/actix/actix.git?rev=d28d286ac652f81e72c2aa413e7c0d3fc6c6099c)",
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2833,37 +2833,37 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_config 0.2.1",
- "witnet_crypto 0.2.1",
- "witnet_data_structures 0.2.1",
- "witnet_p2p 0.2.1",
- "witnet_rad 0.2.1",
- "witnet_storage 0.2.1",
- "witnet_util 0.2.1",
- "witnet_validations 0.2.1",
- "witnet_wallet 0.2.0",
+ "witnet_config 0.3.0",
+ "witnet_crypto 0.3.0",
+ "witnet_data_structures 0.3.0",
+ "witnet_p2p 0.3.0",
+ "witnet_rad 0.3.0",
+ "witnet_storage 0.3.0",
+ "witnet_util 0.3.0",
+ "witnet_validations 0.3.0",
+ "witnet_wallet 0.3.0",
 ]
 
 [[package]]
 name = "witnet_p2p"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_util 0.2.1",
+ "witnet_util 0.3.0",
 ]
 
 [[package]]
 name = "witnet_protected"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "memzero 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "witnet_rad"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2876,14 +2876,14 @@ dependencies = [
  "rmpv 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_crypto 0.2.1",
- "witnet_data_structures 0.2.1",
- "witnet_util 0.2.1",
+ "witnet_crypto 0.3.0",
+ "witnet_data_structures 0.3.0",
+ "witnet_util 0.3.0",
 ]
 
 [[package]]
 name = "witnet_reputation"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2893,17 +2893,17 @@ dependencies = [
 
 [[package]]
 name = "witnet_storage"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_crypto 0.2.1",
- "witnet_protected 0.2.1",
+ "witnet_crypto 0.3.0",
+ "witnet_protected 0.3.0",
 ]
 
 [[package]]
 name = "witnet_util"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2911,18 +2911,18 @@ dependencies = [
 
 [[package]]
 name = "witnet_validations"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_crypto 0.2.1",
- "witnet_data_structures 0.2.1",
- "witnet_rad 0.2.1",
+ "witnet_crypto 0.3.0",
+ "witnet_data_structures 0.3.0",
+ "witnet_rad 0.3.0",
 ]
 
 [[package]]
 name = "witnet_wallet"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "actix 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-jsonrpc-client 0.1.0 (git+https://github.com/witnet/async-jsonrpc-client)",
@@ -2938,12 +2938,12 @@ dependencies = [
  "rocksdb 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_config 0.2.1",
- "witnet_crypto 0.2.1",
- "witnet_data_structures 0.2.1",
+ "witnet_config 0.3.0",
+ "witnet_crypto 0.3.0",
+ "witnet_data_structures 0.3.0",
  "witnet_net 0.1.0",
- "witnet_rad 0.2.1",
- "witnet_storage 0.2.1",
+ "witnet_rad 0.3.0",
+ "witnet_storage 0.3.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 publish = false
 repository = "witnet/witnet-rust"

--- a/Justfile
+++ b/Justfile
@@ -28,7 +28,7 @@ versions:
 # run clippy
 clippy +flags="":
     cargo clippy --all --all-features -- -D warnings {{flags}}
-    cargo clippy --all --all-targets --all-features -- -A clippy::cognitive_complexity {{flags}}
+    cargo clippy --all --all-targets --all-features -- -A clippy::type_complexity {{flags}}
 
 # run formatter
 fmt +flags="":

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "config component"
 edition = "2018"
 name = "witnet_config"
-version = "0.2.1"
+version = "0.3.0"
 workspace = ".."
 
 [dependencies]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -46,7 +46,7 @@ use std::time::Duration;
 use log::warn;
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::defaults::{Defaults, Testnet1};
+use crate::defaults::{Defaults, Testnet1, Testnet3};
 use crate::dirs;
 use partial_struct::PartialStruct;
 use witnet_data_structures::chain::{ConsensusConstants, Environment, PartialConsensusConstants};
@@ -227,11 +227,12 @@ pub struct Mining {
 
 impl Config {
     pub fn from_partial(config: &PartialConfig) -> Self {
-        let defaults = match config.environment {
+        let defaults: &dyn Defaults = match config.environment {
             Environment::Mainnet => {
                 panic!("Config with mainnet environment is currently not allowed");
             }
             Environment::Testnet1 => &Testnet1,
+            Environment::Testnet3 => &Testnet3,
         };
 
         let consensus_constants = match config.environment {
@@ -248,6 +249,9 @@ impl Config {
             }
             // In testnet, allow to override the consensus constants
             Environment::Testnet1 => {
+                consensus_constants_from_partial(&config.consensus_constants, defaults)
+            }
+            Environment::Testnet3 => {
                 consensus_constants_from_partial(&config.consensus_constants, defaults)
             }
         };

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -538,47 +538,47 @@ mod tests {
         let partial_config = PartialConfig::default();
         let config = Config::from_partial(&partial_config);
 
-        assert_eq!(config.environment, Environment::Testnet1);
+        assert_eq!(config.environment, Environment::Testnet3);
         assert_eq!(
             config.connections.server_addr,
-            Testnet1.connections_server_addr()
+            Testnet3.connections_server_addr()
         );
         assert_eq!(
             config.connections.inbound_limit,
-            Testnet1.connections_inbound_limit()
+            Testnet3.connections_inbound_limit()
         );
         assert_eq!(
             config.connections.outbound_limit,
-            Testnet1.connections_outbound_limit()
+            Testnet3.connections_outbound_limit()
         );
         assert_eq!(
             config.connections.known_peers,
-            Testnet1.connections_known_peers()
+            Testnet3.connections_known_peers()
         );
         assert_eq!(
             config.connections.bootstrap_peers_period,
-            Testnet1.connections_bootstrap_peers_period()
+            Testnet3.connections_bootstrap_peers_period()
         );
         assert_eq!(
             config.connections.storage_peers_period,
-            Testnet1.connections_storage_peers_period()
+            Testnet3.connections_storage_peers_period()
         );
         assert_eq!(
             config.connections.discovery_peers_period,
-            Testnet1.connections_discovery_peers_period()
+            Testnet3.connections_discovery_peers_period()
         );
         assert_eq!(
             config.connections.handshake_timeout,
-            Testnet1.connections_handshake_timeout()
+            Testnet3.connections_handshake_timeout()
         );
-        assert_eq!(config.storage.db_path, Testnet1.storage_db_path());
+        assert_eq!(config.storage.db_path, Testnet3.storage_db_path());
         assert_eq!(
             config.jsonrpc.server_address,
-            Testnet1.jsonrpc_server_address()
+            Testnet3.jsonrpc_server_address()
         );
         assert_eq!(
             config.connections.blocks_timeout,
-            Testnet1.connections_blocks_timeout()
+            Testnet3.connections_blocks_timeout()
         );
     }
 }

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -140,6 +140,9 @@ pub struct Mainnet;
 /// Struct that will implement all the testnet-1 defaults
 pub struct Testnet1;
 
+/// Struct that will implement all the testnet-3 defaults
+pub struct Testnet3;
+
 impl Defaults for Mainnet {
     fn connections_server_addr(&self) -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 11337)
@@ -178,8 +181,29 @@ impl Defaults for Testnet1 {
     }
 
     fn consensus_constants_checkpoint_zero_timestamp(&self) -> i64 {
-        // A point far in the future, so the `EpochManager` will return an error
-        // `EpochZeroInTheFuture`
         1_548_855_420
+    }
+}
+
+impl Defaults for Testnet3 {
+    fn connections_server_addr(&self) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 21337)
+    }
+
+    fn jsonrpc_server_address(&self) -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 21338)
+    }
+
+    fn storage_db_path(&self) -> PathBuf {
+        PathBuf::from(".witnet-rust-testnet-3")
+    }
+
+    fn connections_bootstrap_peers_period(&self) -> Duration {
+        Duration::from_secs(15)
+    }
+
+    fn consensus_constants_checkpoint_zero_timestamp(&self) -> i64 {
+        // June 1st, 2019
+        1_559_347_200
     }
 }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_crypto"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 description = "crypto component"

--- a/data_structures/Cargo.toml
+++ b/data_structures/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "data structures component"
 edition = "2018"
 name = "witnet_data_structures"
-version = "0.2.1"
+version = "0.3.0"
 workspace = ".."
 
 [dependencies]

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -56,11 +56,14 @@ pub enum Environment {
     /// "testnet" environment
     #[serde(rename = "testnet-1")]
     Testnet1,
+    /// "testnet" environment
+    #[serde(rename = "testnet-3")]
+    Testnet3,
 }
 
 impl Default for Environment {
     fn default() -> Environment {
-        Environment::Testnet1
+        Environment::Testnet3
     }
 }
 

--- a/docs/configuration/environment.md
+++ b/docs/configuration/environment.md
@@ -24,20 +24,32 @@ At the moment, the available environments are: `testnet-1` and `mainnet`.
 | `jsonrpc`             | `server_address`                 | `"127.0.0.1:21338"`        | JSON-RPC server socket address                                      |
 | `mining`              | `enabled`                        | `true`                     | Enable MiningManager                                                |
 
+## Defaults for Testnet-3
+
+| Section               | Param                            | Default Value              | Description                                                         |
+|-----------------------|----------------------------------|----------------------------|---------------------------------------------------------------------|
+| `connections`         | `server_addr`                    | `"127.0.0.1:21337"`        | Server socket address to which it should bind to                    |
+| `connections`         | `inbound_limit`                  | `128`                      | Maximum number of concurrent connections the server should accept   |
+| `connections`         | `outbound_limit`                 | `8`                        | Maximum number of opened connections to other peers this node has   |
+| `connections`         | `known_peers`                    | `["52.166.178.145:21337"]` | Other peer addresses this node knows about at start                 |
+| `connections`         | `bootstrap_peers_period_seconds` | `5`                        | Period of the outbound peer bootstrapping process (in seconds)      |
+| `connections`         | `discovery_peers_period_seconds` | `5`                        | Period of the outbound peer discovery process (in seconds)          |
+| `connections`         | `handshake_timeout_seconds`      | `5`                        | Timeout for the handshake process (in seconds)                      |
+| `connections`         | `blocks_timeout_secconds`        | `400`                      | Number of seconds before giving up waiting for requested blocks     |
+| `storage`             | `db_path`                        | `".witnet-rust-testnet-3"` | Directory containing the database files                             |
+| `storage`             | `peers_period_seconds`           | `30`                       | Period of the known peers backup into storage process (in seconds)  |
+| `consensus_constants` | `activity_period`                | `40`                       | Number of recent epochs to comput for witness activity metric	      |
+| `consensus_constants` | `checkpoint_zero_timestamp`      | `1559347200`               | Timestamp at checkpoint 0 (the start of epoch 0)                    |
+| `consensus_constants` | `checkpoints_period_seconds`     | `90`                       | Seconds between the start of an epoch and the start of the next one |
+| `consensus_constants` | `max_block_weight`               | `10000`                    | Maximum size for each block in the chain                            |
+| `consensus_constants` | `reputation_issuance`            | `1`                        | How many reputation points to issue per each witnessing act         |
+| `consensus_constants` | `reputation_issuance_stop`       | `1048576`                  | Number of witnessing acts before reputation issuance halts          |
+| `consensus_constants` | `reputation_expire_alpha_diff`   | `20000`                    | Number of witnessing acts before a reputation point expires         |
+| `consensus_constants` | `reputation_penalization_factor  | `0.5`                      | Fraction of reputation lost by witnesses being out of consensus     |
+| `jsonrpc`             | `enabled`                        | `true`                     | Enable JSON-RPC server                                              |
+| `jsonrpc`             | `server_address`                 | `"127.0.0.1:21338"`        | JSON-RPC server socket address                                      |
+| `mining`              | `enabled`                        | `true`                     | Enable MiningManager                                                |
+
 ## Defaults for Mainnet
 
-| Section               | Param                            | Default Value            | Description                                                         |
-|-----------------------|----------------------------------|--------------------------|---------------------------------------------------------------------|
-| `connections`         | `server_addr`                    | `"127.0.0.1:11337"`      | Server socket address to which it should bind to                    |
-| `connections`         | `inbound_limit`                  | `128`                    | Maximum number of concurrent connections the server should accept   |
-| `connections`         | `outbound_limit`                 | `8`                      | Maximum number of opened connections to other peers this node has   |
-| `connections`         | `known_peers`                    | `[]`                     | Other peer addresses this node knows about at start                 |
-| `connections`         | `bootstrap_peers_period_seconds` | `5`                      | Period of the outbound peer bootstrapping process (in seconds)      |
-| `connections`         | `storage_peers_period_seconds`   | `30`                     | Period of the known peers backup into storage process (in seconds)  |
-| `connections`         | `handshake_timeout_seconds`      | `5`                      | Timeout for the handshake process (in seconds)                      |
-| `storage`             | `db_path`                        | `".witnet-rust-mainnet"` | Directory containing the database files                             |
-| `consensus_constants` | `checkpoint_zero_timestamp`      | `19_999_999_999_999`     | Timestamp at checkpoint 0 (the start of epoch 0)                    |
-| `consensus_constants` | `checkpoints_period_seconds`     | `90`                     | Seconds between the start of an epoch and the start of the next one |
-| `jsonrpc`             | `enabled`                        | `true`                   | Enable JSON-RPC server                                              |
-| `jsonrpc`             | `server_address`                 | `"127.0.0.1:11338"`      | JSON-RPC server socket address                                      |
-| `mining`              | `enabled`                        | `true`                   | Enable MiningManager                                                |
+Yet to be defined.

--- a/docs/configuration/toml-file.md
+++ b/docs/configuration/toml-file.md
@@ -5,13 +5,11 @@ A custom `witnet.toml` file can be used to configure parameters of the node. In 
 ## TOML file example
 
 ``` toml
-environment = "testnet-1" # or "mainnet"
-
 [connections] # section for connections-related params
 server_addr = "127.0.0.1:1234"
 inbound_limit = 128
 outbound_limit = 1
-known_peers = ["40.121.131.135:21337"]
+known_peers = ["52.166.178.145:21337"]
 bootstrap_peers_period_seconds = 30
 storage_peers_period_seconds = 30
 handshake_timeout_seconds = 5
@@ -35,23 +33,31 @@ enabled = true
 
 ## Configuration params
 
-| Section               | Param                            | Default Value in testnet-1 | Description                                                         |
+| Section               | Param                            | Default Value              | Description                                                         |
 |-----------------------|----------------------------------|----------------------------|---------------------------------------------------------------------|
 | `connections`         | `server_addr`                    | `"127.0.0.1:21337"`        | Server socket address to which it should bind to                    |
 | `connections`         | `inbound_limit`                  | `128`                      | Maximum number of concurrent connections the server should accept   |
-| `connections`         | `outbound_limit`                 | `1`                        | Maximum number of opened connections to other peers this node has   |
-| `connections`         | `known_peers`                    | `["40.121.131.135:21337"]` | Other peer addresses this node knows about at start                 |
-| `connections`         | `bootstrap_peers_period_seconds` | `30`                       | Period of the outbound peer bootstrapping process (in seconds)      |
-| `connections`         | `storage_peers_period_seconds`   | `30`                       | Period of the known peers backup into storage process (in seconds)  |
+| `connections`         | `outbound_limit`                 | `8`                        | Maximum number of opened connections to other peers this node has   |
+| `connections`         | `known_peers`                    | `["52.166.178.145:21337"]` | Other peer addresses this node knows about at start                 |
+| `connections`         | `bootstrap_peers_period_seconds` | `5`                        | Period of the outbound peer bootstrapping process (in seconds)      |
+| `connections`         | `discovery_peers_period_seconds` | `5`                        | Period of the outbound peer discovery process (in seconds)          |
 | `connections`         | `handshake_timeout_seconds`      | `5`                        | Timeout for the handshake process (in seconds)                      |
-| `storage`             | `db_path`                        | `".witnet-rust-testnet-1"` | Directory containing the database files                             |
-| `consensus_constants` | `checkpoint_zero_timestamp`      | `1548855420`               | Timestamp at checkpoint 0 (the start of epoch 0)                    |
+| `connections`         | `blocks_timeout_secconds`        | `400`                      | Number of seconds before giving up waiting for requested blocks     |
+| `storage`             | `db_path`                        | `".witnet-rust-testnet-3"` | Directory containing the database files                             |
+| `storage`             | `peers_period_seconds`           | `30`                       | Period of the known peers backup into storage process (in seconds)  |
+| `consensus_constants` | `activity_period`                | `40`                       | Number of recent epochs to comput for witness activity metric       |
+| `consensus_constants` | `checkpoint_zero_timestamp`      | `1559347200`               | Timestamp at checkpoint 0 (the start of epoch 0)                    |
 | `consensus_constants` | `checkpoints_period_seconds`     | `90`                       | Seconds between the start of an epoch and the start of the next one |
+| `consensus_constants` | `max_block_weight`               | `10000`                    | Maximum size for each block in the chain                            |
+| `consensus_constants` | `reputation_issuance`            | `1`                        | How many reputation points to issue per each witnessing act         |
+| `consensus_constants` | `reputation_issuance_stop`       | `1048576`                  | Number of witnessing acts before reputation issuance halts          |
+| `consensus_constants` | `reputation_expire_alpha_diff`   | `20000`                    | Number of witnessing acts before a reputation point expires         |
+| `consensus_constants` | `reputation_penalization_factor  | `0.5`                      | Fraction of reputation lost by witnesses being out of consensus     |
 | `jsonrpc`             | `enabled`                        | `true`                     | Enable JSON-RPC server                                              |
 | `jsonrpc`             | `server_address`                 | `"127.0.0.1:21338"`        | JSON-RPC server socket address                                      |
 | `mining`              | `enabled`                        | `true`                     | Enable MiningManager                                                |
 
-These are the defaults for `testnet-1`.
+These are the defaults for `testnet-3`.
 See [environment][environment] for the specific values for all the environments.
 
 The parameters in the `[consensus_constants]` section are ignored when the

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_node"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 description = "node component"

--- a/node/tests/config_test.rs
+++ b/node/tests/config_test.rs
@@ -12,7 +12,7 @@ fn test_get_config() {
 
         let fut = config_mngr::get()
             .and_then(|config| {
-                assert_eq!(Environment::Testnet1, config.environment);
+                assert_eq!(Environment::Testnet3, config.environment);
 
                 Ok(())
             })

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_p2p"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 description = "p2p component"

--- a/partial_struct/Cargo.toml
+++ b/partial_struct/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "Macro that will generate from a struct another one with only Option<T> fields"
 edition = "2018"
 name = "partial_struct"
-version = "0.2.1"
+version = "0.3.0"
 workspace = ".."
 
 [dependencies]

--- a/protected/Cargo.toml
+++ b/protected/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_protected"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 description = "Protected bytes struct that will be zeroed when dropped"

--- a/rad/Cargo.toml
+++ b/rad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_rad"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
 workspace = ".."

--- a/reputation/Cargo.toml
+++ b/reputation/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "Reputation engine"
 edition = "2018"
 name = "witnet_reputation"
-version = "0.2.0"
+version = "0.3.0"
 workspace = ".."
 
 [dependencies]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_storage"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 edition = "2018"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_util"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
 workspace = ".."

--- a/validations/Cargo.toml
+++ b/validations/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "validations component"
 edition = "2018"
 name = "witnet_validations"
-version = "0.2.1"
+version = "0.3.0"
 workspace = ".."
 
 [dependencies]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
 name = "witnet_wallet"
-version = "0.2.0"
+version = "0.3.0"
 workspace = ".."
 
 [dependencies]

--- a/witnet.toml
+++ b/witnet.toml
@@ -2,36 +2,12 @@
 # https://docs.witnet.io/configuration/toml-file/
 [connections]
 server_addr = "127.0.0.1:21337"
-known_peers = ["40.121.131.135:21337"]
+known_peers = ["52.166.178.145:21337"]
 outbound_limit = 1
 bootstrap_peers_period_seconds = 15
 
 [storage]
-db_path = ".wit"
+db_path = ".witnet-rust-testnet-3"
 
 [consensus_constants]
-checkpoint_zero_timestamp = 1553817600
-
-#########################################
-### LOGGING CONFIGURATION             ###
-#########################################
-
-[logging]
-
-# Whether to log to stdout
-log_to_stdout = true
-
-# Log level for stdout: Critical, Error, Warning, Info, Debug, Trace
-stdout_log_level = "Info"
-
-# Whether to log to a file
-log_to_file = true
-
-# Log level for file: Critical, Error, Warning, Info, Debug, Trace
-file_log_level = "Info"
-
-# Log file path
-log_file_path = "wit.log"
-
-# Whether to append to the log file (true), or replace it on every run (false)
-log_file_append = true
+checkpoint_zero_timestamp = 1559347200


### PR DESCRIPTION
- updates the IP of the bootstrap node
- upgrade consensus constants and their documentation
- bumps the versions of all the components from `0.2.x` to `0.3.0`