### PR TITLE
Implement some features to avoid forks

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1371,7 +1371,7 @@ pub type UnspentOutputsPool = HashMap<OutputPointer, ValueTransferOutput>;
 pub type Blockchain = BTreeMap<Epoch, Hash>;
 
 /// Blockchain state (valid at a certain epoch)
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ChainState {
     /// Blockchain information data structure
     pub chain_info: Option<ChainInfo>,
@@ -1420,7 +1420,7 @@ impl ChainState {
 }
 
 /// State related to the Reputation Engine
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct ReputationEngine {
     /// Total number of witnessing acts
     pub current_alpha: Alpha,

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -79,6 +79,7 @@ impl ChainManager {
                                 if consensus_constants == chain_info_from_storage.consensus_constants {
                                     // Update Chain Info from storage
                                     act.chain_state = chain_state_from_storage;
+                                    act.last_chain_state = act.chain_state.clone();
                                     debug!("ChainInfo successfully obtained from storage");
                                 } else {
                                     // Mismatching consensus constants between config and storage
@@ -128,8 +129,14 @@ impl ChainManager {
                                 reputation_engine: Some(reputation_engine),
                                 ..ChainState::default()
                             };
+                            act.last_chain_state = act.chain_state.clone();
                         }
                     }
+
+                    let chain_info = act.chain_state.chain_info.as_ref().unwrap();
+                    info!("Actual ChainState CheckpointBeacon: epoch ({}), hash_block ({})",
+                          chain_info.highest_block_checkpoint.checkpoint,
+                          chain_info.highest_block_checkpoint.hash_prev_block);
 
                     fut::ok(())
                 })

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -2,9 +2,7 @@ use actix::{fut::WrapFuture, prelude::*};
 use log;
 
 use witnet_data_structures::{
-    chain::{
-        ChainState, CheckpointBeacon, Epoch, Hashable, InventoryEntry, InventoryItem, PublicKeyHash,
-    },
+    chain::{ChainState, CheckpointBeacon, Epoch, Hash, Hashable, InventoryItem, PublicKeyHash},
     error::{ChainInfoError, TransactionError},
     transaction::{DRTransaction, Transaction, VTTransaction},
 };
