### PR TITLE
Modify hash method for dr and tally and include them in the PoI

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -376,6 +376,14 @@ impl From<Sha256> for Hash {
     }
 }
 
+impl Into<Sha256> for Hash {
+    fn into(self) -> Sha256 {
+        match self {
+            Hash::SHA256(x) => Sha256(x),
+        }
+    }
+}
+
 impl fmt::Display for Hash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -192,6 +192,12 @@ impl Hashable for CheckpointBeacon {
     }
 }
 
+impl Hashable for DataRequestOutput {
+    fn hash(&self) -> Hash {
+        calculate_sha256(&self.to_pb_bytes().unwrap()).into()
+    }
+}
+
 impl Hashable for PublicKey {
     fn hash(&self) -> Hash {
         let mut v = vec![];
@@ -1620,7 +1626,7 @@ mod tests {
     #[test]
     fn test_transaction_hashable_trait() {
         let transaction = transaction_example();
-        let expected = "27cf16ca127b87361e616d273654ba13afcd7712e83b7217915ef2faae2f6879";
+        let expected = "471a406d903abd7bd4c8536ad79db02f8cd59083936e6cb6fb81382f4514d9cf";
 
         // Signatures don't affect the hash of a transaction (SegWit style), thus both must be equal
         assert_eq!(transaction.hash().to_string(), expected);

--- a/data_structures/src/transaction.rs
+++ b/data_structures/src/transaction.rs
@@ -10,10 +10,7 @@ use crate::{
 };
 use protobuf::Message;
 use std::cell::Cell;
-use witnet_crypto::{
-    hash::{calculate_sha256, Sha256},
-    merkle::FullMerkleTree,
-};
+use witnet_crypto::{hash::calculate_sha256, merkle::FullMerkleTree};
 
 pub trait MemoizedHashable {
     fn hashable_bytes(&self) -> Vec<u8>;
@@ -140,14 +137,7 @@ impl TxInclusionProof {
         index: usize,
         leaves: I,
     ) -> TxInclusionProof {
-        let mt = FullMerkleTree::sha256(
-            leaves
-                .into_iter()
-                .map(|t| match t.hash() {
-                    Hash::SHA256(x) => Sha256(x),
-                })
-                .collect(),
-        );
+        let mt = FullMerkleTree::sha256(leaves.into_iter().map(|t| t.hash().into()).collect());
 
         // The index is valid, so this operation cannot fail
         let proof = mt.inclusion_proof(index).unwrap();

--- a/data_structures/src/transaction.rs
+++ b/data_structures/src/transaction.rs
@@ -147,6 +147,12 @@ impl TxInclusionProof {
             lemma: proof.lemma().iter().map(|sha| (*sha).into()).collect(),
         }
     }
+
+    /// Add a new level in the TxInclusionProof
+    pub fn add_leave(&mut self, leave: Hash) {
+        self.index <<= 1;
+        self.lemma.insert(0, leave);
+    }
 }
 
 #[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize, ProtobufConvert)]
@@ -172,6 +178,16 @@ impl DRTransaction {
         txs.iter()
             .position(|x| x == self)
             .map(|tx_idx| TxInclusionProof::new(tx_idx, txs))
+    }
+
+    /// Modify the proof of inclusion adding a new level that divide a specified data
+    /// from the rest of transaction
+    pub fn data_proof_of_inclusion(&self, block: &Block) -> Option<TxInclusionProof> {
+        self.proof_of_inclusion(block).map(|mut poi| {
+            poi.add_leave(self.body.rest_poi_hash());
+
+            poi
+        })
     }
 }
 
@@ -347,6 +363,16 @@ impl TallyTransaction {
         txs.iter()
             .position(|x| x == self)
             .map(|tx_idx| TxInclusionProof::new(tx_idx, txs))
+    }
+
+    /// Modify the proof of inclusion adding a new level that divide a specified data
+    /// from the rest of transaction
+    pub fn data_proof_of_inclusion(&self, block: &Block) -> Option<TxInclusionProof> {
+        self.proof_of_inclusion(block).map(|mut poi| {
+            poi.add_leave(self.rest_poi_hash());
+
+            poi
+        })
     }
 }
 

--- a/validations/tests/validations.rs
+++ b/validations/tests/validations.rs
@@ -1299,7 +1299,7 @@ fn test_empty_commit(c_tx: &CommitTransaction) -> Result<(), failure::Error> {
     validate_commit_transaction(&c_tx, &dr_pool, beacon, vrf, &rep_eng).map(|_| ())
 }
 
-static DR_HASH: &str = "5591bdaa2161636aac39f31497733ab62581b50d8fcea7f2ea4cb72fd1aebb0a";
+static DR_HASH: &str = "5c480ffab6f430348c493255a111cbf07eadb09198b21584b8cc876bbe3f34dc";
 
 // Helper function to test a commit with an empty state (no utxos, no drs, etc)
 fn test_commit_with_dr(c_tx: &CommitTransaction) -> Result<(), failure::Error> {
@@ -1578,7 +1578,7 @@ fn commitment_proof_lower_than_target() {
     let x = test_commit_difficult_proof();
     // This is just the hash of the VRF, we do not care for the exact value as
     // long as it is below the target hash
-    let vrf_hash = "2a2458f64682b4f41970a2ffb40c19f66191635dad4626c422ff26aea04233d3,"
+    let vrf_hash = "322a2587a40168db8618387a84976bd0a69c0a191fe76fe77c1b70b289a261f8,"
         .parse()
         .unwrap();
     assert_eq!(


### PR DESCRIPTION
Co-authored-by: Tomasz Polaczyk <tmpolaczyk@gmail.com>

Close #706 
Close #707 
Close #709 
Close #710 

Modified methods to create the hash of DRTransaction and TallyTransaction:
--> DRTransaction hash = hash( hash(dr_output bytes) + hash(dr_transaction bytes) )
--> TallyTransaction hash = hash( hash( hash(dr_pointer bytes) + hash(tally_result bytes) ) + hash(tally_transaction bytes) )

The idea to use the total transaction bytes instead of only the rest of fields is avoid to implement new types of messages in Protobuff that represents a vector ("repeated") of messages, so the bytes of dr_output, dr_pointer and tally_result are included twice (inside and outside transaction)

The idea to concatenate tally_result and dr_pointer hashes in TallyTransaction hash creation is to have only one level of hashes in the proof of inclusion of TallyTransaction

