### PR TITLE
feat(p2p): modify Peers to use Bitcoin bucketing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3099,6 +3099,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "witnet_crypto 0.3.2",
  "witnet_util 0.3.2",
 ]
 

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -344,16 +344,6 @@ impl Message for AddConsolidatedPeer {
     type Result = PeersSocketAddrResult;
 }
 
-/// Message to request that a peer would be tested
-pub struct TryPeer {
-    /// Address to check
-    pub address: SocketAddr,
-}
-
-impl Message for TryPeer {
-    type Result = Result<(), failure::Error>;
-}
-
 /// Message to remove one or more peer addresses from the list
 pub struct RemovePeers {
     /// Address of the peer

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -323,12 +323,35 @@ pub type PeersSocketAddrsResult = Result<Vec<SocketAddr>, failure::Error>;
 
 /// Message to add one or more peer addresses to the list
 pub struct AddPeers {
-    /// Address of the peer
+    /// Addresses of the peer
     pub addresses: Vec<SocketAddr>,
+
+    /// Source address of the peer
+    pub src_address: SocketAddr,
 }
 
 impl Message for AddPeers {
     type Result = PeersSocketAddrsResult;
+}
+
+/// Message to add one peer address to the tried addresses bucket
+pub struct AddConsolidatedPeer {
+    /// Tried addresses to add
+    pub address: SocketAddr,
+}
+
+impl Message for AddConsolidatedPeer {
+    type Result = PeersSocketAddrResult;
+}
+
+/// Message to request that a peer would be tested
+pub struct TryPeer {
+    /// Address to check
+    pub address: SocketAddr,
+}
+
+impl Message for TryPeer {
+    type Result = Result<(), failure::Error>;
 }
 
 /// Message to remove one or more peer addresses from the list

--- a/node/src/actors/peers_manager/handlers.rs
+++ b/node/src/actors/peers_manager/handlers.rs
@@ -1,11 +1,12 @@
 use actix::{Context, Handler};
-use log::{debug, error, warn};
+use log;
 
 use super::PeersManager;
 use crate::actors::messages::{
-    AddPeers, GetRandomPeer, PeersSocketAddrResult, PeersSocketAddrsResult, RemovePeers,
-    RequestPeers,
+    AddConsolidatedPeer, AddPeers, GetRandomPeer, PeersSocketAddrResult, PeersSocketAddrsResult,
+    RemovePeers, RequestPeers,
 };
+use witnet_util::timestamp::get_timestamp;
 
 /// Handler for AddPeers message
 impl Handler<AddPeers> for PeersManager {
@@ -13,8 +14,31 @@ impl Handler<AddPeers> for PeersManager {
 
     fn handle(&mut self, msg: AddPeers, _: &mut Context<Self>) -> Self::Result {
         // Insert address
-        debug!("Adding the following peer addresses: {:?}", msg.addresses);
-        self.peers.add(msg.addresses)
+        log::debug!("Adding the following peer addresses: {:?}", msg.addresses);
+        self.peers.add_to_new(msg.addresses, msg.src_address)
+    }
+}
+
+/// Handler for AddPeers message
+impl Handler<AddConsolidatedPeer> for PeersManager {
+    type Result = PeersSocketAddrResult;
+
+    fn handle(&mut self, msg: AddConsolidatedPeer, _: &mut Context<Self>) -> Self::Result {
+        // Insert address
+        log::debug!(
+            "Adding the following consolidated peer address: {:?}",
+            msg.address
+        );
+        let current_ts = get_timestamp();
+
+        let index = self.peers.tried_bucket_index(&msg.address);
+        match self.peers.tried_bucket_get_timestamp(index) {
+            Some(ts) if current_ts - ts < self.bucketing_update_period => {
+                // It is recently updated
+                Ok(None)
+            }
+            _ => self.peers.add_to_tried(msg.address),
+        }
     }
 }
 
@@ -23,9 +47,9 @@ impl Handler<RemovePeers> for PeersManager {
     type Result = PeersSocketAddrsResult;
 
     fn handle(&mut self, msg: RemovePeers, _: &mut Context<Self>) -> Self::Result {
-        // // Find index of element with address
-        debug!("Removing the following addresses: {:?}", msg.addresses);
-        self.peers.remove(&msg.addresses)
+        // Find index of element with address
+        log::debug!("Removing the following addresses: {:?}", msg.addresses);
+        Ok(self.peers.remove_from_tried(&msg.addresses))
     }
 }
 
@@ -38,15 +62,15 @@ impl Handler<GetRandomPeer> for PeersManager {
 
         match result {
             Ok(Some(address)) => {
-                debug!("Selected a random peer address: {:?}", address);
+                log::debug!("Selected a random peer address: {:?}", address);
                 result
             }
             Ok(None) => {
-                warn!("Could not select a random peer address because there were none");
+                log::warn!("Could not select a random peer address because there were none");
                 result
             }
             error => {
-                error!("Error selecting a random peer address: {:?}", error);
+                log::error!("Error selecting a random peer address: {:?}", error);
                 error
             }
         }
@@ -58,7 +82,7 @@ impl Handler<RequestPeers> for PeersManager {
     type Result = PeersSocketAddrsResult;
 
     fn handle(&mut self, _msg: RequestPeers, _: &mut Context<Self>) -> Self::Result {
-        debug!("Get all peers");
-        self.peers.get_all()
+        log::debug!("Get all peers");
+        self.peers.get_all_from_tried()
     }
 }

--- a/node/src/actors/peers_manager/mod.rs
+++ b/node/src/actors/peers_manager/mod.rs
@@ -32,6 +32,10 @@ mod handlers;
 pub struct PeersManager {
     /// Known peers
     peers: Peers,
+    /// Period to consider if a peer is updated
+    pub bucketing_update_period: i64,
+    /// Timeout for handshake
+    pub handshake_timeout: Duration,
 }
 
 impl PeersManager {
@@ -52,6 +56,10 @@ impl PeersManager {
 
             act.persist_peers(ctx, storage_peers_period);
         });
+    }
+
+    fn import_peers(&mut self, peers: Peers) {
+        self.peers = peers;
     }
 }
 

--- a/node/src/actors/session/actor.rs
+++ b/node/src/actors/session/actor.rs
@@ -30,9 +30,8 @@ impl Actor for Session {
                     "Handshake timeout expired, disconnecting session with peer {:?}",
                     act.remote_addr
                 );
-                if let SessionStatus::Unconsolidated = act.status {
-                    ctx.stop();
-                }
+
+                ctx.stop();
             }
         });
 

