### PR TITLE
Bumps crates versions to 0.3.1 and 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "partial_struct"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "witnet"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytecount 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2883,29 +2883,29 @@ dependencies = [
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_config 0.3.1",
- "witnet_data_structures 0.3.1",
- "witnet_node 0.3.1",
- "witnet_wallet 0.3.1",
+ "witnet_config 0.3.2",
+ "witnet_data_structures 0.3.2",
+ "witnet_node 0.3.2",
+ "witnet_wallet 0.3.2",
 ]
 
 [[package]]
 name = "witnet_config"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "partial_struct 0.3.1",
+ "partial_struct 0.3.2",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_data_structures 0.3.1",
- "witnet_protected 0.3.1",
+ "witnet_data_structures 0.3.2",
+ "witnet_protected 0.3.2",
 ]
 
 [[package]]
 name = "witnet_crypto"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2916,18 +2916,18 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_protected 0.3.1",
+ "witnet_protected 0.3.2",
 ]
 
 [[package]]
 name = "witnet_data_structures"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "exonum-build 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "partial_struct 0.3.1",
+ "partial_struct 0.3.2",
  "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-convert 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2935,9 +2935,9 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "vrf 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_crypto 0.3.1",
- "witnet_reputation 0.3.1",
- "witnet_util 0.3.1",
+ "witnet_crypto 0.3.2",
+ "witnet_reputation 0.3.2",
+ "witnet_util 0.3.2",
 ]
 
 [[package]]
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "witnet_node"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "actix 0.7.10 (git+https://github.com/actix/actix.git?rev=d28d286ac652f81e72c2aa413e7c0d3fc6c6099c)",
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2979,37 +2979,37 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_config 0.3.1",
- "witnet_crypto 0.3.1",
- "witnet_data_structures 0.3.1",
- "witnet_p2p 0.3.1",
- "witnet_rad 0.3.1",
- "witnet_storage 0.3.1",
- "witnet_util 0.3.1",
- "witnet_validations 0.3.1",
- "witnet_wallet 0.3.1",
+ "witnet_config 0.3.2",
+ "witnet_crypto 0.3.2",
+ "witnet_data_structures 0.3.2",
+ "witnet_p2p 0.3.2",
+ "witnet_rad 0.3.2",
+ "witnet_storage 0.3.2",
+ "witnet_util 0.3.2",
+ "witnet_validations 0.3.2",
+ "witnet_wallet 0.3.2",
 ]
 
 [[package]]
 name = "witnet_p2p"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_util 0.3.1",
+ "witnet_util 0.3.2",
 ]
 
 [[package]]
 name = "witnet_protected"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "memzero 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "witnet_rad"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3022,14 +3022,14 @@ dependencies = [
  "rmpv 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_crypto 0.3.1",
- "witnet_data_structures 0.3.1",
- "witnet_util 0.3.1",
+ "witnet_crypto 0.3.2",
+ "witnet_data_structures 0.3.2",
+ "witnet_util 0.3.2",
 ]
 
 [[package]]
 name = "witnet_reputation"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3039,17 +3039,17 @@ dependencies = [
 
 [[package]]
 name = "witnet_storage"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_crypto 0.3.1",
- "witnet_protected 0.3.1",
+ "witnet_crypto 0.3.2",
+ "witnet_protected 0.3.2",
 ]
 
 [[package]]
 name = "witnet_util"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3057,18 +3057,18 @@ dependencies = [
 
 [[package]]
 name = "witnet_validations"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_crypto 0.3.1",
- "witnet_data_structures 0.3.1",
- "witnet_rad 0.3.1",
+ "witnet_crypto 0.3.2",
+ "witnet_data_structures 0.3.2",
+ "witnet_rad 0.3.2",
 ]
 
 [[package]]
 name = "witnet_wallet"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-jsonrpc-client 0.1.0 (git+https://github.com/witnet/async-jsonrpc-client)",
@@ -3083,12 +3083,12 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_config 0.3.1",
- "witnet_crypto 0.3.1",
- "witnet_data_structures 0.3.1",
+ "witnet_config 0.3.2",
+ "witnet_crypto 0.3.2",
+ "witnet_data_structures 0.3.2",
  "witnet_net 0.1.0",
- "witnet_rad 0.3.1",
- "witnet_storage 0.3.1",
+ "witnet_rad 0.3.2",
+ "witnet_storage 0.3.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "partial_struct"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2869,7 +2869,7 @@ dependencies = [
 
 [[package]]
 name = "witnet"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytecount 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2883,29 +2883,29 @@ dependencies = [
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_config 0.3.0",
- "witnet_data_structures 0.3.0",
- "witnet_node 0.3.0",
- "witnet_wallet 0.3.0",
+ "witnet_config 0.3.1",
+ "witnet_data_structures 0.3.1",
+ "witnet_node 0.3.1",
+ "witnet_wallet 0.3.1",
 ]
 
 [[package]]
 name = "witnet_config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "directories 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "partial_struct 0.3.0",
+ "partial_struct 0.3.1",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_data_structures 0.3.0",
- "witnet_protected 0.3.0",
+ "witnet_data_structures 0.3.1",
+ "witnet_protected 0.3.1",
 ]
 
 [[package]]
 name = "witnet_crypto"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2916,18 +2916,18 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_protected 0.3.0",
