### PR TITLE
refactor(wallet): implement graceful shutdown of the db

### DIFF
--- a/wallet/src/actors/app/error.rs
+++ b/wallet/src/actors/app/error.rs
@@ -4,8 +4,6 @@ use failure::Fail;
 use witnet_net::client::tcp;
 use witnet_rad::error::RadError;
 
-use crate::storage;
-
 #[derive(Debug, Fail)]
 pub enum Error {
     #[fail(display = "wallet not connected to a node")]
@@ -24,8 +22,6 @@ pub enum Error {
     RadFailed(#[cause] RadError),
     #[fail(display = "could not communicate with database")]
     StorageCommFailed(#[cause] actix::MailboxError),
-    #[fail(display = "{}", _0)]
-    StorageOpFailed(#[cause] storage::Error),
     #[fail(display = "could not communicate with cryptographic engine")]
     CryptoCommFailed(#[cause] actix::MailboxError),
 }

--- a/wallet/src/actors/app/handlers/get_wallet_infos.rs
+++ b/wallet/src/actors/app/handlers/get_wallet_infos.rs
@@ -1,8 +1,7 @@
 use actix::prelude::*;
 use futures::future;
 
-use crate::actors::storage;
-use crate::actors::{app::error, App};
+use crate::actors::App;
 use crate::api;
 
 impl Message for api::WalletInfosRequest {
@@ -14,10 +13,7 @@ impl Handler<api::WalletInfosRequest> for App {
 
     fn handle(&mut self, _msg: api::WalletInfosRequest, _ctx: &mut Self::Context) -> Self::Result {
         let fut = self
-            .storage
-            .send(storage::GetWalletInfos)
-            .map_err(error::Error::StorageCommFailed)
-            .and_then(|res| future::result(res).map_err(error::Error::StorageOpFailed))
+            .get_wallet_infos()
             .and_then(|infos| {
                 future::ok(api::WalletInfosResponse {
                     total: infos.len(),

--- a/wallet/src/actors/app/handlers/mod.rs
+++ b/wallet/src/actors/app/handlers/mod.rs
@@ -11,6 +11,9 @@ mod notification;
 mod run_rad_req;
 mod send_data_req;
 mod send_vtt;
+mod stop;
 mod subscribe;
 mod unlock_wallet;
 mod unsubscribe;
+
+pub use stop::*;

--- a/wallet/src/actors/app/handlers/stop.rs
+++ b/wallet/src/actors/app/handlers/stop.rs
@@ -1,0 +1,18 @@
+use actix::prelude::*;
+
+use crate::actors::app::App;
+
+pub struct Stop;
+
+impl Message for Stop {
+    type Result = Result<(), failure::Error>;
+}
+
+impl Handler<Stop> for App {
+    type Result = ResponseFuture<(), failure::Error>;
+
+    fn handle(&mut self, _msg: Stop, _ctx: &mut Self::Context) -> Self::Result {
+        log::info!("stopping application...");
+        self.stop()
+    }
+}

--- a/wallet/src/actors/storage/builder.rs
+++ b/wallet/src/actors/storage/builder.rs
@@ -1,21 +1,14 @@
-use std::env;
-use std::path::PathBuf;
-use std::sync::Arc;
-
 use actix::prelude::*;
 use failure::Error;
 
 use super::Storage;
 use crate::storage;
 
-pub struct Builder<'a> {
-    options: Option<rocksdb::Options>,
-    path: Option<PathBuf>,
-    name: Option<&'a str>,
+pub struct Builder {
     params: storage::Params,
 }
 
-impl<'a> Builder<'a> {
+impl Builder {
     pub fn new() -> Self {
         let params = storage::Params {
             encrypt_hash_iterations: 10_000,
@@ -23,50 +16,15 @@ impl<'a> Builder<'a> {
             encrypt_salt_length: 32,
         };
 
-        Self {
-            params,
-            path: None,
-            name: None,
-            options: None,
-        }
-    }
-    /// Create a new instance of the Storage actor using the given database options.
-    pub fn with_options(mut self, options: rocksdb::Options) -> Self {
-        self.options = Some(options);
-        self
-    }
-
-    /// Set the path where to store the database files.
-    pub fn with_path(mut self, path: PathBuf) -> Self {
-        self.path = Some(path);
-        self
-    }
-
-    /// Set the filename of the database.
-    pub fn with_file_name(mut self, name: &'a str) -> Self {
-        self.name = Some(name);
-        self
+        Self { params }
     }
 
     /// Start an instance of the actor inside a SyncArbiter.
     pub fn start(self) -> Result<Addr<Storage>, Error> {
-        let mut options = self.options.unwrap_or_default();
-        options.set_merge_operator("merge operator", storage::storage_merge_operator, None);
-        // From rocksdb docs: every store to stable storage will issue a fsync. This parameter
-        // should be set to true while storing data to filesystem like ext3 that can lose files
-        // after a reboot.
-        options.set_use_fsync(true);
-        let path = self.path.map_or_else(env::current_dir, Ok)?;
-        let file_name = self.name.unwrap_or_else(|| "witnet_wallets.db");
-        let db = rocksdb::DB::open(&options, path.join(file_name))
-            .map_err(storage::Error::OpenDbFailed)?;
-        let db_ref = Arc::new(db);
-        let params_ref = Arc::new(self.params);
-
         // Spawn one thread with the storage actor (because is blocking). Do not use more than one
         // thread, otherwise you'll receive and error because RocksDB only allows one connection at a
         // time.
-        let addr = SyncArbiter::start(1, move || Storage::new(params_ref.clone(), db_ref.clone()));
+        let addr = SyncArbiter::start(1, move || Storage::new(self.params.clone()));
 
         Ok(addr)
     }

--- a/wallet/src/actors/storage/handlers/create_wallet.rs
+++ b/wallet/src/actors/storage/handlers/create_wallet.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use actix::prelude::*;
 
 use witnet_protected::ProtectedString;
@@ -6,6 +8,7 @@ use crate::actors::storage::Storage;
 use crate::{storage::Error, wallet};
 
 pub struct CreateWallet(
+    pub Arc<rocksdb::DB>,
     /// Wallet to save
     pub wallet::Wallet,
     /// Encryption password
@@ -21,9 +24,9 @@ impl Handler<CreateWallet> for Storage {
 
     fn handle(
         &mut self,
-        CreateWallet(wallet, password): CreateWallet,
+        CreateWallet(db, wallet, password): CreateWallet,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        self.create_wallet(wallet, password)
+        self.create_wallet(db.as_ref(), wallet, password)
     }
 }

--- a/wallet/src/actors/storage/handlers/flush.rs
+++ b/wallet/src/actors/storage/handlers/flush.rs
@@ -1,0 +1,21 @@
+use std::sync::Arc;
+
+use actix::prelude::*;
+
+use crate::actors::storage::Storage;
+use crate::storage::Error;
+
+pub struct Flush(pub Arc<rocksdb::DB>);
+
+impl Message for Flush {
+    type Result = Result<(), Error>;
+}
+
+impl Handler<Flush> for Storage {
+    type Result = <Flush as Message>::Result;
+
+    fn handle(&mut self, Flush(db): Flush, _ctx: &mut Self::Context) -> Self::Result {
+        log::info!("flushing storage");
+        self.flush(db.as_ref())
+    }
+}

--- a/wallet/src/actors/storage/handlers/get_wallet_infos.rs
+++ b/wallet/src/actors/storage/handlers/get_wallet_infos.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
 use actix::prelude::*;
 
 use crate::actors::storage::Storage;
 use crate::{storage::Error, wallet};
 
 /// Get the list of created wallets along with their ids
-pub struct GetWalletInfos;
+pub struct GetWalletInfos(pub Arc<rocksdb::DB>);
 
 impl Message for GetWalletInfos {
     type Result = Result<Vec<wallet::WalletInfo>, Error>;
@@ -13,7 +15,11 @@ impl Message for GetWalletInfos {
 impl Handler<GetWalletInfos> for Storage {
     type Result = Result<Vec<wallet::WalletInfo>, Error>;
 
-    fn handle(&mut self, _msg: GetWalletInfos, _ctx: &mut Self::Context) -> Self::Result {
-        self.get_wallet_infos()
+    fn handle(
+        &mut self,
+        GetWalletInfos(db): GetWalletInfos,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        self.get_wallet_infos(db.as_ref())
     }
 }

--- a/wallet/src/actors/storage/handlers/mod.rs
+++ b/wallet/src/actors/storage/handlers/mod.rs
@@ -1,5 +1,7 @@
 mod create_wallet;
-mod wallet_infos;
+mod flush;
+mod get_wallet_infos;
 
 pub use create_wallet::*;
-pub use wallet_infos::*;
+pub use flush::*;
+pub use get_wallet_infos::*;

--- a/wallet/src/actors/storage/mod.rs
+++ b/wallet/src/actors/storage/mod.rs
@@ -2,9 +2,9 @@
 //!
 //! It is charge of managing the connection to the key-value database. This actor is blocking so it
 //! must be used with a `SyncArbiter`.
-use std::sync::Arc;
 
 use actix::prelude::*;
+use rocksdb::DB;
 
 use witnet_protected::ProtectedString;
 
@@ -15,32 +15,27 @@ pub mod handlers;
 
 pub use handlers::*;
 
-/// Expose options for tunning the database.
-pub type Options = rocksdb::Options;
-
 /// Storage actor.
 pub struct Storage {
-    /// Holds the wallets ids in plain text, and the wallets information encrypted with a password.
-    db: Arc<rocksdb::DB>,
-    params: Arc<storage::Params>,
+    params: storage::Params,
 }
 
 impl Storage {
-    pub fn build<'a>() -> builder::Builder<'a> {
+    pub fn build() -> builder::Builder {
         builder::Builder::new()
     }
 
-    pub fn new(params: Arc<storage::Params>, db: Arc<rocksdb::DB>) -> Self {
-        Self { db, params }
+    pub fn new(params: storage::Params) -> Self {
+        Self { params }
     }
 
-    pub fn get_wallet_infos(&self) -> Result<Vec<wallet::WalletInfo>, storage::Error> {
-        let ids = self.get_wallet_ids()?;
+    pub fn get_wallet_infos(&self, db: &DB) -> Result<Vec<wallet::WalletInfo>, storage::Error> {
+        let ids = self.get_wallet_ids(db)?;
         let len = ids.len();
         let infos = ids
             .into_iter()
             .try_fold(Vec::with_capacity(len), |mut acc, id| {
-                let info = storage::get(self.db.as_ref(), storage::keys::wallet_info(id.as_ref()))?;
+                let info = storage::get(db, storage::keys::wallet_info(id.as_ref()))?;
                 acc.push(info);
 
                 Ok(acc)
@@ -49,12 +44,13 @@ impl Storage {
         Ok(infos)
     }
 
-    pub fn get_wallet_ids(&self) -> Result<Vec<wallet::WalletId>, storage::Error> {
-        storage::get_default(self.db.as_ref(), storage::keys::wallets())
+    pub fn get_wallet_ids(&self, db: &DB) -> Result<Vec<wallet::WalletId>, storage::Error> {
+        storage::get_default(db, storage::keys::wallets())
     }
 
     pub fn create_wallet(
         &self,
+        db: &DB,
         wallet: wallet::Wallet,
         password: ProtectedString,
     ) -> Result<(), storage::Error> {
@@ -66,17 +62,29 @@ impl Storage {
         storage::put(
             &mut batch,
             storage::keys::wallet(id),
-            &storage::encrypt(self.params.as_ref(), password.as_ref(), &wallet.content)?,
+            &storage::encrypt(&self.params, password.as_ref(), &wallet.content)?,
         )?;
 
-        storage::write(self.db.as_ref(), batch)?;
+        storage::write(db, batch)?;
 
         Ok(())
+    }
+
+    fn flush(&self, db: &DB) -> Result<(), storage::Error> {
+        storage::flush(db)
     }
 }
 
 impl Actor for Storage {
     type Context = SyncContext<Self>;
+
+    fn started(&mut self, _ctx: &mut Self::Context) {
+        log::trace!("storage actor started");
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        log::trace!("storage actor stopped");
+    }
 }
 
 impl Supervised for Storage {}

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -34,7 +34,6 @@ pub fn run(conf: Config) -> Result<(), Error> {
         .start()?;
 
     signal::ctrl_c(move || {
-        log::info!("Shutting down");
         controller.do_send(actors::controller::Shutdown);
     });
 

--- a/wallet/src/storage/mod.rs
+++ b/wallet/src/storage/mod.rs
@@ -11,6 +11,7 @@ pub mod keys;
 pub use error::Error;
 
 /// Encryption parameters used by the encryption function.
+#[derive(Clone)]
 pub struct Params {
     pub(crate) encrypt_hash_iterations: u32,
     pub(crate) encrypt_iv_length: usize,
@@ -62,6 +63,13 @@ where
 /// Write all the opertations in the given batch to the database.
 pub fn write(db: &rocksdb::DB, batch: rocksdb::WriteBatch) -> Result<(), error::Error> {
     db.write(batch).map_err(error::Error::DbOpFailed)
+}
+
+/// Flush database.
+pub fn flush(db: &rocksdb::DB) -> Result<(), error::Error> {
+    let mut opts = rocksdb::FlushOptions::default();
+    opts.set_wait(true);
+    db.flush_opt(&opts).map_err(error::Error::DbOpFailed)
 }
 
 /// Generate an encryption key.


### PR DESCRIPTION
# The Problem

1. When shutting down the application with an `INT` signal (`Ctrl-C`), the database is not flushed. Nevertheless, it will be automatically flushed when starting the application again, but this is not desirable since we are forcing users to always start the application just to persist pending changes that couldn't be applied when the application stopped.

2. If we flush the database before shutting down, we receive a `pure virtual method called` in some cases. The error means we must drop the database handle before static destruction kicks in.

## Solution to `1`

The solution here is very simple, when handling the shutdown signal (`impl Handler<Shutdown> for Controller`) we issue a `Stop` message to the App actor, and in turn this one sends a `Flush` message to the Storage actor.

## Solution to `2`

Solution `1` is very simple, but after we implement it we find ourselves with issue `2`. The reason is this line in Storage's actor builder:

```rust
let db_ref = Arc::new(db);
let addr = SyncArbiter::start(1, move || Storage::new(db_ref.clone(), ...));
```

The reasons for doing this are:

- The closure `SyncArbiter::start` receives has type `Fn() -> impl Actor`
- We want to create the db instance outside that closure to be able to notify the user with an error if the database cannot be opened (we could panic from inside the Storage actor but that's not the ideal solution I'm after)
- We then use an `Arc` to guard the access to the db instance
- This `Arc` is captured by the closure
- Then, when we stop the actor system, it seems that the sync arbiter thread is unable to cleanup before the main thread exists, causing the issue `2`

The solution I've come with is to keep the db ownership inside the App actor itself, and whenever a storage-related message is sent to the Storage actor, we send with it a reference to the db. The difference with the previous solution is that now the references sent to the Storage actor are only "alive" during the message handling, and not for the entire lifetime of the Storage's sync-arbiter thread.

