### PR TITLE
feat(validations): modify commitment in CommitTransaction to simplify…

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -238,6 +238,14 @@ pub enum Signature {
     Secp256k1(Secp256k1Signature),
 }
 
+impl Hashable for Signature {
+    fn hash(&self) -> Hash {
+        match self {
+            Signature::Secp256k1(y) => calculate_sha256(&y.der).into(),
+        }
+    }
+}
+
 impl Default for Signature {
     fn default() -> Self {
         Signature::Secp256k1(Secp256k1Signature::default())
@@ -562,6 +570,11 @@ impl PublicKey {
                 bytes: x,
             })
         }
+    }
+
+    /// Returns the PublicKeyHash related to the PublicKey
+    pub fn pkh(&self) -> PublicKeyHash {
+        PublicKeyHash::from_public_key(&self)
     }
 }
 

--- a/data_structures/src/error.rs
+++ b/data_structures/src/error.rs
@@ -95,6 +95,15 @@ pub enum TransactionError {
         expected_pkh: PublicKeyHash,
         signature_pkh: PublicKeyHash,
     },
+    /// Commit related to a reveal not found
+    #[fail(display = "Commitment related to a reveal not found")]
+    CommitNotFound,
+
+    /// Commitment field in CommitTransaction does not match with RevealTransaction signature
+    #[fail(
+        display = "Commitment field in CommitTransaction does not match with RevealTransaction signature"
+    )]
+    MismatchedCommitment,
 }
 
 /// The error type for operations on a [`Block`](Block)

--- a/data_structures/src/transaction.rs
+++ b/data_structures/src/transaction.rs
@@ -181,8 +181,9 @@ pub struct CommitTransactionBody {
     // Inputs
     // TODO: Discussion about collateral
     //pub collateral: Vec<Input>, // ValueTransferOutput
-    pub dr_pointer: Hash, // DTTransaction hash
-    // Outputs
+    // DRTransaction hash
+    pub dr_pointer: Hash,
+    // RevealTransaction Signature Hash
     pub commitment: Hash,
     // Proof of elegibility for this pkh, epoch, and data request
     pub proof: DataRequestEligibilityClaim,


### PR DESCRIPTION
… validation

Modified commitment field in CommitTransaction from Hash to Signature
Modified protobuf schema of CommitTransaction
Modified mining data request process and validation for Reveal and Commit transactions
Deleted useless methods to create Commit, Reveal and Tally transactions
Created a function to provide the pkh from a PublicKey

Close #667 