+ "witnet_protected 0.3.1",
 ]
 
 [[package]]
 name = "witnet_data_structures"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "exonum-build 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "partial_struct 0.3.0",
+ "partial_struct 0.3.1",
  "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf-convert 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2935,9 +2935,9 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "vrf 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_crypto 0.3.0",
- "witnet_reputation 0.3.0",
- "witnet_util 0.3.0",
+ "witnet_crypto 0.3.1",
+ "witnet_reputation 0.3.1",
+ "witnet_util 0.3.1",
 ]
 
 [[package]]
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "witnet_node"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "actix 0.7.10 (git+https://github.com/actix/actix.git?rev=d28d286ac652f81e72c2aa413e7c0d3fc6c6099c)",
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2979,37 +2979,37 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_config 0.3.0",
- "witnet_crypto 0.3.0",
- "witnet_data_structures 0.3.0",
- "witnet_p2p 0.3.0",
- "witnet_rad 0.3.0",
- "witnet_storage 0.3.0",
- "witnet_util 0.3.0",
- "witnet_validations 0.3.0",
- "witnet_wallet 0.3.0",
+ "witnet_config 0.3.1",
+ "witnet_crypto 0.3.1",
+ "witnet_data_structures 0.3.1",
+ "witnet_p2p 0.3.1",
+ "witnet_rad 0.3.1",
+ "witnet_storage 0.3.1",
+ "witnet_util 0.3.1",
+ "witnet_validations 0.3.1",
+ "witnet_wallet 0.3.1",
 ]
 
 [[package]]
 name = "witnet_p2p"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_util 0.3.0",
+ "witnet_util 0.3.1",
 ]
 
 [[package]]
 name = "witnet_protected"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "memzero 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "witnet_rad"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3022,14 +3022,14 @@ dependencies = [
  "rmpv 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_crypto 0.3.0",