--- a/node/src/actors/sessions_manager/handlers.rs
+++ b/node/src/actors/sessions_manager/handlers.rs
@@ -14,8 +14,8 @@ use super::SessionsManager;
 use crate::actors::{
     codec::P2PCodec,
     messages::{
-        AddPeers, Anycast, Broadcast, Consolidate, Create, EpochNotification, NumSessions,
-        NumSessionsResult, PeerBeacon, Register, SessionsUnitResult, Unregister,
+        AddConsolidatedPeer, Anycast, Broadcast, Consolidate, Create, EpochNotification,
+        NumSessions, NumSessionsResult, PeerBeacon, Register, SessionsUnitResult, Unregister,
     },
     peers_manager::PeersManager,
     session::Session,
@@ -129,12 +129,10 @@ impl Handler<Consolidate> for SessionsManager {
         // Get peers manager address
         let peers_manager_addr = System::current().registry().get::<PeersManager>();
 
-        // Send AddPeers message to the peers manager
-        // If the session is outbound, this won't give any new information (except the timestamp
-        // being updated)
-        // If the session is inbound, this might be a valid information to get a new potential peer
-        peers_manager_addr.do_send(AddPeers {
-            addresses: vec![msg.potential_new_peer],
+        // Send AddConsolidatedPeer message to the peers manager
+        // Try to add this potential peer in the tried addresses bucket
+        peers_manager_addr.do_send(AddConsolidatedPeer {
+            address: msg.potential_new_peer,
         });
 
         match &result {

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 failure = "0.1.5"
 rand = "0.6.5"
 witnet_util = { path = "../util" }
+witnet_crypto = { path = "../crypto" }
 
 [dependencies.serde]
 features = ["derive"]

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -18,3 +18,14 @@ pub enum SessionsError {
     #[fail(display = "Is not an outbound consolidated peer")]
     NotOutboundConsolidatedPeer,
 }
+
+/// Sessions Errors under different operations
+#[derive(Debug, PartialEq, Fail)]
+pub enum PeersError {
+    /// Peer not found. Empty buckets
+    #[fail(display = "Peer not found. Empty buckets")]
+    EmptyBuckets,
+    /// Peer not found. Empty slot
+    #[fail(display = "Peer not found. Empty slot")]
+    EmptySlot,
+}

--- a/p2p/src/peers/mod.rs
+++ b/p2p/src/peers/mod.rs
@@ -1,85 +1,281 @@
 //! Library for managing a list of available peers
 
-use serde::{Deserialize, Serialize};
-
-use std::collections::HashMap;
-use std::net::SocketAddr;
-
 use rand::{thread_rng, Rng};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, net::SocketAddr};
 
+use witnet_crypto::hash::calculate_sha256;
 use witnet_util::timestamp::get_timestamp;
 
 /// Peer information being used while listing available Witnet peers
 #[derive(Serialize, Deserialize)]
 struct PeerInfo {
     address: SocketAddr,
-    _timestamp: i64,
+    timestamp: i64,
 }
 
 /// Peers TBD
 #[derive(Default, Serialize, Deserialize)]
 pub struct Peers {
-    /// Server sessions
-    peers: HashMap<SocketAddr, PeerInfo>,
+    /// Bucket for tried addresses
+    tried_bucket: HashMap<u16, PeerInfo>,
+    /// Bucket for new addresses
+    new_bucket: HashMap<u16, PeerInfo>,
+    /// Nonce value
+    sk: u64,
 }
 
 impl Peers {
-    /// Add multiple peer addresses and save timestamp
+    /// Create a new instance of Peers
+    pub fn new() -> Self {
+        Peers {
+            sk: thread_rng().gen(),
+            tried_bucket: HashMap::new(),
+            new_bucket: HashMap::new(),
+        }
+    }
+
+    /// Algorithm to calculate index for the new addresses buckets
+    pub fn new_bucket_index(&self, socket_addr: &SocketAddr, src_socket_addr: &SocketAddr) -> u16 {
+        let (_, group, host_id) = split_socket_addresses(socket_addr);
+        let (_, src_group, _) = split_socket_addresses(src_socket_addr);
+
+        calculate_index_for_new(self.sk, &src_group, &group, &host_id)
+    }
+
+    /// Algorithm to calculate index for the tried addresses buckets
+    pub fn tried_bucket_index(&self, socket_addr: &SocketAddr) -> u16 {
+        let (ip, group, host_id) = split_socket_addresses(socket_addr);
+
+        calculate_index_for_tried(self.sk, &ip, &group, &host_id)
+    }
+
+    /// Contains for new bucket
+    pub fn new_bucket_contains(&self, index: u16) -> bool {
+        self.new_bucket.contains_key(&index)
+    }
+
+    /// Contains for tried bucket
+    pub fn tried_bucket_contains(&self, index: u16) -> bool {
+        self.tried_bucket.contains_key(&index)
+    }
+
+    /// Returns the timestamp of a specific slot in the new addresses bucket
+    pub fn new_bucket_get_timestamp(&self, index: u16) -> Option<i64> {
+        self.new_bucket.get(&index).map(|p| p.timestamp)
+    }
+
+    /// Returns the timestamp of a specific slot in the tried addresses bucket
+    pub fn tried_bucket_get_timestamp(&self, index: u16) -> Option<i64> {
+        self.tried_bucket.get(&index).map(|p| p.timestamp)
+    }
+
+    /// Returns the timestamp of a specific slot in the new addresses bucket
+    pub fn new_bucket_get_address(&self, index: u16) -> Option<SocketAddr> {
+        self.new_bucket.get(&index).map(|p| p.address)
+    }
+
+    /// Returns the timestamp of a specific slot in the tried addresses bucket
+    pub fn tried_bucket_get_address(&self, index: u16) -> Option<SocketAddr> {
+        self.tried_bucket.get(&index).map(|p| p.address)
+    }
+
+    /// Add multiple peer addresses and save timestamp in the new addresses bucket
     /// If an address did already exist, it gets overwritten
     /// Returns all the overwritten addresses
-    pub fn add(&mut self, addrs: Vec<SocketAddr>) -> Result<Vec<SocketAddr>, failure::Error> {
+    pub fn add_to_new(
+        &mut self,
+        addrs: Vec<SocketAddr>,
+        src_address: SocketAddr,
+    ) -> Result<Vec<SocketAddr>, failure::Error> {
         // Insert address
         // Note: if the peer address exists, the peer info will be overwritten
-        Ok(addrs
+        let result = addrs
             .into_iter()
             // Filter out unspecified addresses (aka 0.0.0.0)
             .filter(|address| !address.ip().is_unspecified())
             .filter_map(|address| {
-                self.peers
+                let index = self.new_bucket_index(&address, &src_address);
+
+                self.new_bucket
                     .insert(
-                        address,
+                        index,
                         PeerInfo {
                             address,
-                            _timestamp: get_timestamp(), //msg.timestamp,
+                            timestamp: get_timestamp(), //msg.timestamp,
                         },
                     )
                     .map(|v| v.address)
             })
-            .collect())
+            .collect();
+
+        Ok(result)
     }
 
-    /// Remove a peer given an address
+    /// Add multiple peer addresses and save timestamp in the tried addresses bucket
+    /// If an address did already exist, it gets overwritten
+    /// Returns all the overwritten or rejected addresses
+    pub fn add_to_tried(
+        &mut self,
+        address: SocketAddr,
+    ) -> Result<Option<SocketAddr>, failure::Error> {
+        // Insert address
+        let result = if !address.ip().is_unspecified() {
+            let index = self.tried_bucket_index(&address);
+
+            self.tried_bucket
+                .insert(
+                    index,
+                    PeerInfo {
+                        address,
+                        timestamp: get_timestamp(), //msg.timestamp,
+                    },
+                )
+                .map(|v| v.address)
+        } else {
+            None
+        };
+
+        Ok(result)
+    }
+
+    /// Remove a peer given an address from tried addresses bucket
     /// Returns the removed addresses
-    pub fn remove(&mut self, addrs: &[SocketAddr]) -> Result<Vec<SocketAddr>, failure::Error> {
-        Ok(addrs
+    pub fn remove_from_tried(&mut self, addrs: &[SocketAddr]) -> Vec<SocketAddr> {
+        addrs
             .iter()
-            .filter_map(|address| self.peers.remove(&address).map(|info| info.address))
-            .collect())
+            .filter_map(|address| {
+                let index = self.tried_bucket_index(&address);
+                let elem = self.tried_bucket.get(&index);
+
+                if elem.is_some() && (elem.unwrap().address == *address) {
+                    self.tried_bucket.remove(&index)
+                } else {
+                    None
+                }
+            })
+            .map(|info| info.address)
+            .collect()
     }
 
     /// Get a random socket address from the peers list
-    pub fn get_random(&mut self) -> Result<Option<SocketAddr>, failure::Error> {
+    pub fn get_random(&self) -> Result<Option<SocketAddr>, failure::Error> {
+        let bucket = match (self.new_bucket.is_empty(), self.tried_bucket.is_empty()) {
+            (true, true) => return Ok(None),
+            (true, false) => &self.tried_bucket,
+            (false, true) => &self.new_bucket,
+            (false, false) => {
+                if thread_rng().gen() {
+                    &self.tried_bucket
+                } else {
+                    &self.new_bucket
+                }
+            }
+        };
+
         // Random index with range [0, len) of the peers vector
-        let index = thread_rng().gen_range(0, std::cmp::max(self.peers.len(), 1));
+        let index = thread_rng().gen_range(0, bucket.len());
 
-        // Get element at index
-        let random_addr = self
-            .peers
-            // get peer infos
-            .values()
-            // enumerate them -> (indices, peer info)
-            .enumerate()
-            // filter by index and get address -> Iterator<Option<SocketAddr>>
-            .filter_map(|(i, v)| if i == index { Some(v.address) } else { None })
-            // Get first one, because
-            .next()
-            .map(|v| v.to_owned());
-
-        Ok(random_addr)
+        Ok(bucket.values().nth(index).map(|v| v.address.to_owned()))
     }
 
-    /// Get all the peers from the list
-    pub fn get_all(&self) -> Result<Vec<SocketAddr>, failure::Error> {
-        Ok(self.peers.values().map(|v| v.address).collect())
+    /// Get all the peers from the tried bucket
+    pub fn get_all_from_tried(&self) -> Result<Vec<SocketAddr>, failure::Error> {
+        Ok(self.tried_bucket.values().map(|v| v.address).collect())
     }
+
+    /// Get all the peers from the tried bucket
+    pub fn get_all_from_new(&self) -> Result<Vec<SocketAddr>, failure::Error> {
+        Ok(self.new_bucket.values().map(|v| v.address).collect())
+    }
+
+    /// Clear tried addresses bucket
+    pub fn clear_tried_bucket(&mut self) {
+        self.tried_bucket.clear();
+    }
+
+    /// Clear new addresses bucket
+    pub fn clear_new_bucket(&mut self) {
+        self.new_bucket.clear();
+    }
+}
+
+/// Returns the ip and ip split
+fn split_socket_addresses(socket_addr: &SocketAddr) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    match socket_addr {
+        SocketAddr::V4(addr) => {
+            let ip = addr.ip().octets();
+            let port_a = (addr.port() >> 8) as u8;
+            let port_b = addr.port() as u8;
+            let (left, right) = ip.split_at(ip.len() / 2);
+            let data = [right, &[port_a], &[port_b]].concat();
+            (ip.to_vec(), left.to_vec(), data)
+        }
+        SocketAddr::V6(addr) => {
+            let ip = addr.ip().octets();
+            let port_a = (addr.port() >> 8) as u8;
+            let port_b = addr.port() as u8;
+            let (left, right) = ip.split_at(ip.len() / 2);
+            let data = [right, &[port_a], &[port_b]].concat();
+            (ip.to_vec(), left.to_vec(), data)
+        }
+    }
+}
+
+/// Algorithm to calculate index for the tried addresses buckets
+/// SK = random value chosen when node is born.
+/// IP = the peer’s IP address and port number.
+/// Group = the peer’s group
+/// Host_ID = the peer's host id
+///
+/// i = Hash( SK, IP ) % 4
+/// Bucket = Hash( SK, Group, i ) % 64
+/// Slot = Hash( SK, Host_ID, i ) % 64
+///
+/// Index = Bucket * Slot
+fn calculate_index_for_tried(sk: u64, ip: &[u8], group: &[u8], host_id: &[u8]) -> u16 {
+    let sk = sk.to_be_bytes();
+
+    let data = [&sk, ip].concat();
+    let data_hash = calculate_sha256(&data);
+    let i = data_hash.0[31] % 4;
+
+    let data = [&sk, group, &[i]].concat();
+    let data_hash = calculate_sha256(&data);
+    let bucket = u16::from(data_hash.0[31]) % 64;
+
+    let data = [&sk, host_id, &[i]].concat();
+    let data_hash = calculate_sha256(&data);
+    let slot = u16::from(data_hash.0[31]) % 64;
+
+    (bucket * 64) + slot
+}
+
+/// Algorithm to calculate index for the new addresses buckets
+/// SK = random value chosen when node is born.
+/// IP = the peer’s IP address and port number.
+/// Group = the peer’s group
+/// Src_group = the source peer's group
+///
+/// i = Hash( SK, Src_group, Group ) % 32
+/// Bucket = Hash( SK, Src_group, i ) % 256
+/// Slot = Hash( SK, Host_ID, i ) % 64
+///
+/// Index = Bucket * Slot
+fn calculate_index_for_new(sk: u64, src_group: &[u8], group: &[u8], host_id: &[u8]) -> u16 {
+    let sk = sk.to_be_bytes();
+
+    let data = [&sk, src_group, group].concat();
+    let data_hash = calculate_sha256(&data);
+    let i = data_hash.0[31] % 32;
+
+    let data = [&sk, src_group, &[i]].concat();
+    let data_hash = calculate_sha256(&data);
+    let bucket = u16::from(data_hash.0[31]) % 256;
+
+    let data = [&sk, host_id, &[i]].concat();
+    let data_hash = calculate_sha256(&data);
+    let slot = u16::from(data_hash.0[31]) % 64;
+
+    (bucket * 64) + slot
 }

--- a/p2p/tests/peers.rs
+++ b/p2p/tests/peers.rs
@@ -3,16 +3,23 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use witnet_p2p::peers::*;
 
 #[test]
-fn p2p_peers_add() {
+fn p2p_peers_add_to_new() {
     // Create peers struct
     let mut peers = Peers::default();
 
     // Add address
     let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    let src_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 8080);
 
-    assert_eq!(peers.add(vec![address]).unwrap(), vec![]);
+    assert_eq!(
+        peers.add_to_new(vec![address], src_address).unwrap(),
+        vec![]
+    );
     // If we add the same address again, the method returns it
-    assert_eq!(peers.add(vec![address]).unwrap(), vec![address]);
+    assert_eq!(
+        peers.add_to_new(vec![address], src_address).unwrap(),
+        vec![address]
+    );
 
     // Get a random address (there is only 1)
     let result = peers.get_random();
@@ -21,15 +28,29 @@ fn p2p_peers_add() {
     assert_eq!(result.unwrap(), Some(address));
 
     // There is only 1 address
-    assert_eq!(peers.get_all().unwrap(), vec![address]);
+    assert_eq!(peers.get_all_from_new().unwrap(), vec![address]);
+}
 
-    // Add 100 addresses more
-    let many_peers = (0..100)
-        .map(|i| SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, i)), 8080))
-        .collect();
-    peers.add(many_peers).unwrap();
+#[test]
+fn p2p_peers_add_to_tried() {
+    // Create peers struct
+    let mut peers = Peers::default();
 
-    assert_eq!(peers.get_all().unwrap().len(), 1 + 100);
+    // Add address
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+
+    assert_eq!(peers.add_to_tried(address).unwrap(), None);
+    // If we add the same address again, the method returns it
+    assert_eq!(peers.add_to_tried(address).unwrap(), Some(address));
+
+    // Get a random address (there is only 1)
+    let result = peers.get_random().unwrap();
+
+    // Check that both addresses are the same
+    assert_eq!(result, Some(address));
+
+    // There is only 1 address
+    assert_eq!(peers.get_all_from_tried().unwrap(), vec![address]);
 }
 
 #[test]
@@ -39,10 +60,10 @@ fn p2p_peers_remove() {
 
     // Add address
     let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-    peers.add(vec![address]).unwrap();
+    peers.add_to_tried(address).unwrap();
 
     // Remove address
-    assert_eq!(peers.remove(&[address]).unwrap(), vec![address]);
+    assert_eq!(peers.remove_from_tried(&[address]), vec![address]);
 
     // Get a random address
     let result = peers.get_random();
@@ -51,7 +72,7 @@ fn p2p_peers_remove() {
     assert_eq!(result.unwrap(), None);
 
     // Remove the same address twice doesn't panic
-    assert_eq!(peers.remove(&[address, address]).unwrap(), vec![]);
+    assert_eq!(peers.remove_from_tried(&[address, address]), vec![]);
 }
 
 #[test]
@@ -62,10 +83,11 @@ fn p2p_peers_get_random() {
     // Add addresses
     let address1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     let address2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 8080);
-    peers.add(vec![address1, address2]).unwrap();
+    peers.add_to_tried(address1).unwrap();
+    peers.add_to_tried(address2).unwrap();
 
     // Get random address for a "big" number
-    let mut diff: i16 = 0;
+    let mut diff: i32 = 0;
     for _ in 0..100_000 {
         // Get a random address (there is only 1)
         match peers.get_random().unwrap() {
@@ -84,26 +106,32 @@ fn p2p_peers_get_random() {
 }
 
 #[test]
-fn p2p_peers_get_all() {
+fn p2p_peers_get_all_from_new() {
     // Create peers struct
     let mut peers = Peers::default();
 
     // Add 100 addresses
-    let mut many_peers: Vec<_> = (0..100)
+    let many_peers: Vec<_> = (0..100)
         .map(|i| SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, i)), 8080))
         .collect();
-    peers.add(many_peers.clone()).unwrap();
+    let src_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(168, 0, 0, 12)), 8080);
+    peers.add_to_new(many_peers.clone(), src_address).unwrap();
 
-    // There are 100 peers in total
-    assert_eq!(peers.get_all().unwrap().len(), 100);
+    assert!(!peers.get_all_from_new().unwrap().is_empty());
+    assert!(peers.get_all_from_tried().unwrap().is_empty());
+}
 
-    let mut added_peers = peers.get_all().unwrap();
+#[test]
+fn p2p_peers_get_all_from_tried() {
+    // Create peers struct
+    let mut peers = Peers::default();
 
-    // Check that all peers were added
-    // We need to sort the vectors first
-    let sort_by_ip_then_port =
-        |a: &SocketAddr, b: &SocketAddr| (a.ip(), a.port()).cmp(&(b.ip(), b.port()));
-    many_peers.sort_by(sort_by_ip_then_port);
-    added_peers.sort_by(sort_by_ip_then_port);
-    assert_eq!(many_peers, added_peers);
+    // Add 100 addresses
+    for i in 0..100 {
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, i)), 8080);
+        peers.add_to_tried(address).unwrap();
+    }
+
+    assert!(peers.get_all_from_new().unwrap().is_empty());
+    assert!(!peers.get_all_from_tried().unwrap().is_empty());
 }


### PR DESCRIPTION
Modified Peers structure and methods to implement Bitcoin bucketing with 2 buckets (tried and new)
Modified get_random_peer method in Peers that choose a peer randomly from each bucket
Modified Peers tests
Added src_address field in AddPeers message
Created a new method in PeersManager to import peers from a Peers structure
Created a new method in PeersManager, `try_peer`, to check if a peer is good initializing a handshake protocol

Close #732 
Close #737
Close #738 