@@ -402,7 +400,7 @@ impl Handler<AddTransaction> for ChainManager {
 
 /// Handler for GetBlocksEpochRange
 impl Handler<GetBlocksEpochRange> for ChainManager {
-    type Result = Result<Vec<(Epoch, InventoryEntry)>, ChainManagerError>;
+    type Result = Result<Vec<(Epoch, Hash)>, ChainManagerError>;
 
     fn handle(
         &mut self,
@@ -415,11 +413,11 @@ impl Handler<GetBlocksEpochRange> for ChainManager {
         // TODO: we should only accept this message in Synced state, but that breaks the
         // JSON-RPC getBlockChain method
 
-        let mut hashes: Vec<(Epoch, InventoryEntry)> = self
+        let mut hashes: Vec<(Epoch, Hash)> = self
             .chain_state
             .block_chain
             .range(range)
-            .map(|(k, v)| (*k, InventoryEntry::Block(*v)))
+            .map(|(k, v)| (*k, *v))
             .collect();
 
         // Hashes Vec has not to be bigger than MAX_BLOCKS_SYNC

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -25,6 +25,13 @@ use crate::{
     utils::mode_consensus,
 };
 
+pub const SYNCED_BANNER: &str = r"███████╗██╗   ██╗███╗   ██╗ ██████╗███████╗██████╗ ██╗
+██╔════╝╚██╗ ██╔╝████╗  ██║██╔════╝██╔════╝██╔══██╗██║
+███████╗ ╚████╔╝ ██╔██╗ ██║██║     █████╗  ██║  ██║██║
+╚════██║  ╚██╔╝  ██║╚██╗██║██║     ██╔══╝  ██║  ██║╚═╝
+███████║   ██║   ██║ ╚████║╚██████╗███████╗██████╔╝██╗
+╚══════╝ ╚═╝ ╚═╝ ╚═══╝ ╚═════╝╚══════╝╚═════╝ ╚═╝";
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // ACTOR MESSAGE HANDLERS
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -509,7 +516,7 @@ impl Handler<PeersBeacons> for ChainManager {
 
                     // Check if we are already synchronized
                     self.sm_state = if our_beacon == consensus_beacon {
-                        log::info!("Synced state");
+                        log::info!("{}", SYNCED_BANNER);
                         StateMachine::Synced
                     } else if our_beacon.checkpoint == consensus_beacon.checkpoint
                         && our_beacon.hash_prev_block != consensus_beacon.hash_prev_block
@@ -534,6 +541,7 @@ impl Handler<PeersBeacons> for ChainManager {
                             match self.process_requested_block(ctx, &consensus_block) {
                                 Ok(()) => {
                                     log::info!("Consolidate consensus candidate. Synced state");
+                                    log::info!("{}", SYNCED_BANNER);
                                     self.persist_item(
                                         ctx,
                                         InventoryItem::Block(consensus_block.clone()),
@@ -586,7 +594,7 @@ impl Handler<PeersBeacons> for ChainManager {
 
                     // Check if we are already synchronized
                     self.sm_state = if our_beacon == consensus_beacon {
-                        log::info!("Synced state");
+                        log::info!("{}", SYNCED_BANNER);
                         StateMachine::Synced
                     } else if our_beacon.checkpoint == consensus_beacon.checkpoint
                         && our_beacon.hash_prev_block != consensus_beacon.hash_prev_block

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -12,7 +12,7 @@ use jsonrpc_pubsub::{PubSubHandler, Session, Subscriber, SubscriptionId};
 use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
 
-use witnet_data_structures::chain::{self, Block, Hash, InventoryEntry};
+use witnet_data_structures::chain::{self, Block, Hash};
 
 use crate::actors::{
     chain_manager::{ChainManager, ChainManagerError},
@@ -255,17 +255,13 @@ pub fn get_block_chain(
 ) -> JsonRpcResultAsync {
     // Helper function to convert the result of GetBlockEpochRange to a JSON value, or a JSON-RPC error
     fn process_get_block_chain(
-        res: Result<Result<Vec<(u32, InventoryEntry)>, ChainManagerError>, MailboxError>,
+        res: Result<Result<Vec<(u32, Hash)>, ChainManagerError>, MailboxError>,
     ) -> impl Future<Item = Value, Error = jsonrpc_core::Error> {
         match res {
             Ok(Ok(vec_inv_entry)) => {
                 let epoch_and_hash: Vec<_> = vec_inv_entry
                     .into_iter()
-                    .map(|(epoch, inv_entry)| {
-                        let hash = match inv_entry {
-                            InventoryEntry::Block(hash) => hash,
-                            x => panic!("{:?} is not a block", x),
-                        };
+                    .map(|(epoch, hash)| {
                         let hash_string = format!("{}", hash);
                         (epoch, hash_string)
                     })

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -127,7 +127,7 @@ impl GetBlocksEpochRange {
 }
 
 impl Message for GetBlocksEpochRange {
-    type Result = Result<Vec<(Epoch, InventoryEntry)>, ChainManagerError>;
+    type Result = Result<Vec<(Epoch, Hash)>, ChainManagerError>;
 }
 
 /// A list of peers and their respective last beacon, used to establish consensus

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -577,7 +577,7 @@ fn session_last_beacon_inbound(
             match res {
                 Ok(Ok(chain_beacon)) => {
                     if chain_beacon.checkpoint > received_checkpoint {
-                        let range = (received_checkpoint + 1)..=chain_beacon.checkpoint;
+                        let range = received_checkpoint..=chain_beacon.checkpoint;
 
                         chain_manager_addr
                             .send(GetBlocksEpochRange::new_with_const_limit(range))

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -13,6 +13,7 @@ use witnet_data_structures::{
     builders::from_address,
     chain::{Block, CheckpointBeacon, Hashable, InventoryEntry, InventoryItem},
     proto::ProtobufConvert,
+    transaction::Transaction,
     types::{
         Address, Command, InventoryAnnouncement, InventoryRequest, LastBeacon,
         Message as WitnetMessage, Peers, Version,
@@ -34,7 +35,6 @@ use crate::actors::{
     peers_manager::PeersManager,
     sessions_manager::SessionsManager,
 };
-use witnet_data_structures::transaction::Transaction;
 use witnet_util::timestamp::get_timestamp;
 
 /// Implement WriteHandler for Session
@@ -587,7 +587,9 @@ fn session_last_beacon_inbound(
                                     // Try to create an Inv protocol message with the items to
                                     // be announced
                                     if let Ok(inv_msg) =
-                                        WitnetMessage::build_inventory_announcement(act.magic_number, blocks.into_iter().map(|(_epoch, hash)| hash).collect())
+                                        WitnetMessage::build_inventory_announcement(act.magic_number, blocks.into_iter().map(|(_epoch, hash)| {
+                                            InventoryEntry::Block(hash)
+                                        }).collect())
                                     {
                                         // Send Inv message through the session network connection
                                         act.send_message(inv_msg);

--- a/reputation/src/ars.rs
+++ b/reputation/src/ars.rs
@@ -20,7 +20,7 @@ use std::{
 /// and also update with the identities that are expired.
 
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ActiveReputationSet<K>
 where
     K: Clone + Eq + Hash,


### PR DESCRIPTION
- Created last_chain_state in ChainManager to have a backup of the previous state of ChainState field.
- Modified persist_chain_state function to persist last_chain_state instead of chain_state
- Modified GetBlockEpochRange response to returns hashes instead of InventoryEntries to simplify some operations.
- Modified Synchronization protocol, outbound peer include the block of the last epoch consolidated by the inbound to allow it checking fork cases.
- Created peers_beacons_received boolean in ChainManager to handle cases when we dont obtain a consensus message (PeersBeacons) from our outbounds
- Handled fork or out of consensus cases in PeersBeacons, using the initialize_from_storage function and handling the state machine states

Close #682 