- "witnet_data_structures 0.3.0",
- "witnet_util 0.3.0",
+ "witnet_crypto 0.3.1",
+ "witnet_data_structures 0.3.1",
+ "witnet_util 0.3.1",
 ]
 
 [[package]]
 name = "witnet_reputation"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3039,17 +3039,17 @@ dependencies = [
 
 [[package]]
 name = "witnet_storage"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_crypto 0.3.0",
- "witnet_protected 0.3.0",
+ "witnet_crypto 0.3.1",
+ "witnet_protected 0.3.1",
 ]
 
 [[package]]
 name = "witnet_util"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3057,18 +3057,18 @@ dependencies = [
 
 [[package]]
 name = "witnet_validations"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_crypto 0.3.0",
- "witnet_data_structures 0.3.0",
- "witnet_rad 0.3.0",
+ "witnet_crypto 0.3.1",
+ "witnet_data_structures 0.3.1",
+ "witnet_rad 0.3.1",
 ]
 
 [[package]]
 name = "witnet_wallet"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-jsonrpc-client 0.1.0 (git+https://github.com/witnet/async-jsonrpc-client)",
@@ -3083,12 +3083,12 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "witnet_config 0.3.0",
- "witnet_crypto 0.3.0",
- "witnet_data_structures 0.3.0",
+ "witnet_config 0.3.1",
+ "witnet_crypto 0.3.1",
+ "witnet_data_structures 0.3.1",
  "witnet_net 0.1.0",
- "witnet_rad 0.3.0",
- "witnet_storage 0.3.0",
+ "witnet_rad 0.3.1",
+ "witnet_storage 0.3.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 publish = false
 repository = "witnet/witnet-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 publish = false
 repository = "witnet/witnet-rust"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "config component"
 edition = "2018"
 name = "witnet_config"
-version = "0.3.1"
+version = "0.3.2"
 workspace = ".."
 
 [dependencies]

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "config component"
 edition = "2018"
 name = "witnet_config"
-version = "0.3.0"
+version = "0.3.1"
 workspace = ".."
 
 [dependencies]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_crypto"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 description = "crypto component"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_crypto"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 description = "crypto component"

--- a/data_structures/Cargo.toml
+++ b/data_structures/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "data structures component"
 edition = "2018"
 name = "witnet_data_structures"
-version = "0.3.1"
+version = "0.3.2"
 workspace = ".."
 
 [dependencies]

--- a/data_structures/Cargo.toml
+++ b/data_structures/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "data structures component"
 edition = "2018"
 name = "witnet_data_structures"
-version = "0.3.0"
+version = "0.3.1"
 workspace = ".."
 
 [dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_node"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 description = "node component"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_node"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 description = "node component"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_p2p"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 description = "p2p component"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_p2p"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 description = "p2p component"

--- a/partial_struct/Cargo.toml
+++ b/partial_struct/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "Macro that will generate from a struct another one with only Option<T> fields"
 edition = "2018"
 name = "partial_struct"
-version = "0.3.1"
+version = "0.3.2"
 workspace = ".."
 
 [dependencies]

--- a/partial_struct/Cargo.toml
+++ b/partial_struct/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "Macro that will generate from a struct another one with only Option<T> fields"
 edition = "2018"
 name = "partial_struct"
-version = "0.3.0"
+version = "0.3.1"
 workspace = ".."
 
 [dependencies]

--- a/protected/Cargo.toml
+++ b/protected/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_protected"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 description = "Protected bytes struct that will be zeroed when dropped"

--- a/protected/Cargo.toml
+++ b/protected/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_protected"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 description = "Protected bytes struct that will be zeroed when dropped"

--- a/rad/Cargo.toml
+++ b/rad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_rad"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
 workspace = ".."

--- a/rad/Cargo.toml
+++ b/rad/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_rad"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
 workspace = ".."

--- a/reputation/Cargo.toml
+++ b/reputation/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "Reputation engine"
 edition = "2018"
 name = "witnet_reputation"
-version = "0.3.0"
+version = "0.3.1"
 workspace = ".."
 
 [dependencies]

--- a/reputation/Cargo.toml
+++ b/reputation/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "Reputation engine"
 edition = "2018"
 name = "witnet_reputation"
-version = "0.3.1"
+version = "0.3.2"
 workspace = ".."
 
 [dependencies]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_storage"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 edition = "2018"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_storage"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 workspace = ".."
 edition = "2018"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_util"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
 workspace = ".."

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet_util"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
 workspace = ".."

--- a/validations/Cargo.toml
+++ b/validations/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "validations component"
 edition = "2018"
 name = "witnet_validations"
-version = "0.3.0"
+version = "0.3.1"
 workspace = ".."
 
 [dependencies]

--- a/validations/Cargo.toml
+++ b/validations/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 description = "validations component"
 edition = "2018"
 name = "witnet_validations"
-version = "0.3.1"
+version = "0.3.2"
 workspace = ".."
 
 [dependencies]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
 name = "witnet_wallet"
-version = "0.3.1"
+version = "0.3.2"
 workspace = ".."
 
 [dependencies]

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
 name = "witnet_wallet"
-version = "0.3.0"
+version = "0.3.1"
 workspace = ".."
 
 [dependencies]

--- a/witnet.toml
+++ b/witnet.toml
@@ -10,4 +10,6 @@ bootstrap_peers_period_seconds = 15
 db_path = ".witnet-rust-testnet-3"
 
 [consensus_constants]
-checkpoint_zero_timestamp = 1559347200
+checkpoints_period = 30
+checkpoint_zero_timestamp = 1560643200
+genesis_hash = "00000000000000000000000000000000000000007769746e65742d302e332e31"


### PR DESCRIPTION
The commit in between (929c1e7923bda50cdddc42d3b8b32c9a38de13c6) is the release candidate for testnet-3.1.

Commit 5fd33bc76749c80329a542975a1a0a6931a33334 is far from trivial, as it changes three different consensus constants:
```patch
-checkpoint_zero_timestamp = 1559347200
+checkpoints_period = 30
+checkpoint_zero_timestamp = 1560643200
+genesis_hash = "00000000000000000000000000000000000000007769746e65742d302e332e31"
```
- The checkpoint zero timestamp has been updated to Jun 16 2019, 12am. 
- The checkpoint period is temporarily reduced to allow faster testing. This will be reverted back when we are closer to mainnet.
- Genesis hash now contains a reference to the testnet version (it's the codification of `witnet-0.3.1`). In future releases we can change this to avoid annoying retro-peering without having to change the checkpoint zero. 