### PR TITLE
refactor(cli): rename run command to server

### DIFF
--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -59,7 +59,7 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
 
 #[derive(Debug, StructOpt)]
 pub enum Command {
-    #[structopt(name = "run", about = "Run the Witnet server.")]
+    #[structopt(name = "server", about = "Run a Witnet node server.", alias = "run")]
     Run(ConfigParams),
     #[structopt(
         name = "raw",

--- a/src/cli/wallet/with_wallet.rs
+++ b/src/cli/wallet/with_wallet.rs
@@ -29,7 +29,11 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
 
 #[derive(Debug, StructOpt)]
 pub enum Command {
-    #[structopt(name = "run", about = "Run the wallet websockets server.")]
+    #[structopt(
+        name = "server",
+        about = "Run a wallet server exposing a websockets API.",
+        alias = "run"
+    )]
     Run(ConfigParams),
     #[structopt(
         name = "show-config",


### PR DESCRIPTION
Rename wallet and node `run` commands to `server`, but keep `run` as an alias, so this change shouldn't break anything.