### PR TITLE
Unlock wallet

### DIFF
--- a/wallet/src/actors/app/builder.rs
+++ b/wallet/src/actors/app/builder.rs
@@ -51,14 +51,7 @@ impl AppBuilder {
         let crypto = Crypto::build().start();
         let rad_executor = RadExecutor::start();
 
-        let app = super::App {
-            db,
-            storage,
-            rad_executor,
-            node_client,
-            crypto,
-            subscriptions: Default::default(),
-        };
+        let app = super::App::new(db, storage, rad_executor, crypto, node_client);
 
         Ok(app.start())
     }

--- a/wallet/src/actors/app/handlers/mod.rs
+++ b/wallet/src/actors/app/handlers/mod.rs
@@ -15,5 +15,7 @@ mod stop;
 mod subscribe;
 mod unlock_wallet;
 mod unsubscribe;
+mod wallet_unlocked;
 
 pub use stop::*;
+pub use wallet_unlocked::*;

--- a/wallet/src/actors/app/handlers/unlock_wallet.rs
+++ b/wallet/src/actors/app/handlers/unlock_wallet.rs
@@ -4,13 +4,20 @@ use crate::actors::App;
 use crate::api;
 
 impl Message for api::UnlockWalletRequest {
-    type Result = Result<(), failure::Error>;
+    type Result = Result<api::UnlockWalletResponse, failure::Error>;
 }
 
 impl Handler<api::UnlockWalletRequest> for App {
-    type Result = Result<(), failure::Error>;
+    type Result = ResponseActFuture<Self, api::UnlockWalletResponse, failure::Error>;
 
-    fn handle(&mut self, _msg: api::UnlockWalletRequest, _ctx: &mut Self::Context) -> Self::Result {
-        Ok(())
+    fn handle(&mut self, msg: api::UnlockWalletRequest, _ctx: &mut Self::Context) -> Self::Result {
+        let id = msg.wallet_id.clone();
+        let fut = self
+            .unlock_wallet(msg.wallet_id, msg.session_id, msg.password)
+            .map(move |_, _, _| api::UnlockWalletResponse {
+                unlocked_wallet_id: id,
+            });
+
+        Box::new(fut)
     }
 }

--- a/wallet/src/actors/app/handlers/wallet_unlocked.rs
+++ b/wallet/src/actors/app/handlers/wallet_unlocked.rs
@@ -1,0 +1,21 @@
+use actix::prelude::*;
+
+use crate::actors::App;
+use crate::wallet;
+
+pub struct WalletUnlocked {
+    pub session_id: String,
+    pub unlocked_wallet: wallet::UnlockedWallet,
+}
+
+impl Message for WalletUnlocked {
+    type Result = ();
+}
+
+impl Handler<WalletUnlocked> for App {
+    type Result = ();
+
+    fn handle(&mut self, msg: WalletUnlocked, _ctx: &mut Self::Context) -> Self::Result {
+        self.assoc_wallet_to_session(msg.unlocked_wallet, msg.session_id)
+    }
+}

--- a/wallet/src/actors/app/mod.rs
+++ b/wallet/src/actors/app/mod.rs
@@ -8,7 +8,7 @@ use failure::Error;
 use futures::future;
 use jsonrpc_core as rpc;
 use jsonrpc_pubsub as pubsub;
-use serde_json::{self as json, json};
+use serde_json::json;
 
 use witnet_net::client::tcp::{jsonrpc as rpc_client, JsonRpcClient};
 use witnet_protected::ProtectedString;
@@ -82,7 +82,7 @@ impl App {
         &mut self,
         method: String,
         params: rpc::Params,
-    ) -> ResponseFuture<json::Value, Error> {
+    ) -> ResponseFuture<serde_json::Value, Error> {
         match &self.node_client {
             Some(addr) => {
                 let req = rpc_client::Request::method(method)

--- a/wallet/src/actors/storage/error.rs
+++ b/wallet/src/actors/storage/error.rs
@@ -1,0 +1,13 @@
+//! # Error type for the Storage actor handlers.
+use failure::Fail;
+
+/// Error type for errors that may originate in the Storage actor.
+#[derive(Debug, Fail)]
+pub enum Error {
+    #[fail(display = "failed to deserialize value from bincode")]
+    DeserializeFailed(#[cause] bincode::Error),
+    #[fail(display = "couldn't open database file")]
+    OpenDbFailed(#[cause] rocksdb::Error),
+    #[fail(display = "failed to read key from database")]
+    DbGetFailed(#[cause] rocksdb::Error),
+}

--- a/wallet/src/actors/storage/handlers/mod.rs
+++ b/wallet/src/actors/storage/handlers/mod.rs
@@ -1,7 +1,9 @@
 mod create_wallet;
 mod flush;
 mod get_wallet_infos;
+mod unlock_wallet;
 
 pub use create_wallet::*;
 pub use flush::*;
 pub use get_wallet_infos::*;
+pub use unlock_wallet::*;

--- a/wallet/src/actors/storage/handlers/unlock_wallet.rs
+++ b/wallet/src/actors/storage/handlers/unlock_wallet.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use actix::prelude::*;
+
+use witnet_protected::ProtectedString;
+
+use crate::actors::storage::Storage;
+use crate::{storage, wallet};
+
+pub struct UnlockWallet(
+    pub Arc<rocksdb::DB>,
+    pub wallet::WalletId,
+    pub ProtectedString,
+);
+
+impl Message for UnlockWallet {
+    type Result = Result<wallet::UnlockedWallet, storage::Error>;
+}
+
+impl Handler<UnlockWallet> for Storage {
+    type Result = <UnlockWallet as Message>::Result;
+
+    fn handle(
+        &mut self,
+        UnlockWallet(db, id, password): UnlockWallet,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        self.unlock_wallet(db.as_ref(), id.as_ref(), password.as_ref())
+    }
+}

--- a/wallet/src/actors/storage/handlers/wallet_infos.rs
+++ b/wallet/src/actors/storage/handlers/wallet_infos.rs
@@ -1,0 +1,19 @@
+use actix::prelude::*;
+
+use crate::actors::storage::{error::Error, Storage};
+use crate::wallet;
+
+/// Get the list of created wallets along with their ids
+pub struct GetWalletInfos;
+
+impl Message for GetWalletInfos {
+    type Result = Result<Vec<wallet::WalletInfo>, Error>;
+}
+
+impl Handler<GetWalletInfos> for Storage {
+    type Result = Result<Vec<wallet::WalletInfo>, Error>;
+
+    fn handle(&mut self, _msg: GetWalletInfos, _ctx: &mut Self::Context) -> Self::Result {
+        self.get_wallet_infos()
+    }
+}

--- a/wallet/src/api/endpoints/unlock_wallet.rs
+++ b/wallet/src/api/endpoints/unlock_wallet.rs
@@ -1,7 +1,19 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+
+use witnet_protected::ProtectedString;
+
+use crate::wallet;
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UnlockWalletRequest {
-    pub id: String,
-    pub password: String,
+    pub wallet_id: wallet::WalletId,
+    pub session_id: String,
+    pub password: ProtectedString,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnlockWalletResponse {
+    pub unlocked_wallet_id: wallet::WalletId,
 }

--- a/wallet/src/storage/error.rs
+++ b/wallet/src/storage/error.rs
@@ -18,4 +18,8 @@ pub enum Error {
     DbKeyNotFound,
     #[fail(display = "cipher operation failed: {}", _0)]
     CipherOpFailed(#[cause] cipher::Error),
+    #[fail(display = "could not find a wallet with the given id: {}", _0)]
+    UnknownWalletId(String),
+    #[fail(display = "wrong password")]
+    WrongPassword,
 }

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -5,9 +5,13 @@ use serde::{Deserialize, Serialize};
 
 use witnet_crypto::key::ExtendedSK;
 pub use witnet_data_structures::chain::RADRequest;
-use witnet_protected::ProtectedString;
+use witnet_protected::{Protected, ProtectedString};
+
+use super::storage;
 
 pub type WalletId = String;
+
+pub type SessionId = String;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct WalletInfo {
@@ -200,4 +204,16 @@ pub type MasterKey = ExtendedSK;
 #[serde(rename_all = "lowercase")]
 pub enum Wip {
     Wip3,
+}
+
+pub struct Key {
+    pub(crate) secret: Protected,
+    pub(crate) salt: Vec<u8>,
+}
+
+/// TODO: Remove allow(dead_code) when these fields are used
+#[allow(dead_code)]
+pub struct UnlockedWallet {
+    pub(crate) id: WalletId,
+    pub(crate) key: storage::Key,
 }


### PR DESCRIPTION
# What

Implement the *unlockWallet* API endpoint. This enpoint will:

* Use the provided password to derive the key used to encrypt/decrypt the stored password
* Use the key to read the wallet contents and keep it open for the current session

## Example: Unlock a wallet

### Request

The `seesionId` param is used to associate the unlocked wallet with the given session. After that, every time the client wants to interact with this wallet it will have to specify its `sessionId` as well as the `walletId`.

```json
{
  "id": "<request id>",
  "params": {
    "password": "<wallet password>",
    "sessionId": "<session id>",
    "walletId": "<wallet id>"
  },
  "method": "unlockWallet",
  "jsonrpc": "2.0"
}
```

### Success Response

If the unlock wallet succeeds it will send an empty ok-response.

```json
{
  "id": "1",
  "result": {
    "unlockedWalletId":"6c344625884c2f910065ab170dc18ad3cbbc03c7234507c7c22dbd78e3b26667"
  },
  "jsonrpc": "2.0"
}
```

## Example: Unlock a wallet used by another session

If the wallet has been unlocked by another session, trying to unlock it again will append the session id to the internal list of sessions associated to an unlocked wallet.