### PR TITLE
Lock wallet and Close session methods

### DIFF
--- a/wallet/src/actors/app/handlers/close_session.rs
+++ b/wallet/src/actors/app/handlers/close_session.rs
@@ -1,0 +1,17 @@
+use actix::prelude::*;
+
+use crate::actors::App;
+use crate::api;
+
+impl Message for api::CloseSessionRequest {
+    type Result = Result<api::CloseSessionResponse, api::Error>;
+}
+
+impl Handler<api::CloseSessionRequest> for App {
+    type Result = Result<api::CloseSessionResponse, api::Error>;
+
+    fn handle(&mut self, msg: api::CloseSessionRequest, _ctx: &mut Self::Context) -> Self::Result {
+        self.close_session(msg.session_id);
+        Ok(())
+    }
+}

--- a/wallet/src/actors/app/handlers/lock_wallet.rs
+++ b/wallet/src/actors/app/handlers/lock_wallet.rs
@@ -1,16 +1,21 @@
 use actix::prelude::*;
 
 use crate::actors::App;
-use crate::api;
+use crate::{api, app};
 
 impl Message for api::LockWalletRequest {
-    type Result = Result<(), api::Error>;
+    type Result = Result<api::LockWalletResponse, api::Error>;
 }
 
 impl Handler<api::LockWalletRequest> for App {
-    type Result = Result<(), api::Error>;
+    type Result = Result<api::LockWalletResponse, api::Error>;
 
-    fn handle(&mut self, _msg: api::LockWalletRequest, _ctx: &mut Self::Context) -> Self::Result {
-        Ok(())
+    fn handle(&mut self, msg: api::LockWalletRequest, _ctx: &mut Self::Context) -> Self::Result {
+        self.lock_wallet(msg.session_id, msg.wallet_id)
+            .map_err(|err| match err {
+                app::Error::UnknownSession => api::Error::Unauthorized,
+                app::Error::WrongWallet(_) => api::Error::Forbidden,
+                e => api::internal_error(e),
+            })
     }
 }

--- a/wallet/src/actors/app/handlers/mod.rs
+++ b/wallet/src/actors/app/handlers/mod.rs
@@ -1,3 +1,4 @@
+mod close_session;
 mod create_data_req;
 mod create_mnemonics;
 mod create_wallet;

--- a/wallet/src/api/endpoints/close_session.rs
+++ b/wallet/src/api/endpoints/close_session.rs
@@ -1,0 +1,11 @@
+use serde::Deserialize;
+
+use crate::app;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CloseSessionRequest {
+    pub(crate) session_id: app::SessionId,
+}
+
+pub type CloseSessionResponse = ();

--- a/wallet/src/api/endpoints/lock_wallet.rs
+++ b/wallet/src/api/endpoints/lock_wallet.rs
@@ -1,8 +1,12 @@
 use serde::Deserialize;
 
+use crate::{app, wallet};
+
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LockWalletRequest {
-    pub wallet_id: String,
-    #[serde(default)]
-    pub wipe: bool,
+    pub(crate) wallet_id: wallet::WalletId,
+    pub(crate) session_id: app::SessionId,
 }
+
+pub type LockWalletResponse = ();

--- a/wallet/src/api/endpoints/mod.rs
+++ b/wallet/src/api/endpoints/mod.rs
@@ -1,3 +1,4 @@
+pub mod close_session;
 pub mod create_data_req;
 pub mod create_mnemonics;
 pub mod create_wallet;
@@ -14,6 +15,7 @@ pub mod subscribe;
 pub mod unlock_wallet;
 pub mod unsubscribe;
 
+pub use close_session::*;
 pub use create_data_req::*;
 pub use create_mnemonics::*;
 pub use create_wallet::*;

--- a/wallet/src/api/endpoints/unlock_wallet.rs
+++ b/wallet/src/api/endpoints/unlock_wallet.rs
@@ -7,12 +7,12 @@ use crate::{app, wallet};
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UnlockWalletRequest {
-    pub wallet_id: wallet::WalletId,
-    pub password: ProtectedString,
+    pub(crate) wallet_id: wallet::WalletId,
+    pub(crate) password: ProtectedString,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UnlockWalletResponse {
-    pub session_id: app::SessionId,
+    pub(crate) session_id: app::SessionId,
 }

--- a/wallet/src/api/error.rs
+++ b/wallet/src/api/error.rs
@@ -9,6 +9,8 @@ pub enum Error {
     Validation(validation::Error),
     Internal(failure::Error),
     Node(failure::Error),
+    Unauthorized,
+    Forbidden,
 }
 
 impl Error {
@@ -19,6 +21,8 @@ impl Error {
                 "Validation Error",
                 Some(serde_json::to_value(e).expect("serialization of errors failed")),
             ),
+            Error::Unauthorized => (401, "Unauthorized", None),
+            Error::Forbidden => (402, "Forbidden", None),
             Error::Node(e) => {
                 log::error!("Node Error: {}", &e);
                 (

--- a/wallet/src/api/routes.rs
+++ b/wallet/src/api/routes.rs
@@ -113,6 +113,7 @@ where
         ("Create-Wallet", "createWallet", api::CreateWalletRequest),
         ("Lock-Wallet", "lockWallet", api::LockWalletRequest),
         ("Unlock-Wallet", "unlockWallet", api::UnlockWalletRequest),
+        ("Lock-Wallet", "lockWallet", api::LockWalletRequest),
         (
             "Get-Transactions",
             "getTransactions",

--- a/wallet/src/api/routes.rs
+++ b/wallet/src/api/routes.rs
@@ -114,6 +114,7 @@ where
         ("Lock-Wallet", "lockWallet", api::LockWalletRequest),
         ("Unlock-Wallet", "unlockWallet", api::UnlockWalletRequest),
         ("Lock-Wallet", "lockWallet", api::LockWalletRequest),
+        ("Close-Session", "closeSession", api::CloseSessionRequest),
         (
             "Get-Transactions",
             "getTransactions",

--- a/wallet/src/app/error.rs
+++ b/wallet/src/app/error.rs
@@ -4,7 +4,7 @@ use failure::Fail;
 use witnet_net::client::tcp;
 use witnet_rad::error::RadError;
 
-use crate::{crypto, storage};
+use crate::{crypto, storage, wallet};
 
 /// Error type for errors that may originate in the Storage actor.
 #[derive(Debug, Fail)]
@@ -31,4 +31,8 @@ pub enum Error {
     CryptoFailed(#[cause] actix::MailboxError),
     #[fail(display = "{}", _0)]
     Crypto(#[cause] crypto::Error),
+    #[fail(display = "Session not active.")]
+    UnknownSession,
+    #[fail(display = "Session does not have access to wallet: {}", _0)]
+    WrongWallet(wallet::WalletId),
 }


### PR DESCRIPTION
## What

This PR adds two methods to the Wallet API:

- [`lockWallet`](https://github.com/witnet/witnet-rust/wiki/Lock-Wallet) which locks the specified wallet if it's unlocked, and closes the active session
- [`closeSession`](https://github.com/witnet/witnet-rust/wiki/Close-Session) which closes the active session
- Introduce `Unauthorized` and `Forbidden` API errors. See the [wiki](https://github.com/witnet/witnet-rust/wiki/Wallet-API-Errors) for more information.
