### PR TITLE
Ethereum bridge 0.1 + PoI Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2989,6 +2989,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "witnet-ethereum-bridge"
+version = "0.1.0"
+
+[[package]]
 name = "witnet_config"
 version = "0.3.2"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,6 +3273,7 @@ dependencies = [
  "async-jsonrpc-client 0.1.0 (git+https://github.com/witnet/async-jsonrpc-client)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3271,6 +3271,8 @@ name = "witnet-ethereum-bridge"
 version = "0.1.0"
 dependencies = [
  "async-jsonrpc-client 0.1.0 (git+https://github.com/witnet/async-jsonrpc-client)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,11 +769,11 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -795,23 +795,15 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethbloom 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types-serialize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
- "uint 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ethereum-types-serialize"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "primitive-types 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1141,6 +1133,14 @@ dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parity-codec 3.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1655,6 +1655,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parity-codec"
+version = "3.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,6 +1781,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "ppv-lite86"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "primitive-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-codec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -2984,7 +3005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uint"
-version = "0.5.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3116,21 +3137,21 @@ dependencies = [
 
 [[package]]
 name = "web3"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethabi 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3281,7 +3302,7 @@ dependencies = [
  "async-jsonrpc-client 0.1.0 (git+https://github.com/witnet/async-jsonrpc-client)",
  "bimap 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethabi 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3289,7 +3310,7 @@ dependencies = [
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "web3 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web3 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_data_structures 0.3.2",
 ]
 
@@ -3607,10 +3628,9 @@ dependencies = [
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
-"checksum ethabi 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be9a03ff8f3d495d9b73d59fd166acc91d0fd81779911b0b8b4c87b6024a670a"
+"checksum ethabi 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b312e5740d6e0369491ebe81a8752f7797b70e495530f28bbb7cc967ded3d77c"
 "checksum ethbloom 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3932e82d64d347a045208924002930dc105a138995ccdc1479d0f05f0359f17c"
-"checksum ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b054df51e53f253837ea422681215b42823c02824bde982699d0dceecf6165a1"
-"checksum ethereum-types-serialize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1873d77b32bc1891a79dad925f2acbc318ee942b38b9110f9dbc5fbeffcea350"
+"checksum ethereum-types 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62d1bc682337e2c5ec98930853674dd2b4bd5d0d246933a9e98e5280f7c76c5f"
 "checksum exonum-build 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9347df5a2daa4bef24658c6a84cfd33dddca0ffb27647bd281fcc96c5810a09a"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
@@ -3648,6 +3668,7 @@ dependencies = [
 "checksum hyper 0.12.32 (registry+https://github.com/rust-lang/crates.io-index)" = "a64d71c1e77d39da024f06f5821ee00ad9c38febb90370bad1f07a94e0bc8793"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+"checksum impl-codec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2050d823639fbeae26b2b5ba09aca8907793117324858070ade0673c49f793b"
 "checksum impl-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f39b9963cf5f12fcc4ae4b30a6927ed67d6b4ea4cbe7d17a41131163b401303b"
 "checksum impl-serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d26be4b97d738552ea423f76c4f681012ff06c3fa36fa968656b3679f60b4a1"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
@@ -3706,6 +3727,7 @@ dependencies = [
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)" = "75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
+"checksum parity-codec 3.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2b9df1283109f542d8852cd6b30e9341acc2137481eb6157d2e62af68b0afec9"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
@@ -3719,6 +3741,7 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
+"checksum primitive-types 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2288eb2a39386c4bc817974cc413afe173010dc80e470fcb1e9a35580869f024"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f00e4a3cb64ecfeac2c0a73c74c68ae3439d7a6bead3870be56ad5dd2620a6f"
 "checksum protobuf-codegen 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2c6e555166cdb646306f599da020e01548e9f4d6ec2fd39802c6db2347cbd3e"
@@ -3843,7 +3866,7 @@ dependencies = [
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
-"checksum uint 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "082df6964410f6aa929a61ddfafc997e4f32c62c22490e439ac351cec827f436"
+"checksum uint 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2143cded94692b156c356508d92888acc824db5bffc0b4089732264c6fcf86d4"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
@@ -3861,7 +3884,7 @@ dependencies = [
 "checksum vrf 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47382d96667d2abefe4f1a4054827b5c72fbfcfbee0a112c57d6461e132cd58b"
 "checksum walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c7904a7e2bb3cdf0cf5e783f44204a85a37a93151738fa349f06680f59a98b45"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
-"checksum web3 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b545923a9f3a9bb054ac3375f8fba91761c5c010ffb5c0f680a212bb73dcc32c"
+"checksum web3 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "076f34ed252d74a8521e3b013254b1a39f94a98f23aae7cfc85cda6e7b395664"
 "checksum websocket 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c9faed2bff8af2ea6b9f8b917d3d00b467583f6781fe3def174a9e33c879703"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "base64"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -349,6 +358,11 @@ dependencies = [
  "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bitflags"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
@@ -605,6 +619,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +760,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethabi"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethbloom 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types-serialize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethereum-types-serialize"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "exonum-build"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +839,18 @@ dependencies = [
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fixed-hash"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "flate2"
@@ -911,6 +989,14 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "heapsize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1068,24 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.10.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyper"
 version = "0.12.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1029,6 +1133,22 @@ dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rlp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1237,6 +1357,14 @@ dependencies = [
 
 [[package]]
 name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1270,6 +1398,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "memzero"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mime"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "mime"
@@ -1999,6 +2135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,6 +2188,11 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc-hex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2058,6 +2208,11 @@ dependencies = [
 [[package]]
 name = "ryu"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "safemem"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2229,6 +2384,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "slab"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -2256,6 +2416,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "static_assertions"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2404,6 +2569,14 @@ dependencies = [
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2579,6 +2752,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-timer"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-timer"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2586,6 +2768,16 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-tls"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2600,6 +2792,22 @@ dependencies = [
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-uds"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2626,6 +2834,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "traitobject"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "trust-dns-proto"
@@ -2747,6 +2960,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeable"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "typenum"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,6 +2973,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "ucd-util"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "uint"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "unicase"
@@ -2878,6 +3107,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "web3"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "websocket 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "websocket"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "which"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,6 +3269,16 @@ dependencies = [
 [[package]]
 name = "witnet-ethereum-bridge"
 version = "0.1.0"
+dependencies = [
+ "async-jsonrpc-client 0.1.0 (git+https://github.com/witnet/async-jsonrpc-client)",
+ "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web3 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "witnet_data_structures 0.3.2",
+]
 
 [[package]]
 name = "witnet_config"
@@ -3254,9 +3542,11 @@ dependencies = [
 "checksum backtrace 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)" = "18b50f5258d1a9ad8396d2d345827875de4261b158124d4c819d9b351454fae5"
 "checksum backtrace-sys 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "5b3a000b9c543553af61bc01cbfc403b04b5caa9e421033866f2e98061eb3e61"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
 "checksum bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7"
 "checksum bindgen 0.47.3 (registry+https://github.com/rust-lang/crates.io-index)" = "df683a55b54b41d5ea8ebfaebb5aa7e6b84e3f3006a78f010dadc9ca88469260"
+"checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
@@ -3287,6 +3577,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
 "checksum derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d944ac6003ed268757ef1ee686753b57efc5fcf0ebe7b64c9fc81e7e32ff839"
@@ -3302,10 +3593,15 @@ dependencies = [
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
+"checksum ethabi 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be9a03ff8f3d495d9b73d59fd166acc91d0fd81779911b0b8b4c87b6024a670a"
+"checksum ethbloom 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3932e82d64d347a045208924002930dc105a138995ccdc1479d0f05f0359f17c"
+"checksum ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b054df51e53f253837ea422681215b42823c02824bde982699d0dceecf6165a1"
+"checksum ethereum-types-serialize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1873d77b32bc1891a79dad925f2acbc318ee942b38b9110f9dbc5fbeffcea350"
 "checksum exonum-build 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9347df5a2daa4bef24658c6a84cfd33dddca0ffb27647bd281fcc96c5810a09a"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d1a683d1234507e4f3bf2736eeddf0de1dc65996dc0164d57eba0a74bcf29489"
 "checksum flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "550934ad4808d5d39365e5d61727309bf18b3b02c6c56b729cb92e7dd84bc3d8"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
@@ -3324,6 +3620,7 @@ dependencies = [
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum hashbrown 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "29fba9abe4742d586dfd0c06ae4f7e73a1c2d86b856933509b269d82cdf06e18"
 "checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
+"checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f127a908633569f208325f86f71255d3363c79721d7f9fe31cd5569908819771"
@@ -3333,9 +3630,12 @@ dependencies = [
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
+"checksum hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
 "checksum hyper 0.12.32 (registry+https://github.com/rust-lang/crates.io-index)" = "a64d71c1e77d39da024f06f5821ee00ad9c38febb90370bad1f07a94e0bc8793"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+"checksum impl-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f39b9963cf5f12fcc4ae4b30a6927ed67d6b4ea4cbe7d17a41131163b401303b"
+"checksum impl-serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d26be4b97d738552ea423f76c4f681012ff06c3fa36fa968656b3679f60b4a1"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "08f7eadeaf4b52700de180d147c4805f199854600b36faa963d91114827b2ffc"
@@ -3359,12 +3659,14 @@ dependencies = [
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
+"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum memzero 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "93c0d11ac30a033511ae414355d80f70d9f29a44a49140face477117a1ee90db"
+"checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "30de2e4613efcba1ec63d8133f344076952090c122992a903359be5a4f99c3ed"
 "checksum miniz_oxide 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b6c3756d66cf286314d5f7ebe74886188a9a92f5eee68b06f31ac2b4f314c99d"
@@ -3440,14 +3742,17 @@ dependencies = [
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)" = "e57803405f8ea0eb041c1567dac36127e0c8caa1251c843cb03d43fd767b3d50"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
+"checksum rlp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b0d56c1450bfbef1181fdeb78b902dc1d23178de77c23d705317508e03d1b7c"
 "checksum rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a3d45d7afc9b132b34a2479648863aa95c5c88e98b32285326a6ebadc80ec5c9"
 "checksum rmpv 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29af0205707de955a396a1d3c657677c65f791ebabb63c0596c0b2fec0bf6325"
 "checksum rocksdb 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d29e12aab379a49bfbca337132440be73d1de6f328d5635641c2b28ac9dfe514"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
+"checksum rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "403bb3a286107a04825a5f82e1270acc1e14028d3d554d7a1e08914549575ab8"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
+"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
 "checksum scoped-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "332ffa32bf586782a3efaeb58f127980944bbc8c4d6913a86107ac2a5ab24b28"
@@ -3469,11 +3774,13 @@ dependencies = [
 "checksum signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "72ab58f1fda436857e6337dcb6a5aaa34f16c5ddc87b3a8b6ef7a212f90b9c5a"
 "checksum signal-hook-registry 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cded4ffa32146722ec54ab1f16320568465aa922aa9ab4708129599740da85d7"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+"checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "4e626972d3593207547f14bf5fc9efa4d0e7283deb73fef1dff313dae9ab8878"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
@@ -3490,6 +3797,7 @@ dependencies = [
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c1c5676413eaeb1ea35300a0224416f57abc3bd251657e0fafc12c47ff98c060"
+"checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
@@ -3503,10 +3811,14 @@ dependencies = [
 "checksum tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2162248ff317e2bc713b261f242b69dbb838b85248ed20bb21df56d60ea4cae7"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "90ca01319dea1e376a001e8dc192d42ebde6dd532532a5bad988ac37db365b19"
+"checksum tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6131e780037787ff1b3f8aad9da83bca02438b72277850dd6ad0d455e0e20efc"
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
+"checksum tokio-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
 "checksum tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92"
+"checksum tokio-uds 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "65ae5d255ce739e8537221ed2942e0445f4b3b813daebac1c0050ddaaa3587f9"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+"checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum trust-dns-proto 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0838272e89f1c693b4df38dc353412e389cf548ceed6f9fd1af5a8d6e0e7cf74"
 "checksum trust-dns-proto 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "09144f0992b0870fa8d2972cc069cbf1e3c0fda64d1f3d45c4d68d0e0b52ad4e"
 "checksum trust-dns-proto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5559ebdf6c2368ddd11e20b11d6bbaf9e46deb803acd7815e93f5a7b4a6d2901"
@@ -3514,8 +3826,10 @@ dependencies = [
 "checksum trust-dns-resolver 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c9992e58dba365798803c0b91018ff6c8d3fc77e06977c4539af2a6bfe0a039"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
+"checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
+"checksum uint 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "082df6964410f6aa929a61ddfafc997e4f32c62c22490e439ac351cec827f436"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
@@ -3533,6 +3847,8 @@ dependencies = [
 "checksum vrf 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "47382d96667d2abefe4f1a4054827b5c72fbfcfbee0a112c57d6461e132cd58b"
 "checksum walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c7904a7e2bb3cdf0cf5e783f44204a85a37a93151738fa349f06680f59a98b45"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
+"checksum web3 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b545923a9f3a9bb054ac3375f8fba91761c5c010ffb5c0f680a212bb73dcc32c"
+"checksum websocket 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c9faed2bff8af2ea6b9f8b917d3d00b467583f6781fe3def174a9e33c879703"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"
 "checksum widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effc0e4ff8085673ea7b9b2e3c73f6bd4d118810c9009ed8f1e16bd96c331db6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,14 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bimap"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bincode"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3271,8 +3279,10 @@ name = "witnet-ethereum-bridge"
 version = "0.1.0"
 dependencies = [
  "async-jsonrpc-client 0.1.0 (git+https://github.com/witnet/async-jsonrpc-client)",
+ "bimap 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3547,6 +3557,7 @@ dependencies = [
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
+"checksum bimap 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "446177e5c72eca392a27926194ceb51a6d3f6a855ef56a490fca096e93f9971f"
 "checksum bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7"
 "checksum bindgen 0.47.3 (registry+https://github.com/rust-lang/crates.io-index)" = "df683a55b54b41d5ea8ebfaebb5aa7e6b84e3f3006a78f010dadc9ca88469260"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "An in-progress open source implementation of the Witnet protocol 
 edition = "2018"
 
 [workspace]
-members = ["config", "node", "crypto", "data_structures", "p2p", "storage", "wallet", "validations", "protected", "reputation", "net"]
+members = ["config", "node", "crypto", "data_structures", "p2p", "storage", "wallet", "validations", "protected", "reputation", "net", "bridges/ethereum"]
 
 [features]
 default = ["wallet", "node"]

--- a/bridges/ethereum/Cargo.toml
+++ b/bridges/ethereum/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"] }
 env_logger = "0.6.1"
 ethabi = "7.0"
+log = "0.4.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = "0.1"

--- a/bridges/ethereum/Cargo.toml
+++ b/bridges/ethereum/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2018"
 
 [dependencies]
 async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"] }
+bimap = "0.3.1"
 env_logger = "0.6.1"
 ethabi = "7.0"
+futures = "0.1.28"
 log = "0.4.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/bridges/ethereum/Cargo.toml
+++ b/bridges/ethereum/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "witnet-ethereum-bridge"
+version = "0.1.0"
+authors = ["Witnet Foundation <info@witnet.foundation>"]
+edition = "2018"
+
+[dependencies]

--- a/bridges/ethereum/Cargo.toml
+++ b/bridges/ethereum/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"] }
 bimap = "0.3.1"
 env_logger = "0.6.1"
-ethabi = "7.0"
+ethabi = "8.0"
 futures = "0.1.28"
 log = "0.4.6"
 serde = { version = "1.0", features = ["derive"] }
@@ -16,5 +16,5 @@ serde_json = "1.0"
 tokio = "0.1"
 toml = "0.4.10"
 tokio-core = "0.1"
-web3 = "0.7"
+web3 = "0.8"
 witnet_data_structures = { path = "../../data_structures" }

--- a/bridges/ethereum/Cargo.toml
+++ b/bridges/ethereum/Cargo.toml
@@ -5,3 +5,11 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
 
 [dependencies]
+async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = "0.1"
+toml = "0.4.10"
+tokio-core = "0.1"
+web3 = "0.7"
+witnet_data_structures = { path = "../../data_structures" }

--- a/bridges/ethereum/Cargo.toml
+++ b/bridges/ethereum/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 
 [dependencies]
 async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"] }
+env_logger = "0.6.1"
+ethabi = "7.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = "0.1"

--- a/bridges/ethereum/block_relay_abi.json
+++ b/bridges/ethereum/block_relay_abi.json
@@ -10,11 +10,11 @@
       "name": "blocks",
       "outputs": [
         {
-          "name": "dr_hash_merkle_root",
+          "name": "drHashMerkleRoot",
           "type": "uint256"
         },
         {
-          "name": "tally_hash_merkle_root",
+          "name": "tallyHashMerkleRoot",
           "type": "uint256"
         }
       ],

--- a/bridges/ethereum/block_relay_abi.json
+++ b/bridges/ethereum/block_relay_abi.json
@@ -1,0 +1,109 @@
+[
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "blocks",
+      "outputs": [
+        {
+          "name": "dr_hash_merkle_root",
+          "type": "uint256"
+        },
+        {
+          "name": "tally_hash_merkle_root",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "_id",
+          "type": "uint256"
+        }
+      ],
+      "name": "NewBlock",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_blockHash",
+          "type": "uint256"
+        },
+        {
+          "name": "_drMerkleRoot",
+          "type": "uint256"
+        },
+        {
+          "name": "_tallyMerkleRoot",
+          "type": "uint256"
+        }
+      ],
+      "name": "postNewBlock",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_blockHash",
+          "type": "uint256"
+        }
+      ],
+      "name": "readDrMerkleRoot",
+      "outputs": [
+        {
+          "name": "drMerkleRoot",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_blockHash",
+          "type": "uint256"
+        }
+      ],
+      "name": "readTallyMerkleRoot",
+      "outputs": [
+        {
+          "name": "tallyMerkleRoot",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
+]
+

--- a/bridges/ethereum/examples/post_dr.rs
+++ b/bridges/ethereum/examples/post_dr.rs
@@ -3,7 +3,6 @@ use std::{
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
-
 use web3::{
     contract,
     futures::{future, Future},

--- a/bridges/ethereum/examples/post_dr.rs
+++ b/bridges/ethereum/examples/post_dr.rs
@@ -15,6 +15,7 @@ struct Config {
     witnet_jsonrpc_addr: SocketAddr,
     eth_client_url: String,
     wbi_contract_addr: H160,
+    block_relay_contract_addr: H160,
     eth_account: H160,
 }
 
@@ -68,7 +69,7 @@ fn eth_event_stream(
 
     contract
         .call(
-            "post_dr",
+            "postDataRequest",
             (data_request_bytes, tally_value),
             accounts[0],
             contract::Options::with(|opt| {

--- a/bridges/ethereum/examples/post_dr.rs
+++ b/bridges/ethereum/examples/post_dr.rs
@@ -8,6 +8,8 @@ use web3::{
     futures::{future, Future},
     types::H160,
 };
+use witnet_data_structures::chain::DataRequestOutput;
+use witnet_data_structures::proto::ProtobufConvert;
 
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -65,7 +67,9 @@ fn eth_event_stream(
     let data_request_string = format!("{}{}{}", drs0, drs1, drs2);
     //if post_dr {
     let tally_value = U256::from_dec_str("50000000000000000").unwrap();
-    let data_request_bytes = data_request_string.as_bytes().to_vec();
+    let data_request_output: DataRequestOutput =
+        serde_json::from_str(&data_request_string).unwrap();
+    let data_request_bytes = data_request_output.to_pb_bytes().unwrap();
 
     contract
         .call(

--- a/bridges/ethereum/examples/post_dr.rs
+++ b/bridges/ethereum/examples/post_dr.rs
@@ -4,15 +4,16 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use web3::types::U256;
 use web3::{
     contract,
     futures::{future, Future},
+    types::U256,
 };
-use witnet_data_structures::chain::DataRequestOutput;
-use witnet_data_structures::proto::ProtobufConvert;
-use witnet_ethereum_bridge::config::{read_config, Config};
-use witnet_ethereum_bridge::eth::EthState;
+use witnet_data_structures::{chain::DataRequestOutput, proto::ProtobufConvert};
+use witnet_ethereum_bridge::{
+    config::{read_config, Config},
+    eth::EthState,
+};
 
 fn data_request_example() -> DataRequestOutput {
     let start = SystemTime::now();

--- a/bridges/ethereum/examples/post_dr.rs
+++ b/bridges/ethereum/examples/post_dr.rs
@@ -1,0 +1,110 @@
+use log::*;
+use serde::{Deserialize, Serialize};
+use std::{net::SocketAddr, path::Path, sync::Arc};
+use web3::types::U256;
+use web3::{
+    contract,
+    contract::Contract,
+    futures::{future, Future},
+    types::H160,
+};
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Config {
+    witnet_jsonrpc_addr: SocketAddr,
+    eth_client_url: String,
+    wbi_contract_addr: H160,
+    eth_account: H160,
+}
+
+/// Load configuration from a file written in Toml format.
+fn from_file<S: AsRef<Path>>(file: S) -> Result<Config, toml::de::Error> {
+    use std::fs::File;
+    use std::io::Read;
+
+    let f = file.as_ref();
+    let mut contents = String::new();
+
+    debug!("Loading config from `{}`", f.to_string_lossy());
+
+    let mut file = File::open(file).unwrap();
+    file.read_to_string(&mut contents).unwrap();
+    toml::from_str(&contents)
+}
+
+fn read_config() -> Config {
+    from_file("witnet_ethereum_bridge.toml").unwrap()
+}
+
+fn eth_event_stream(
+    config: Arc<Config>,
+    web3: web3::Web3<web3::transports::Http>,
+) -> impl Future<Item = (), Error = ()> {
+    // Example from
+    // https://github.com/tomusdrw/rust-web3/blob/master/examples/simple_log_filter.rs
+
+    let accounts = web3.eth().accounts().wait().unwrap();
+    debug!("Web3 accounts: {:?}", accounts);
+
+    // Why read files at runtime when you can read files at compile time
+    let contract_abi_json: &[u8] = include_bytes!("../wbi_abi.json");
+    let contract_abi = ethabi::Contract::load(contract_abi_json).unwrap();
+    let contract_address = config.wbi_contract_addr;
+    let contract = Contract::new(web3.eth(), contract_address, contract_abi.clone());
+
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let start = SystemTime::now();
+    let since_the_epoch = start
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+    let drs0 = r#"{"data_request":{"not_before":"#;
+    let drs1 = since_the_epoch.as_secs().to_string();
+    let drs2 = r#","retrieve":[{"kind":"HTTP-GET","url":"https://api.coindesk.com/v1/bpi/currentprice.json","script":[152, 83, 204, 132, 146, 1, 163, 98, 112, 105, 204, 132, 146, 1, 163, 85, 83, 68, 204, 132, 146, 1, 170, 114, 97, 116, 101, 95, 102, 108, 111, 97, 116, 204, 130]}],"aggregate":{"script":[145,  146,  102,  32]},"consensus":{"script":[145,  146, 102,  32]},"deliver":[{"kind":"HTTP-GET","url":"https://hooks.zapier.com/hooks/catch/3860543/l2awcd/"},{"kind":"HTTP-GET","url":"https://hooks.zapier.com/hooks/catch/3860543/l1awcw/"}]},"value":1002,"witnesses":2,"backup_witnesses":1,"commit_fee":0,"reveal_fee":0,"tally_fee":0,"time_lock":0}"#;
+    let data_request_string = format!("{}{}{}", drs0, drs1, drs2);
+    //if post_dr {
+    let tally_value = U256::from_dec_str("50000000000000000").unwrap();
+    let data_request_bytes = data_request_string.as_bytes().to_vec();
+
+    contract
+        .call(
+            "post_dr",
+            (data_request_bytes, tally_value),
+            accounts[0],
+            contract::Options::with(|opt| {
+                opt.value = Some(U256::from_dec_str("250000000000000000").unwrap());
+                opt.gas = Some(1_000_000.into());
+            }),
+        )
+        .map(|tx| {
+            debug!("posted dr to wbi: {:?}", tx);
+        })
+        .map_err(|e| error!("Error posting dr to wbi: {}", e))
+}
+
+fn init_logger() {
+    // Debug log level by default
+    let mut log_level = log::LevelFilter::Debug;
+    if let Ok(rust_log) = std::env::var("RUST_LOG") {
+        if rust_log.contains("witnet") {
+            log_level = env_logger::Logger::from_default_env().filter();
+        }
+    }
+
+    env_logger::Builder::from_env(env_logger::Env::default())
+        .filter_module("post_dr", log_level)
+        .init();
+}
+
+fn main() {
+    init_logger();
+    let config = Arc::new(read_config());
+    let (_eloop, web3_http) = web3::transports::Http::new(&config.eth_client_url).unwrap();
+    let web3 = web3::Web3::new(web3_http);
+
+    let ees = eth_event_stream(Arc::clone(&config), web3);
+
+    tokio::run(future::ok(()).map(move |_| {
+        tokio::spawn(ees);
+    }));
+}

--- a/bridges/ethereum/examples/post_dr.rs
+++ b/bridges/ethereum/examples/post_dr.rs
@@ -31,10 +31,9 @@ fn data_request_example() -> DataRequestOutput {
 }
 
 fn eth_event_stream(
-    _config: Arc<Config>,
+    config: Arc<Config>,
     eth_state: Arc<EthState>,
 ) -> impl Future<Item = (), Error = ()> {
-    let accounts = eth_state.accounts.clone();
     let wbi_contract = eth_state.wbi_contract.clone();
 
     let data_request_output = data_request_example();
@@ -46,7 +45,7 @@ fn eth_event_stream(
         .call(
             "postDataRequest",
             (data_request_bytes, tally_value),
-            accounts[0],
+            config.eth_account,
             contract::Options::with(|opt| {
                 opt.value = Some(U256::from_dec_str("250000000000000000").unwrap());
                 opt.gas = Some(1_000_000.into());

--- a/bridges/ethereum/examples/read_requests.rs
+++ b/bridges/ethereum/examples/read_requests.rs
@@ -1,0 +1,101 @@
+use ethabi::Bytes;
+use log::*;
+use serde::{Deserialize, Serialize};
+use std::{net::SocketAddr, path::Path, sync::Arc};
+use web3::{
+    contract,
+    contract::Contract,
+    futures::{future, Future},
+    types::H160,
+};
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Config {
+    witnet_jsonrpc_addr: SocketAddr,
+    eth_client_url: String,
+    wbi_contract_addr: H160,
+    eth_account: H160,
+}
+
+/// Load configuration from a file written in Toml format.
+fn from_file<S: AsRef<Path>>(file: S) -> Result<Config, toml::de::Error> {
+    use std::fs::File;
+    use std::io::Read;
+
+    let f = file.as_ref();
+    let mut contents = String::new();
+
+    debug!("Loading config from `{}`", f.to_string_lossy());
+
+    let mut file = File::open(file).unwrap();
+    file.read_to_string(&mut contents).unwrap();
+    toml::from_str(&contents)
+}
+
+fn read_config() -> Config {
+    from_file("witnet_ethereum_bridge.toml").unwrap()
+}
+
+fn eth_event_stream(
+    config: Arc<Config>,
+    web3: web3::Web3<web3::transports::Http>,
+) -> impl Future<Item = (), Error = ()> {
+    // Example from
+    // https://github.com/tomusdrw/rust-web3/blob/master/examples/simple_log_filter.rs
+
+    let accounts = web3.eth().accounts().wait().unwrap();
+    debug!("Web3 accounts: {:?}", accounts);
+
+    // Why read files at runtime when you can read files at compile time
+    let contract_abi_json: &[u8] = include_bytes!("../wbi_abi.json");
+    let contract_abi = ethabi::Contract::load(contract_abi_json).unwrap();
+    let contract_address = config.wbi_contract_addr;
+    let contract = Contract::new(web3.eth(), contract_address, contract_abi.clone());
+
+    // TODO: how to access the public mapping "requests"?
+    // (this doesn't work)
+    let requests: Bytes = contract
+        .query(
+            "requests",
+            (),
+            accounts[0],
+            contract::Options::with(|opt| {
+                opt.value = Some(1000.into());
+                opt.gas = Some(1_000_000.into());
+            }),
+            None,
+        )
+        .wait()
+        .unwrap();
+    info!("Got requests: {:?}", requests);
+
+    future::finished(())
+}
+
+fn init_logger() {
+    // Debug log level by default
+    let mut log_level = log::LevelFilter::Debug;
+    if let Ok(rust_log) = std::env::var("RUST_LOG") {
+        if rust_log.contains("witnet") {
+            log_level = env_logger::Logger::from_default_env().filter();
+        }
+    }
+
+    env_logger::Builder::from_env(env_logger::Env::default())
+        .filter_module("post_dr", log_level)
+        .init();
+}
+
+fn main() {
+    init_logger();
+    let config = Arc::new(read_config());
+    let (_eloop, web3_http) = web3::transports::Http::new(&config.eth_client_url).unwrap();
+    let web3 = web3::Web3::new(web3_http);
+
+    let ees = eth_event_stream(Arc::clone(&config), web3);
+
+    tokio::run(future::ok(()).map(move |_| {
+        tokio::spawn(ees);
+    }));
+}

--- a/bridges/ethereum/examples/read_requests.rs
+++ b/bridges/ethereum/examples/read_requests.rs
@@ -1,13 +1,15 @@
 use log::*;
 use std::sync::Arc;
 
-use web3::types::U256;
 use web3::{
     contract,
     futures::{future, Future},
+    types::U256,
 };
-use witnet_ethereum_bridge::config::{read_config, Config};
-use witnet_ethereum_bridge::eth::EthState;
+use witnet_ethereum_bridge::{
+    config::{read_config, Config},
+    eth::EthState,
+};
 
 fn eth_event_stream(
     _config: Arc<Config>,

--- a/bridges/ethereum/examples/read_requests.rs
+++ b/bridges/ethereum/examples/read_requests.rs
@@ -1,61 +1,24 @@
-use ethabi::Bytes;
 use log::*;
-use serde::{Deserialize, Serialize};
-use std::{net::SocketAddr, path::Path, sync::Arc};
+use std::sync::Arc;
+
+use web3::types::U256;
 use web3::{
     contract,
-    contract::Contract,
     futures::{future, Future},
-    types::H160,
 };
-
-#[derive(Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct Config {
-    witnet_jsonrpc_addr: SocketAddr,
-    eth_client_url: String,
-    wbi_contract_addr: H160,
-    block_relay_contract_addr: H160,
-    eth_account: H160,
-}
-/// Load configuration from a file written in Toml format.
-fn from_file<S: AsRef<Path>>(file: S) -> Result<Config, toml::de::Error> {
-    use std::fs::File;
-    use std::io::Read;
-
-    let f = file.as_ref();
-    let mut contents = String::new();
-
-    debug!("Loading config from `{}`", f.to_string_lossy());
-
-    let mut file = File::open(file).unwrap();
-    file.read_to_string(&mut contents).unwrap();
-    toml::from_str(&contents)
-}
-
-fn read_config() -> Config {
-    from_file("witnet_ethereum_bridge.toml").unwrap()
-}
+use witnet_ethereum_bridge::config::{read_config, Config};
+use witnet_ethereum_bridge::eth::EthState;
 
 fn eth_event_stream(
-    config: Arc<Config>,
-    web3: web3::Web3<web3::transports::Http>,
+    _config: Arc<Config>,
+    eth_state: Arc<EthState>,
 ) -> impl Future<Item = (), Error = ()> {
-    // Example from
-    // https://github.com/tomusdrw/rust-web3/blob/master/examples/simple_log_filter.rs
-
-    let accounts = web3.eth().accounts().wait().unwrap();
-    debug!("Web3 accounts: {:?}", accounts);
-
-    // Why read files at runtime when you can read files at compile time
-    let contract_abi_json: &[u8] = include_bytes!("../wbi_abi.json");
-    let contract_abi = ethabi::Contract::load(contract_abi_json).unwrap();
-    let contract_address = config.wbi_contract_addr;
-    let contract = Contract::new(web3.eth(), contract_address, contract_abi.clone());
+    let accounts = eth_state.accounts.clone();
+    let wbi_contract = eth_state.wbi_contract.clone();
 
     // TODO: how to access the public mapping "requests"?
     // (this doesn't work)
-    let requests: Bytes = contract
+    let requests: U256 = wbi_contract
         .query(
             "requests",
             (),
@@ -89,11 +52,10 @@ fn init_logger() {
 
 fn main() {
     init_logger();
-    let config = Arc::new(read_config());
-    let (_eloop, web3_http) = web3::transports::Http::new(&config.eth_client_url).unwrap();
-    let web3 = web3::Web3::new(web3_http);
+    let config = Arc::new(read_config().unwrap());
+    let eth_state = Arc::new(EthState::create(&config).unwrap());
 
-    let ees = eth_event_stream(Arc::clone(&config), web3);
+    let ees = eth_event_stream(Arc::clone(&config), Arc::clone(&eth_state));
 
     tokio::run(future::ok(()).map(move |_| {
         tokio::spawn(ees);

--- a/bridges/ethereum/examples/read_requests.rs
+++ b/bridges/ethereum/examples/read_requests.rs
@@ -15,9 +15,9 @@ struct Config {
     witnet_jsonrpc_addr: SocketAddr,
     eth_client_url: String,
     wbi_contract_addr: H160,
+    block_relay_contract_addr: H160,
     eth_account: H160,
 }
-
 /// Load configuration from a file written in Toml format.
 fn from_file<S: AsRef<Path>>(file: S) -> Result<Config, toml::de::Error> {
     use std::fs::File;

--- a/bridges/ethereum/src/config.rs
+++ b/bridges/ethereum/src/config.rs
@@ -19,7 +19,6 @@ pub struct Config {
     /// Address of the BlockRelay deployed contract
     pub block_relay_contract_addr: H160,
     /// Ethereum account used to create the transactions
-    //TODO: unimplemented
     pub eth_account: H160,
     /// Enable block relay from witnet to ethereum?
     pub enable_block_relay: bool,

--- a/bridges/ethereum/src/config.rs
+++ b/bridges/ethereum/src/config.rs
@@ -1,0 +1,46 @@
+//! Configuration
+
+use log::*;
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use std::path::Path;
+use web3::types::H160;
+
+/// Configuration
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    /// Address of the witnet node JSON-RPC server
+    pub witnet_jsonrpc_addr: SocketAddr,
+    /// Url of the ethereum client
+    pub eth_client_url: String,
+    /// Address of the WitnetBridgeInterface deployed contract
+    pub wbi_contract_addr: H160,
+    /// Address of the BlockRelay deployed contract
+    pub block_relay_contract_addr: H160,
+    /// Ethereum account used to create the transactions
+    //TODO: unimplemented
+    pub eth_account: H160,
+    /// Enable block relay from witnet to ethereum?
+    pub enable_block_relay: bool,
+}
+
+/// Load configuration from a file written in Toml format.
+pub fn from_file<S: AsRef<Path>>(file: S) -> Result<Config, toml::de::Error> {
+    use std::fs::File;
+    use std::io::Read;
+
+    let f = file.as_ref();
+    let mut contents = String::new();
+
+    debug!("Loading config from `{}`", f.to_string_lossy());
+
+    let mut file = File::open(file).unwrap();
+    file.read_to_string(&mut contents).unwrap();
+    toml::from_str(&contents)
+}
+
+/// Read config from default file
+pub fn read_config() -> Result<Config, toml::de::Error> {
+    from_file("witnet_ethereum_bridge.toml")
+}

--- a/bridges/ethereum/src/config.rs
+++ b/bridges/ethereum/src/config.rs
@@ -26,7 +26,7 @@ pub struct Config {
 }
 
 /// Load configuration from a file written in Toml format.
-pub fn from_file<S: AsRef<Path>>(file: S) -> Result<Config, toml::de::Error> {
+pub fn from_file<S: AsRef<Path>>(file: S) -> Result<Config, Box<dyn std::error::Error>> {
     use std::fs::File;
     use std::io::Read;
 
@@ -35,12 +35,12 @@ pub fn from_file<S: AsRef<Path>>(file: S) -> Result<Config, toml::de::Error> {
 
     debug!("Loading config from `{}`", f.to_string_lossy());
 
-    let mut file = File::open(file).unwrap();
-    file.read_to_string(&mut contents).unwrap();
-    toml::from_str(&contents)
+    let mut file = File::open(file)?;
+    file.read_to_string(&mut contents)?;
+    Ok(toml::from_str(&contents)?)
 }
 
 /// Read config from default file
-pub fn read_config() -> Result<Config, toml::de::Error> {
+pub fn read_config() -> Result<Config, Box<dyn std::error::Error>> {
     from_file("witnet_ethereum_bridge.toml")
 }

--- a/bridges/ethereum/src/eth.rs
+++ b/bridges/ethereum/src/eth.rs
@@ -1,0 +1,109 @@
+use crate::config::Config;
+use ethabi::Token;
+use futures::Future;
+use log::*;
+use web3::{
+    contract::Contract,
+    types::{H160, H256, U256},
+};
+
+/// State needed to interact with the ethereum side of the bridge
+pub struct EthState {
+    /// Web3 event loop handle
+    pub _eloop: web3::transports::EventLoopHandle,
+    /// Web3
+    pub web3: web3::Web3<web3::transports::Http>,
+    /// Accounts
+    pub accounts: Vec<H160>,
+    /// WBI contract
+    pub wbi_contract: Contract<web3::transports::Http>,
+    /// PostDataRequest event signature
+    pub post_dr_event_sig: H256,
+    /// InclusionDataRequest event signature
+    pub inclusion_dr_event_sig: H256,
+    /// PostResult event signature
+    pub post_tally_event_sig: H256,
+    /// BlockRelay contract
+    pub block_relay_contract: Contract<web3::transports::Http>,
+}
+
+impl EthState {
+    /// Read addresses from config and create `State` struct
+    pub fn create(config: &Config) -> Result<Self, ()> {
+        let (_eloop, web3_http) =
+            web3::transports::Http::new(&config.eth_client_url).map_err(|_| ())?;
+        let web3 = web3::Web3::new(web3_http);
+        let accounts = web3.eth().accounts().wait().map_err(|_| ())?;
+        debug!("Web3 accounts: {:?}", accounts);
+
+        // Why read files at runtime when you can read files at compile time
+        let wbi_contract_abi_json: &[u8] = include_bytes!("../wbi_abi.json");
+        let wbi_contract_abi = ethabi::Contract::load(wbi_contract_abi_json).map_err(|_| ())?;
+        let wbi_contract_address = config.wbi_contract_addr;
+        let wbi_contract =
+            Contract::new(web3.eth(), wbi_contract_address, wbi_contract_abi.clone());
+
+        let block_relay_contract_abi_json: &[u8] = include_bytes!("../block_relay_abi.json");
+        let block_relay_contract_abi =
+            ethabi::Contract::load(block_relay_contract_abi_json).map_err(|_| ())?;
+        let block_relay_contract_address = config.block_relay_contract_addr;
+        let block_relay_contract = Contract::new(
+            web3.eth(),
+            block_relay_contract_address,
+            block_relay_contract_abi.clone(),
+        );
+
+        //debug!("WBI events: {:?}", contract_abi.events);
+        let post_dr_event = wbi_contract_abi
+            .event("PostDataRequest")
+            .map_err(|_| ())?
+            .clone();
+        let inclusion_dr_event = wbi_contract_abi
+            .event("InclusionDataRequest")
+            .map_err(|_| ())?
+            .clone();
+        let post_tally_event = wbi_contract_abi
+            .event("PostResult")
+            .map_err(|_| ())?
+            .clone();
+
+        let post_dr_event_sig = post_dr_event.signature();
+        let inclusion_dr_event_sig = inclusion_dr_event.signature();
+        let post_tally_event_sig = post_tally_event.signature();
+
+        Ok(Self {
+            _eloop,
+            web3,
+            accounts,
+            wbi_contract,
+            block_relay_contract,
+            post_dr_event_sig,
+            inclusion_dr_event_sig,
+            post_tally_event_sig,
+        })
+    }
+}
+
+/// Assume the first return value of an event log is a U256 and return it
+pub fn read_u256_from_event_log(value: &web3::types::Log) -> Result<U256, ()> {
+    let event_types = vec![ethabi::ParamType::Uint(0)];
+    let event_data = ethabi::decode(&event_types, &value.data.0);
+    debug!("Event data: {:?}", event_data);
+
+    match event_data.map_err(|_| ())?.get(0).ok_or(())? {
+        Token::Uint(x) => Ok(*x),
+        _ => Err(()),
+    }
+}
+
+/// Possible ethereum events emited by the WBI ethereum contract
+pub enum WbiEvent {
+    /// A new data request has been posted to ethereum
+    PostDataRequest(U256),
+    /// A data request from ethereum has been posted to witnet with a proof of
+    /// inclusion in a block
+    InclusionDataRequest(U256),
+    /// A data request has been resolved in witnet, and the result was reported
+    /// to ethereum with a proof of inclusion
+    PostResult(U256),
+}

--- a/bridges/ethereum/src/eth.rs
+++ b/bridges/ethereum/src/eth.rs
@@ -53,17 +53,17 @@ impl EthState {
             block_relay_contract_abi.clone(),
         );
 
-        //debug!("WBI events: {:?}", contract_abi.events);
+        debug!("WBI events: {:?}", wbi_contract_abi.events);
         let post_dr_event = wbi_contract_abi
-            .event("PostDataRequest")
+            .event("PostedRequest")
             .map_err(|_| ())?
             .clone();
         let inclusion_dr_event = wbi_contract_abi
-            .event("InclusionDataRequest")
+            .event("IncludedRequest")
             .map_err(|_| ())?
             .clone();
         let post_tally_event = wbi_contract_abi
-            .event("PostResult")
+            .event("PostedResult")
             .map_err(|_| ())?
             .clone();
 
@@ -99,11 +99,11 @@ pub fn read_u256_from_event_log(value: &web3::types::Log) -> Result<U256, ()> {
 /// Possible ethereum events emited by the WBI ethereum contract
 pub enum WbiEvent {
     /// A new data request has been posted to ethereum
-    PostDataRequest(U256),
+    PostedRequest(U256),
     /// A data request from ethereum has been posted to witnet with a proof of
     /// inclusion in a block
-    InclusionDataRequest(U256),
+    IncludedRequest(U256),
     /// A data request has been resolved in witnet, and the result was reported
     /// to ethereum with a proof of inclusion
-    PostResult(U256),
+    PostedResult(U256),
 }

--- a/bridges/ethereum/src/lib.rs
+++ b/bridges/ethereum/src/lib.rs
@@ -1,0 +1,12 @@
+//! Witnet <> Ethereum bridge
+#![deny(rust_2018_idioms)]
+#![deny(non_upper_case_globals)]
+#![deny(non_camel_case_types)]
+#![deny(non_snake_case)]
+#![deny(unused_mut)]
+#![deny(missing_docs)]
+
+/// Configuration
+pub mod config;
+/// Ethereum related state
+pub mod eth;

--- a/bridges/ethereum/src/main.rs
+++ b/bridges/ethereum/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/bridges/ethereum/src/main.rs
+++ b/bridges/ethereum/src/main.rs
@@ -231,8 +231,8 @@ fn witnet_block_stream(
 }
 
 fn init_logger() {
-    // Debug log level by default
-    let mut log_level = log::LevelFilter::Debug;
+    // Info log level by default
+    let mut log_level = log::LevelFilter::Info;
     if let Ok(rust_log) = std::env::var("RUST_LOG") {
         if rust_log.contains("witnet") {
             log_level = env_logger::Logger::from_default_env().filter();

--- a/bridges/ethereum/src/main.rs
+++ b/bridges/ethereum/src/main.rs
@@ -1,3 +1,139 @@
+use async_jsonrpc_client::{futures::Stream, DuplexTransport, Transport};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{net::SocketAddr, path::Path, sync::Arc, time};
+use web3::{
+    contract::Contract,
+    futures::{future, Future},
+    types::FilterBuilder,
+    types::H160,
+};
+use witnet_data_structures::chain::Block;
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Config {
+    witnet_jsonrpc_addr: SocketAddr,
+    eth_client_url: String,
+    wbi_contract_addr: H160,
+    eth_account: H160,
+}
+
+/// Load configuration from a file written in Toml format.
+fn from_file<S: AsRef<Path>>(file: S) -> Result<Config, toml::de::Error> {
+    use std::fs::File;
+    use std::io::Read;
+
+    let f = file.as_ref();
+    let mut contents = String::new();
+
+    println!("Loading config from `{}`", f.to_string_lossy());
+
+    let mut file = File::open(file).unwrap();
+    file.read_to_string(&mut contents).unwrap();
+    toml::from_str(&contents)
+}
+
+fn read_config() -> Config {
+    from_file("witnet_ethereum_bridge.toml").unwrap()
+}
+
+fn eth_event_stream(
+    config: Arc<Config>,
+    web3: web3::Web3<web3::transports::Http>,
+) -> impl Future<Item = (), Error = ()> {
+    // Example from
+    // https://github.com/tomusdrw/rust-web3/blob/master/examples/simple_log_filter.rs
+
+    let accounts = web3.eth().accounts().wait().unwrap();
+    println!("Web3 accounts: {:?}", accounts);
+
+    let contract_address = config.wbi_contract_addr;
+    // Why read files at runtime when you can read files at compile time
+    let contract_abi_json = include_bytes!("../wbi_abi.json");
+
+    let _contract = Contract::from_json(web3.eth(), contract_address, contract_abi_json).unwrap();
+
+    // TODO: replace with actual "new data request" event
+    // Filter for Hello event in our contract
+    let filter = FilterBuilder::default()
+        .address(vec![contract_address])
+        .topics(
+            Some(vec![
+                "d282f389399565f3671145f5916e51652b60eee8e5c759293a2f5771b8ddfd2e"
+                    .parse()
+                    .unwrap(),
+            ]),
+            None,
+            None,
+            None,
+        )
+        .build();
+
+    // Example call
+    /*
+    let call_future = contract
+        .call("hello", (), accounts[0], Options::default())
+        .then(|tx| {
+            println!("got tx: {:?}", tx);
+            Result::<(), ()>::Ok(())
+        });
+    */
+
+    web3.eth_filter()
+        .create_logs_filter(filter)
+        .then(|filter| {
+            filter
+                .unwrap()
+                // This poll interval was set to 0 in the example, which resulted in the
+                // bridge having 100% cpu usage...
+                .stream(time::Duration::from_secs(1))
+                .for_each(|log| {
+                    println!("Got ethereum log: {:?}", log);
+                    Ok(())
+                })
+        })
+        .map_err(|_| ())
+}
+
+fn witnet_block_stream(config: Arc<Config>) -> impl Future<Item = (), Error = ()> {
+    let witnet_addr = config.witnet_jsonrpc_addr.to_string();
+    let (_handle, witnet_client) =
+        async_jsonrpc_client::transports::tcp::TcpSocket::new(&witnet_addr).unwrap();
+    let witnet_subscription_id_value = witnet_client
+        .execute("witnet_subscribe", json!(["newBlocks"]))
+        .wait()
+        .unwrap();
+    let witnet_subscription_id: String = match witnet_subscription_id_value {
+        serde_json::Value::String(s) => s,
+        _ => panic!("Not a string"),
+    };
+    println!(
+        "Suscribed to witnet newBlocks with subscription id {}",
+        witnet_subscription_id
+    );
+
+    witnet_client
+        .subscribe(&witnet_subscription_id.into())
+        .map(|value| {
+            let block = serde_json::from_value::<Block>(value).unwrap();
+            println!("Got witnet block: {:?}", block);
+        })
+        .map_err(|e| println!("witnet notification error = {:?}", e))
+        .for_each(|_| Ok(()))
+        .then(|_| Ok(()))
+}
+
 fn main() {
-    println!("Hello, world!");
+    let config = Arc::new(read_config());
+    let (_eloop, web3_http) = web3::transports::Http::new(&config.eth_client_url).unwrap();
+    let web3 = web3::Web3::new(web3_http);
+    let ees = eth_event_stream(Arc::clone(&config), web3);
+
+    let wbs = witnet_block_stream(Arc::clone(&config));
+
+    tokio::run(future::ok(()).map(move |_| {
+        tokio::spawn(wbs);
+        tokio::spawn(ees);
+    }));
 }

--- a/bridges/ethereum/src/main.rs
+++ b/bridges/ethereum/src/main.rs
@@ -1,16 +1,21 @@
 use async_jsonrpc_client::{futures::Stream, DuplexTransport, Transport};
+use bimap::BiMap;
+use ethabi::{Bytes, Token};
+use futures::sink::Sink;
 use log::*;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{net::SocketAddr, path::Path, sync::Arc, time};
+use tokio::sync::mpsc;
 use web3::{
+    contract,
     contract::Contract,
     futures::{future, Future},
-    types::FilterBuilder,
-    types::H160,
+    types::U256,
+    types::{FilterBuilder, H160},
 };
 use witnet_data_structures::{
-    chain::{Block, Hash, Hashable},
+    chain::{Block, DataRequestOutput, Hash, Hashable},
     proto::ProtobufConvert,
 };
 
@@ -44,23 +49,31 @@ fn read_config() -> Config {
 
 fn eth_event_stream(
     config: Arc<Config>,
-    web3: web3::Web3<web3::transports::Http>,
+    web3: &mut web3::Web3<web3::transports::Http>,
+    tx: mpsc::Sender<ActorMessage>,
 ) -> impl Future<Item = (), Error = ()> {
     // Example from
     // https://github.com/tomusdrw/rust-web3/blob/master/examples/simple_log_filter.rs
 
     let accounts = web3.eth().accounts().wait().unwrap();
     debug!("Web3 accounts: {:?}", accounts);
+    let account0 = accounts[0];
 
     // Why read files at runtime when you can read files at compile time
     let contract_abi_json: &[u8] = include_bytes!("../wbi_abi.json");
     let contract_abi = ethabi::Contract::load(contract_abi_json).unwrap();
     let contract_address = config.wbi_contract_addr;
-    let _contract = Contract::new(web3.eth(), contract_address, contract_abi.clone());
+    let contract = Contract::new(web3.eth(), contract_address, contract_abi.clone());
 
-    // TODO: replace with actual "new data request" event
     //debug!("WBI events: {:?}", contract_abi.events);
-    let post_dr_event = contract_abi.event("PostDataRequest").unwrap();
+    let post_dr_event = contract_abi.event("PostDataRequest").unwrap().clone();
+    let inclusion_dr_event = contract_abi.event("InclusionDataRequest").unwrap().clone();
+    let post_tally_event = contract_abi.event("PostResult").unwrap().clone();
+
+    let post_dr_event_sig = post_dr_event.signature();
+    let inclusion_dr_event_sig = inclusion_dr_event.signature();
+    let post_tally_event_sig = post_tally_event.signature();
+
     /*
     let post_dr_filter = FilterBuilder::default()
         .from_block(0.into())
@@ -72,17 +85,6 @@ fn eth_event_stream(
         .build();
     */
 
-    info!(
-        "Subscribing to contract {:?} topic {:?}",
-        contract_address,
-        post_dr_event.signature()
-    );
-    let post_dr_filter = FilterBuilder::default()
-        //.from_block(0.into())
-        .address(vec![contract_address])
-        .topics(Some(vec![post_dr_event.signature()]), None, None, None)
-        .build();
-
     // Example call
     /*
     let call_future = contract
@@ -93,27 +95,185 @@ fn eth_event_stream(
         });
     */
 
+    info!(
+        "Subscribing to contract {:?} topic {:?}",
+        contract_address,
+        post_dr_event.signature()
+    );
+    let post_dr_filter = FilterBuilder::default()
+        .from_block(0.into())
+        .address(vec![contract_address])
+        .topics(
+            Some(vec![
+                post_dr_event_sig,
+                inclusion_dr_event_sig,
+                post_tally_event_sig,
+            ]),
+            None, //Some(vec![inclusion_dr_event.signature()]),
+            None, //Some(vec![post_tally_event.signature()]),
+            None,
+        )
+        .build();
+
     web3.eth_filter()
         .create_logs_filter(post_dr_filter)
-        .then(|filter| {
+        .map_err(|e| error!("Failed to create logs filter: {}", e))
+        .then(move |filter| {
             // TODO: for some reason, this is never executed
             let filter = filter.unwrap();
             debug!("Created filter: {:?}", filter);
             filter
                 // This poll interval was set to 0 in the example, which resulted in the
                 // bridge having 100% cpu usage...
-                .stream(time::Duration::from_secs(0))
-                .map(|value| {
-                    debug!("Got ethereum event: {:?}", value);
-                })
+                .stream(time::Duration::from_secs(1))
                 .map_err(|e| error!("ethereum event error = {:?}", e))
+                .map(move |value| {
+                    let tx3 = tx.clone();
+                    debug!("Got ethereum event: {:?}", value);
+                    let fut: Box<dyn Future<Item = (), Error = ()> + Send> = match &value.topics[0]
+                    {
+                        x if x == &post_dr_event_sig => {
+                            debug!("PostDrEvent types: {:?}", post_dr_event.inputs);
+                            let event_types = vec![ethabi::ParamType::Uint(0)];
+                            let event_data = ethabi::decode(&event_types, &value.data.0);
+                            debug!("Event data: {:?}", event_data);
+                            let dr_id = &event_data.unwrap()[0];
+                            info!("New posted data request, id: {}", dr_id);
+                            // Get data request info
+                            let dr_id = match dr_id {
+                                Token::Uint(x) => *x,
+                                _ => panic!("Wrong type"),
+                            };
+
+                            let contract = contract.clone();
+                            Box::new(
+                                contract
+                                    .query(
+                                        "read_dr",
+                                        (dr_id,),
+                                        account0,
+                                        contract::Options::default(),
+                                        None,
+                                    )
+                                    .then(move |res| {
+                                        let dr_bytes: Bytes = res.unwrap();
+                                        //let dr_string = String::from_utf8_lossy(&dr_bytes);
+                                        //debug!("{}", dr_string);
+
+                                        // Claim dr
+                                        let poe: Bytes = vec![];
+                                        info!("Claiming dr {}", dr_id);
+
+                                        contract
+                                            .call(
+                                                "claim_drs",
+                                                (vec![dr_id], poe),
+                                                account0,
+                                                contract::Options::default(),
+                                            )
+                                            .then(|tx| {
+                                                debug!("claim_drs tx: {:?}", tx);
+                                                Result::<(), ()>::Ok(())
+                                            })
+                                            .then(move |_| {
+                                                let dr_output = serde_json::from_str(
+                                                    &String::from_utf8_lossy(&dr_bytes),
+                                                )
+                                                .unwrap();
+                                                // Assuming claim is successful
+                                                // Post dr in witnet
+                                                tx3.send(ActorMessage::PostDr(dr_id, dr_output))
+                                                    .map(|_| ())
+                                                    .map_err(|_| ())
+                                            })
+                                    }),
+                            )
+                        }
+                        x if x == &inclusion_dr_event_sig => {
+                            debug!(
+                                "InclusionDataRequest types: {:?}",
+                                inclusion_dr_event.inputs
+                            );
+                            let event_types = vec![ethabi::ParamType::Uint(0)];
+                            let event_data = ethabi::decode(&event_types, &value.data.0);
+                            debug!("Event data: {:?}", event_data);
+                            let dr_id = &event_data.unwrap()[0];
+                            // Get data request info
+                            let dr_id = match dr_id {
+                                Token::Uint(x) => *x,
+                                _ => panic!("Wrong type"),
+                            };
+
+                            debug!("Reading dr_tx_hash for id {}", dr_id);
+                            Box::new(
+                                contract
+                                    .query(
+                                        "read_dr_hash",
+                                        (dr_id,),
+                                        accounts[0],
+                                        contract::Options::default(),
+                                        None,
+                                    )
+                                    .then(move |res: Result<U256, _>| {
+                                        let dr_tx_hash = res.unwrap();
+                                        let dr_tx_hash = Hash::SHA256(dr_tx_hash.into());
+                                        info!(
+                                            "New included data request, id: {} with dr_tx_hash: {}",
+                                            dr_id, dr_tx_hash
+                                        );
+                                        tx3.send(ActorMessage::WaitForTally(dr_id, dr_tx_hash))
+                                            .map(|_| ())
+                                            .map_err(|_| ())
+                                    }),
+                            )
+                        }
+                        x if x == &post_tally_event_sig => {
+                            debug!("PostResult types: {:?}", inclusion_dr_event.inputs);
+                            let event_types = vec![ethabi::ParamType::Uint(0)];
+                            let event_data = ethabi::decode(&event_types, &value.data.0);
+                            debug!("Event data: {:?}", event_data);
+                            let dr_id = &event_data.unwrap()[0];
+                            // Get data request info
+                            let dr_id = match dr_id {
+                                Token::Uint(x) => *x,
+                                _ => panic!("Wrong type"),
+                            };
+
+                            info!("Data request with id: {} has been resolved!", dr_id);
+                            Box::new(
+                                tx3.send(ActorMessage::TallyClaimed(dr_id))
+                                    .map(|_| ())
+                                    .map_err(|_| ()),
+                            )
+                        }
+                        _ => {
+                            panic!("Received unknown ethereum event");
+                        }
+                    };
+
+                    tokio::spawn(fut);
+                })
                 .for_each(|_| Ok(()))
         })
-        .map_err(|_| ())
+
+    /*
+    web3.eth_filter().create_blocks_filter().then(|filter| {
+        filter.unwrap().stream(time::Duration::from_secs(1))
+            .map_err(|e| error!("ethereum block filter error = {:?}", e))
+            .then(move |block_hash| {
+                debug!("Got ethereum block: {:?}", block_hash.unwrap());
+                web3.eth().block(BlockId::Hash(block_hash.unwrap())).map(|block| {
+                    debug!("Block contents: {:?}", block);
+                })
+            })
+            .for_each(|_| Ok(()))
+    }).map_err(|e| error!("ethereum block filter could not be created: {:?}", e))
+    */
 }
 
 fn witnet_block_stream(
     config: Arc<Config>,
+    tx: mpsc::Sender<ActorMessage>,
 ) -> (
     async_jsonrpc_client::transports::shared::EventLoopHandle,
     impl Future<Item = (), Error = ()>,
@@ -138,34 +298,16 @@ fn witnet_block_stream(
 
     let fut = witnet_client
         .subscribe(&witnet_subscription_id.into())
-        .map(|value| {
+        .map_err(|e| error!("witnet notification error = {:?}", e))
+        .then(move |value| {
+            let value = value.unwrap();
+            let tx1 = tx.clone();
             // TODO: get current epoch to distinguish between old blocks that are sent
             // to us while synchronizing and new blocks
             let block = serde_json::from_value::<Block>(value).unwrap();
             debug!("Got witnet block: {:?}", block);
-
-            for dr in &block.txns.data_request_txns {
-                let dr_inclusion_proof = dr.data_proof_of_inclusion(&block).unwrap();
-                debug!(
-                    "Proof of inclusion for data request {}:\nData: {:?}\n{:?}",
-                    dr.hash(),
-                    dr.body.dr_output.to_pb_bytes().unwrap(),
-                    dr_inclusion_proof
-                );
-            }
-
-            for tally in &block.txns.tally_txns {
-                let tally_inclusion_proof = tally.data_proof_of_inclusion(&block).unwrap();
-                let Hash::SHA256(dr_pointer_bytes) = tally.dr_pointer;
-                debug!(
-                    "Proof of inclusion for tally        {}:\nData: {:?}\n{:?}",
-                    tally.hash(),
-                    [&dr_pointer_bytes[..], &tally.tally].concat(),
-                    tally_inclusion_proof
-                );
-            }
+            tx1.send(ActorMessage::NewWitnetBlock(Box::new(block)))
         })
-        .map_err(|e| error!("witnet notification error = {:?}", e))
         .for_each(|_| Ok(()))
         .then(|_| Ok(()));
 
@@ -186,16 +328,154 @@ fn init_logger() {
         .init();
 }
 
+enum ActorMessage {
+    PostDr(U256, DataRequestOutput),
+    WaitForTally(U256, Hash),
+    TallyClaimed(U256),
+    NewWitnetBlock(Box<Block>),
+}
+
+fn main_actor(
+    config: Arc<Config>,
+    web3: &mut web3::Web3<web3::transports::Http>,
+    rx: mpsc::Receiver<ActorMessage>,
+) -> impl Future<Item = (), Error = ()> {
+    let mut claimed_drs = BiMap::new();
+    let mut waiting_for_tally = BiMap::new();
+
+    let accounts = web3.eth().accounts().wait().unwrap();
+    debug!("Web3 accounts: {:?}", accounts);
+
+    // Why read files at runtime when you can read files at compile time
+    let contract_abi_json: &[u8] = include_bytes!("../wbi_abi.json");
+    let contract_abi = ethabi::Contract::load(contract_abi_json).unwrap();
+    let contract_address = config.wbi_contract_addr;
+    let contract = Contract::new(web3.eth(), contract_address, contract_abi.clone());
+
+    let witnet_addr = config.witnet_jsonrpc_addr.to_string();
+    // Important: the handle cannot be dropped, otherwise the client stops
+    // processing events
+    let (handle, witnet_client) =
+        async_jsonrpc_client::transports::tcp::TcpSocket::new(&witnet_addr).unwrap();
+
+    rx.for_each(move |value| {
+        // Force moving handle to closure to avoid drop
+        let _ = &handle;
+        match value {
+            ActorMessage::PostDr(dr_id, dr_output) => {
+                let bdr_params = json!({"dro": dr_output, "fee": 0});
+                let bdr_res = witnet_client.execute("buildDataRequest", bdr_params).wait();
+                // TODO: this method should return the transaction hash,
+                // so we can identify the transaction later in the block
+                debug!("buildDataRequest: {:?}", bdr_res);
+                claimed_drs.insert(dr_id, dr_output.hash());
+            }
+            ActorMessage::WaitForTally(dr_id, dr_tx_hash) => {
+                claimed_drs.remove_by_left(&dr_id);
+                waiting_for_tally.insert(dr_id, dr_tx_hash);
+            }
+            ActorMessage::TallyClaimed(dr_id) => {
+                waiting_for_tally.remove_by_left(&dr_id);
+            }
+            ActorMessage::NewWitnetBlock(block) => {
+                let block_hash: U256 = match block.hash() {
+                    Hash::SHA256(x) => x.into(),
+                };
+                for dr in &block.txns.data_request_txns {
+                    if let Some((dr_id, _)) = claimed_drs.remove_by_right(&dr.body.dr_output.hash())
+                    {
+                        let dr_inclusion_proof = dr.data_proof_of_inclusion(&block).unwrap();
+                        debug!(
+                            "Proof of inclusion for data request {}:\nData: {:?}\n{:?}",
+                            dr.hash(),
+                            dr.body.dr_output.to_pb_bytes().unwrap(),
+                            dr_inclusion_proof
+                        );
+                        info!("Claimed dr got included in witnet block!");
+                        info!("Sending proof of inclusion to WBI contract");
+
+                        //let poi = dr_inclusion_proof.lemma;
+                        let poi: Bytes = vec![];
+                        // TODO: since the poi is not implemented, we have no way to get
+                        // the dr transaction hash later on, for the tally.
+                        // So we send the dr transaction hash as the block hash, which
+                        // under the current implementation of the WBI will be stored as
+                        // dr_hash
+                        let drtx_hash: U256 = match dr.hash() {
+                            Hash::SHA256(x) => x.into(),
+                        };
+                        tokio::spawn(
+                            contract
+                                .call(
+                                    "report_dr_inclusion",
+                                    (dr_id, poi, drtx_hash),
+                                    accounts[0],
+                                    contract::Options::default(),
+                                )
+                                .then(|tx| {
+                                    debug!("report_dr_inclusion tx: {:?}", tx);
+                                    Result::<(), ()>::Ok(())
+                                }),
+                        );
+                    }
+                }
+
+                for tally in &block.txns.tally_txns {
+                    if let Some((dr_id, _)) = waiting_for_tally.remove_by_right(&tally.dr_pointer) {
+                        // Call report_result method of the WBI
+                        let tally_inclusion_proof = tally.data_proof_of_inclusion(&block).unwrap();
+                        let Hash::SHA256(dr_pointer_bytes) = tally.dr_pointer;
+                        debug!(
+                            "Proof of inclusion for tally        {}:\nData: {:?}\n{:?}",
+                            tally.hash(),
+                            [&dr_pointer_bytes[..], &tally.tally].concat(),
+                            tally_inclusion_proof
+                        );
+
+                        // Call report_result
+                        //let poi = dr_inclusion_proof.lemma;
+                        let poi: Bytes = vec![];
+                        let result: Bytes = tally.tally.clone();
+                        tokio::spawn(
+                            contract
+                                .call(
+                                    "report_result",
+                                    (dr_id, poi, block_hash, result),
+                                    accounts[0],
+                                    contract::Options::default(),
+                                )
+                                .then(|tx| {
+                                    debug!("report_result tx: {:?}", tx);
+                                    Result::<(), ()>::Ok(())
+                                }),
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    })
+    .map(|_| ())
+    .map_err(|_| ())
+}
+
 fn main() {
     init_logger();
     let config = Arc::new(read_config());
     let (_eloop, web3_http) = web3::transports::Http::new(&config.eth_client_url).unwrap();
-    let web3 = web3::Web3::new(web3_http);
-    let ees = eth_event_stream(Arc::clone(&config), web3);
-    let (_handle, wbs) = witnet_block_stream(Arc::clone(&config));
+    let mut web3 = web3::Web3::new(web3_http);
+
+    let (tx1, rx) = mpsc::channel(16);
+    let tx2 = tx1.clone();
+
+    let ees = eth_event_stream(Arc::clone(&config), &mut web3, tx1);
+    let (_handle, wbs) = witnet_block_stream(Arc::clone(&config), tx2);
+    let act = main_actor(Arc::clone(&config), &mut web3, rx);
 
     tokio::run(future::ok(()).map(move |_| {
         tokio::spawn(wbs);
         tokio::spawn(ees);
+        tokio::spawn(act);
     }));
 }

--- a/bridges/ethereum/wbi_abi.json
+++ b/bridges/ethereum/wbi_abi.json
@@ -172,14 +172,14 @@
         },
         {
           "name": "_poi",
-          "type": "bytes"
+          "type": "uint256[]"
         },
         {
-          "name": "_blockHash",
+          "name": "_index",
           "type": "uint256"
         },
         {
-          "name": "_drTxHash",
+          "name": "_blockHash",
           "type": "uint256"
         }
       ],
@@ -198,7 +198,11 @@
         },
         {
           "name": "_poi",
-          "type": "bytes"
+          "type": "uint256[]"
+        },
+        {
+          "name": "_index",
+          "type": "uint256"
         },
         {
           "name": "_blockHash",

--- a/bridges/ethereum/wbi_abi.json
+++ b/bridges/ethereum/wbi_abi.json
@@ -14,11 +14,11 @@
           "type": "bytes"
         },
         {
-          "name": "inclusion_reward",
+          "name": "inclusionReward",
           "type": "uint256"
         },
         {
-          "name": "tallie_reward",
+          "name": "tallieReward",
           "type": "uint256"
         },
         {
@@ -30,17 +30,28 @@
           "type": "uint256"
         },
         {
-          "name": "dr_hash",
+          "name": "drHash",
           "type": "uint256"
         },
         {
-          "name": "pkh_claim",
+          "name": "pkhClaim",
           "type": "address"
         }
       ],
       "payable": false,
       "stateMutability": "view",
       "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "name": "_blockRelayAddress",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "constructor"
     },
     {
       "anonymous": false,
@@ -52,7 +63,7 @@
         },
         {
           "indexed": false,
-          "name": "",
+          "name": "_id",
           "type": "uint256"
         }
       ],
@@ -69,7 +80,7 @@
         },
         {
           "indexed": false,
-          "name": "id",
+          "name": "_id",
           "type": "uint256"
         }
       ],
@@ -86,7 +97,7 @@
         },
         {
           "indexed": false,
-          "name": "id",
+          "name": "_id",
           "type": "uint256"
         }
       ],
@@ -97,18 +108,18 @@
       "constant": false,
       "inputs": [
         {
-          "name": "dr",
+          "name": "_dr",
           "type": "bytes"
         },
         {
-          "name": "tallie_reward",
+          "name": "_tallieReward",
           "type": "uint256"
         }
       ],
-      "name": "post_dr",
+      "name": "postDataRequest",
       "outputs": [
         {
-          "name": "id",
+          "name": "_id",
           "type": "uint256"
         }
       ],
@@ -120,15 +131,15 @@
       "constant": false,
       "inputs": [
         {
-          "name": "id",
+          "name": "_id",
           "type": "uint256"
         },
         {
-          "name": "tallie_reward",
+          "name": "_tallieReward",
           "type": "uint256"
         }
       ],
-      "name": "upgrade_dr",
+      "name": "upgradeDataRequest",
       "outputs": [],
       "payable": true,
       "stateMutability": "payable",
@@ -138,15 +149,15 @@
       "constant": false,
       "inputs": [
         {
-          "name": "ids",
+          "name": "_ids",
           "type": "uint256[]"
         },
         {
-          "name": "PoE",
+          "name": "_poe",
           "type": "bytes"
         }
       ],
-      "name": "claim_drs",
+      "name": "claimDataRequests",
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
@@ -156,19 +167,23 @@
       "constant": false,
       "inputs": [
         {
-          "name": "id",
+          "name": "_id",
           "type": "uint256"
         },
         {
-          "name": "poi",
+          "name": "_poi",
           "type": "bytes"
         },
         {
-          "name": "block_hash",
+          "name": "_blockHash",
+          "type": "uint256"
+        },
+        {
+          "name": "_drTxHash",
           "type": "uint256"
         }
       ],
-      "name": "report_dr_inclusion",
+      "name": "reportDataRequestInclusion",
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
@@ -178,23 +193,23 @@
       "constant": false,
       "inputs": [
         {
-          "name": "id",
+          "name": "_id",
           "type": "uint256"
         },
         {
-          "name": "poi",
+          "name": "_poi",
           "type": "bytes"
         },
         {
-          "name": "block_hash",
+          "name": "_blockHash",
           "type": "uint256"
         },
         {
-          "name": "result",
+          "name": "_result",
           "type": "bytes"
         }
       ],
-      "name": "report_result",
+      "name": "reportResult",
       "outputs": [],
       "payable": false,
       "stateMutability": "nonpayable",
@@ -204,11 +219,11 @@
       "constant": true,
       "inputs": [
         {
-          "name": "id",
+          "name": "_id",
           "type": "uint256"
         }
       ],
-      "name": "read_dr",
+      "name": "readDataRequest",
       "outputs": [
         {
           "name": "",
@@ -223,11 +238,11 @@
       "constant": true,
       "inputs": [
         {
-          "name": "id",
+          "name": "_id",
           "type": "uint256"
         }
       ],
-      "name": "read_dr_hash",
+      "name": "readDrHash",
       "outputs": [
         {
           "name": "",
@@ -242,11 +257,11 @@
       "constant": true,
       "inputs": [
         {
-          "name": "id",
+          "name": "_id",
           "type": "uint256"
         }
       ],
-      "name": "read_result",
+      "name": "readResult",
       "outputs": [
         {
           "name": "",

--- a/bridges/ethereum/wbi_abi.json
+++ b/bridges/ethereum/wbi_abi.json
@@ -1,208 +1,261 @@
 [
-	{
-		"constant": false,
-		"inputs": [
-			{
-				"name": "id",
-				"type": "uint256"
-			},
-			{
-				"name": "result",
-				"type": "uint256"
-			}
-		],
-		"name": "report_result_election",
-		"outputs": [],
-		"payable": false,
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"constant": true,
-		"inputs": [
-			{
-				"name": "id",
-				"type": "uint256"
-			}
-		],
-		"name": "read_result",
-		"outputs": [
-			{
-				"name": "result",
-				"type": "bool"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"constant": true,
-		"inputs": [
-			{
-				"name": "id",
-				"type": "uint256"
-			}
-		],
-		"name": "read_dr",
-		"outputs": [
-			{
-				"name": "dr",
-				"type": "string"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"constant": true,
-		"inputs": [
-			{
-				"name": "",
-				"type": "uint256"
-			}
-		],
-		"name": "requests",
-		"outputs": [
-			{
-				"name": "script",
-				"type": "string"
-			},
-			{
-				"name": "result",
-				"type": "bool"
-			},
-			{
-				"name": "reward",
-				"type": "uint256"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"constant": true,
-		"inputs": [
-			{
-				"name": "id",
-				"type": "uint256"
-			}
-		],
-		"name": "read_result_election",
-		"outputs": [
-			{
-				"name": "result",
-				"type": "uint256"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"constant": false,
-		"inputs": [
-			{
-				"name": "id",
-				"type": "uint256"
-			},
-			{
-				"name": "result",
-				"type": "bool"
-			}
-		],
-		"name": "report_result",
-		"outputs": [],
-		"payable": false,
-		"stateMutability": "nonpayable",
-		"type": "function"
-	},
-	{
-		"constant": true,
-		"inputs": [
-			{
-				"name": "",
-				"type": "uint256"
-			}
-		],
-		"name": "election_requests",
-		"outputs": [
-			{
-				"name": "script",
-				"type": "string"
-			},
-			{
-				"name": "result",
-				"type": "uint256"
-			},
-			{
-				"name": "reward",
-				"type": "uint256"
-			}
-		],
-		"payable": false,
-		"stateMutability": "view",
-		"type": "function"
-	},
-	{
-		"constant": false,
-		"inputs": [
-			{
-				"name": "dr",
-				"type": "string"
-			}
-		],
-		"name": "post_dr",
-		"outputs": [
-			{
-				"name": "id",
-				"type": "uint256"
-			}
-		],
-		"payable": true,
-		"stateMutability": "payable",
-		"type": "function"
-	},
-	{
-		"inputs": [],
-		"payable": false,
-		"stateMutability": "nonpayable",
-		"type": "constructor"
-	},
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"name": "_from",
-				"type": "address"
-			},
-			{
-				"indexed": false,
-				"name": "id",
-				"type": "uint256"
-			}
-		],
-		"name": "PostDataRequest",
-		"type": "event"
-	},
-	{
-		"anonymous": false,
-		"inputs": [
-			{
-				"indexed": true,
-				"name": "_from",
-				"type": "address"
-			},
-			{
-				"indexed": false,
-				"name": "id",
-				"type": "uint256"
-			}
-		],
-		"name": "PostResult",
-		"type": "event"
-	}
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "requests",
+      "outputs": [
+        {
+          "name": "dr",
+          "type": "bytes"
+        },
+        {
+          "name": "inclusion_reward",
+          "type": "uint256"
+        },
+        {
+          "name": "tallie_reward",
+          "type": "uint256"
+        },
+        {
+          "name": "result",
+          "type": "bytes"
+        },
+        {
+          "name": "timestamp",
+          "type": "uint256"
+        },
+        {
+          "name": "dr_hash",
+          "type": "uint256"
+        },
+        {
+          "name": "pkh_claim",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "PostDataRequest",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "name": "InclusionDataRequest",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "name": "PostResult",
+      "type": "event"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "dr",
+          "type": "bytes"
+        },
+        {
+          "name": "tallie_reward",
+          "type": "uint256"
+        }
+      ],
+      "name": "post_dr",
+      "outputs": [
+        {
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "payable": true,
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "id",
+          "type": "uint256"
+        },
+        {
+          "name": "tallie_reward",
+          "type": "uint256"
+        }
+      ],
+      "name": "upgrade_dr",
+      "outputs": [],
+      "payable": true,
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "ids",
+          "type": "uint256[]"
+        },
+        {
+          "name": "PoE",
+          "type": "bytes"
+        }
+      ],
+      "name": "claim_drs",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "id",
+          "type": "uint256"
+        },
+        {
+          "name": "poi",
+          "type": "bytes"
+        },
+        {
+          "name": "block_hash",
+          "type": "uint256"
+        }
+      ],
+      "name": "report_dr_inclusion",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "id",
+          "type": "uint256"
+        },
+        {
+          "name": "poi",
+          "type": "bytes"
+        },
+        {
+          "name": "block_hash",
+          "type": "uint256"
+        },
+        {
+          "name": "result",
+          "type": "bytes"
+        }
+      ],
+      "name": "report_result",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "name": "read_dr",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "name": "read_dr_hash",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "name": "read_result",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    }
 ]
+

--- a/bridges/ethereum/wbi_abi.json
+++ b/bridges/ethereum/wbi_abi.json
@@ -1,0 +1,208 @@
+[
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "id",
+				"type": "uint256"
+			},
+			{
+				"name": "result",
+				"type": "uint256"
+			}
+		],
+		"name": "report_result_election",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "id",
+				"type": "uint256"
+			}
+		],
+		"name": "read_result",
+		"outputs": [
+			{
+				"name": "result",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "id",
+				"type": "uint256"
+			}
+		],
+		"name": "read_dr",
+		"outputs": [
+			{
+				"name": "dr",
+				"type": "string"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "requests",
+		"outputs": [
+			{
+				"name": "script",
+				"type": "string"
+			},
+			{
+				"name": "result",
+				"type": "bool"
+			},
+			{
+				"name": "reward",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "id",
+				"type": "uint256"
+			}
+		],
+		"name": "read_result_election",
+		"outputs": [
+			{
+				"name": "result",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "id",
+				"type": "uint256"
+			},
+			{
+				"name": "result",
+				"type": "bool"
+			}
+		],
+		"name": "report_result",
+		"outputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"name": "election_requests",
+		"outputs": [
+			{
+				"name": "script",
+				"type": "string"
+			},
+			{
+				"name": "result",
+				"type": "uint256"
+			},
+			{
+				"name": "reward",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "dr",
+				"type": "string"
+			}
+		],
+		"name": "post_dr",
+		"outputs": [
+			{
+				"name": "id",
+				"type": "uint256"
+			}
+		],
+		"payable": true,
+		"stateMutability": "payable",
+		"type": "function"
+	},
+	{
+		"inputs": [],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"name": "_from",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "id",
+				"type": "uint256"
+			}
+		],
+		"name": "PostDataRequest",
+		"type": "event"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"name": "_from",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "id",
+				"type": "uint256"
+			}
+		],
+		"name": "PostResult",
+		"type": "event"
+	}
+]

--- a/bridges/ethereum/wbi_abi.json
+++ b/bridges/ethereum/wbi_abi.json
@@ -18,7 +18,7 @@
           "type": "uint256"
         },
         {
-          "name": "tallieReward",
+          "name": "tallyReward",
           "type": "uint256"
         },
         {
@@ -67,7 +67,7 @@
           "type": "uint256"
         }
       ],
-      "name": "PostDataRequest",
+      "name": "PostedRequest",
       "type": "event"
     },
     {
@@ -84,7 +84,7 @@
           "type": "uint256"
         }
       ],
-      "name": "InclusionDataRequest",
+      "name": "IncludedRequest",
       "type": "event"
     },
     {
@@ -101,7 +101,7 @@
           "type": "uint256"
         }
       ],
-      "name": "PostResult",
+      "name": "PostedResult",
       "type": "event"
     },
     {
@@ -112,7 +112,7 @@
           "type": "bytes"
         },
         {
-          "name": "_tallieReward",
+          "name": "_tallyReward",
           "type": "uint256"
         }
       ],
@@ -135,7 +135,7 @@
           "type": "uint256"
         },
         {
-          "name": "_tallieReward",
+          "name": "_tallyReward",
           "type": "uint256"
         }
       ],
@@ -246,6 +246,25 @@
           "type": "uint256"
         }
       ],
+      "name": "readResult",
+      "outputs": [
+        {
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_id",
+          "type": "uint256"
+        }
+      ],
       "name": "readDrHash",
       "outputs": [
         {
@@ -261,19 +280,31 @@
       "constant": true,
       "inputs": [
         {
-          "name": "_id",
+          "name": "_poi",
+          "type": "uint256[]"
+        },
+        {
+          "name": "_root",
+          "type": "uint256"
+        },
+        {
+          "name": "_index",
+          "type": "uint256"
+        },
+        {
+          "name": "_element",
           "type": "uint256"
         }
       ],
-      "name": "readResult",
+      "name": "verifyPoi",
       "outputs": [
         {
           "name": "",
-          "type": "bytes"
+          "type": "bool"
         }
       ],
       "payable": false,
-      "stateMutability": "view",
+      "stateMutability": "pure",
       "type": "function"
     }
 ]

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -1,0 +1,5 @@
+witnet_jsonrpc_addr = "127.0.0.1:1234"
+eth_client_url = "http://127.0.0.1:8545"
+wbi_contract_addr = "0x1aEe6BAD4e2B3ea2dadF6753dA3d77Da79290c9b"
+eth_account = "0x1aEe6BAD4e2B3ea2dadF6753dA3d77Da79290c9b"
+

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -1,11 +1,11 @@
 # Address of the witnet node JSON-RPC server
-witnet_jsonrpc_addr = "127.0.0.1:21338"
+witnet_jsonrpc_addr = "127.0.0.1:1233"
 # Url of the ethereum client
 eth_client_url = "http://127.0.0.1:8545"
 # Address of the WitnetBridgeInterface deployed contract
-wbi_contract_addr = "0x8e19a7028D846eCc60c50e5cEdE74E5448448116"
+wbi_contract_addr = "0xc408f2534b64f641b27f17372042937762829dAe"
 # Address of the BlockRelay deployed contract
-block_relay_contract_addr = "0x1F2835b515170f2f713B26B9e480716Dbe61F75D"
+block_relay_contract_addr = "0x59053ACa5E548636F0B0e78eAf36De812f939E9d"
 # Ethereum account used to create the transactions
 eth_account = "0x33Cb9179aF22b4C0392b1E2C651e233E894E48Ff"
 # Enable block relay from witnet to ethereum?

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -1,5 +1,5 @@
 witnet_jsonrpc_addr = "127.0.0.1:1234"
 eth_client_url = "http://127.0.0.1:8545"
-wbi_contract_addr = "0x1aEe6BAD4e2B3ea2dadF6753dA3d77Da79290c9b"
+wbi_contract_addr = "0x0a9c5E6664D48aB11093ebed0C67f4Bd81a719bC"
 eth_account = "0x1aEe6BAD4e2B3ea2dadF6753dA3d77Da79290c9b"
 

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -1,5 +1,5 @@
 witnet_jsonrpc_addr = "127.0.0.1:1234"
 eth_client_url = "http://127.0.0.1:8545"
-wbi_contract_addr = "0x1aEe6BAD4e2B3ea2dadF6753dA3d77Da79290c9b"
+wbi_contract_addr = "0xEa6DD3cC3cE6690762518819698238D0a9fC5A95"
 eth_account = "0x1aEe6BAD4e2B3ea2dadF6753dA3d77Da79290c9b"
 

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -1,5 +1,6 @@
 witnet_jsonrpc_addr = "127.0.0.1:1234"
 eth_client_url = "http://127.0.0.1:8545"
-wbi_contract_addr = "0xEa6DD3cC3cE6690762518819698238D0a9fC5A95"
+wbi_contract_addr = "0x1EcABA175f7C4411D0849be9A2277121190e8cF6"
+block_relay_contract_addr = "0x88Ff8aa317ea8A34Aa5876666a304EA1D029D7c5"
 eth_account = "0x1aEe6BAD4e2B3ea2dadF6753dA3d77Da79290c9b"
 

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -1,6 +1,12 @@
+# Address of the witnet node JSON-RPC server
 witnet_jsonrpc_addr = "127.0.0.1:1234"
+# Url of the ethereum client
 eth_client_url = "http://127.0.0.1:8545"
+# Address of the WitnetBridgeInterface deployed contract
 wbi_contract_addr = "0x1EcABA175f7C4411D0849be9A2277121190e8cF6"
+# Address of the BlockRelay deployed contract
 block_relay_contract_addr = "0x88Ff8aa317ea8A34Aa5876666a304EA1D029D7c5"
+# Ethereum account used to create the transactions
 eth_account = "0x1aEe6BAD4e2B3ea2dadF6753dA3d77Da79290c9b"
-
+# Enable block relay from witnet to ethereum?
+enable_block_relay = true

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -1,12 +1,12 @@
 # Address of the witnet node JSON-RPC server
-witnet_jsonrpc_addr = "127.0.0.1:1234"
+witnet_jsonrpc_addr = "127.0.0.1:21338"
 # Url of the ethereum client
 eth_client_url = "http://127.0.0.1:8545"
 # Address of the WitnetBridgeInterface deployed contract
-wbi_contract_addr = "0x1EcABA175f7C4411D0849be9A2277121190e8cF6"
+wbi_contract_addr = "0x8e19a7028D846eCc60c50e5cEdE74E5448448116"
 # Address of the BlockRelay deployed contract
-block_relay_contract_addr = "0x88Ff8aa317ea8A34Aa5876666a304EA1D029D7c5"
+block_relay_contract_addr = "0x1F2835b515170f2f713B26B9e480716Dbe61F75D"
 # Ethereum account used to create the transactions
-eth_account = "0x1aEe6BAD4e2B3ea2dadF6753dA3d77Da79290c9b"
+eth_account = "0x33Cb9179aF22b4C0392b1E2C651e233E894E48Ff"
 # Enable block relay from witnet to ethereum?
 enable_block_relay = true

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -1,5 +1,5 @@
 witnet_jsonrpc_addr = "127.0.0.1:1234"
 eth_client_url = "http://127.0.0.1:8545"
-wbi_contract_addr = "0x0a9c5E6664D48aB11093ebed0C67f4Bd81a719bC"
+wbi_contract_addr = "0x1aEe6BAD4e2B3ea2dadF6753dA3d77Da79290c9b"
 eth_account = "0x1aEe6BAD4e2B3ea2dadF6753dA3d77Da79290c9b"
 


### PR DESCRIPTION
Until PR https://github.com/witnet/witnet-ethereum-bridge/pull/13



This PR adds a new crate "witnet-ethereum-bridge" with some basic capabilities:

Close #712 
Close #713 
Close #714 
Close #728 
Close #766 

* Subscribe to and parse witnet blocks
* Subscribe to ethereum events

Error handling is not implemented. There is a configuration file which can be used to configure server addresses, contract address and ethereum account address.

The contract abi is stored as a separate file.

Sample run:

```
$ cargo run -p witnet-ethereum-bridge
[2019-06-26T09:51:15Z DEBUG witnet_ethereum_bridge] Loading config from `witnet_ethereum_bridge.toml`
[2019-06-26T09:51:15Z DEBUG witnet_ethereum_bridge] Web3 accounts: [0xfe1b2865b74200dceabf9ddee04fdc32c2c8e3fb, 0x62640139d722f483fd735a07fbff2d299b44c415, 0xd513883712d0cb037b12acd086e8c743f062a933, 0x12cb94056c05f79efecb2478f3d20e0ae4824259, 0x16e36bba89e48fcf16d3359d6500f7186e119724, 0xdb06bab06f187ab3ddfb18763628a3b096cce125, 0xdfd0146b967c1ef8f7477a92701b8874ea021ad3, 0x47b219b18c82df9013f38cb1e4989da8176da25e, 0xaab2867138bd70991e3bb8518a2947ed7ff0daa7, 0xc36681e64e959f16171748c3c5ceb1b5780dffd5]
[2019-06-26T09:51:15Z INFO  witnet_ethereum_bridge] Subscribing to contract 0x1aee6bad4e2b3ea2dadf6753da3d77da79290c9b topic 0xcf1533ed093ea4ecd1abdb7c4aeec88ad87b26afef4c722a681c8650227b90d5
[2019-06-26T09:51:15Z INFO  witnet_ethereum_bridge] Subscribed to witnet newBlocks with subscription id "3"
[2019-06-26T09:51:15Z DEBUG witnet_ethereum_bridge] Created filter: BaseFilter { id: "0x9", transport: Http { id: 2, url: http://127.0.0.1:8545/, basic_auth: None, write_sender: UnboundedSender(Sender { inner: Inner { buffer: None, state: 9223372036854775808, message_queue: Queue { head: 0x55dfb397e010, tail: UnsafeCell }, parked_queue: Queue { head: 0x7f0118030470, tail: UnsafeCell }, num_senders: 1, recv_task: Mutex { data: ReceiverTask { unparked: false, task: Some(Task) } } }, sender_task: Mutex { data: SenderTask { task: None, is_parked: false } }, maybe_parked: false }) }, item: PhantomData }
[2019-06-26T09:51:41Z DEBUG witnet_ethereum_bridge] Got ethereum event: Log { address: 0x1aee6bad4e2b3ea2dadf6753da3d77da79290c9b, topics: [0xcf1533ed093ea4ecd1abdb7c4aeec88ad87b26afef4c722a681c8650227b90d5, 0x000000000000000000000000fe1b2865b74200dceabf9ddee04fdc32c2c8e3fb], data: Bytes([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2]), block_hash: Some(0xa7da1b9509e381c56f9305d86f668fed9476adca16dd02c0c5ff3d36a5fefe3e), block_number: Some(9), transaction_hash: Some(0x0adb0c2be6c040f5dd2aad51aa0b09b4d45a6d6a12b748592ebfb3ddad54b450), transaction_index: Some(0), log_index: Some(0), transaction_log_index: None, log_type: None, removed: None }
[2019-06-26T09:53:01Z DEBUG witnet_ethereum_bridge] Got witnet block: Block { block_header: BlockHeader { version: 0, beacon: CheckpointBeacon { checkpoint: 541235, hash_prev_block: 1693493add74aac1689dcd2485a8c3261e90ba35054fe76fb2fea78e5a382cde }, merkle_roots: BlockMerkleRoots { mint_hash: d1bfb11fc4c8546a01d448b823e2eb57d0eecef6844eadfe968d483c7f16fcbb, vt_hash_merkle_root: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, dr_hash_merkle_root: eda132c1eb3afac8d6c83c777feaf5173cff502ec6625552af4f2151d331f294, commit_hash_merkle_root: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, reveal_hash_merkle_root: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, tally_hash_merkle_root: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 }, proof: BlockEligibilityClaim { proof: VrfProof { proof: [3, 237, 172, 212, 11, 56, 35, 218, 83, 104, 67, 143, 139, 117, 250, 82, 137, 1, 114, 32, 118, 189, 108, 126, 111, 101, 136, 122, 197, 90, 89, 222, 132, 140, 4, 185, 148, 135, 44, 244, 44, 76, 86, 111, 79, 17, 37, 162, 191, 203, 144, 47, 86, 140, 204, 11, 101, 219, 26, 130, 120, 223, 104, 165, 74, 211, 110, 152, 159, 204, 195, 73, 11, 183, 61, 125, 175, 185, 195, 160, 157], public_key: PublicKey { compressed: 3, bytes: [158, 86, 59, 137, 32, 92, 60, 155, 16, 72, 31, 121, 206, 86, 91, 135, 63, 36, 240, 13, 80, 234, 254, 248, 98, 240, 51, 120, 75, 72, 199, 29] } } } }, block_sig: KeyedSignature { signature: Secp256k1(Secp256k1Signature { der: [48, 68, 2, 32, 78, 210, 117, 141, 15, 193, 113, 189, 61, 141, 110, 0, 34, 246, 140, 59, 240, 237, 102, 66, 193, 237, 13, 8, 92, 28, 51, 127, 52, 137, 247, 152, 2, 32, 64, 131, 31, 163, 191, 25, 161, 130, 179, 184, 115, 180, 167, 43, 169, 20, 128, 164, 136, 231, 86, 249, 10, 7, 125, 167, 19, 66, 125, 177, 129, 224] }), public_key: PublicKey { compressed: 3, bytes: [158, 86, 59, 137, 32, 92, 60, 155, 16, 72, 31, 121, 206, 86, 91, 135, 63, 36, 240, 13, 80, 234, 254, 248, 98, 240, 51, 120, 75, 72, 199, 29] } }, txns: BlockTransactions { mint: MintTransaction { epoch: 541235, output: ValueTransferOutput { pkh: PublicKeyHash { hash: [13, 164, 177, 9, 192, 137, 38, 5, 137, 12, 13, 134, 152, 252, 113, 253, 211, 22, 51, 241] }, value: 50000000000 }, hash: MemoHash { hash: Cell { value: None } } }, value_transfer_txns: [], data_request_txns: [DRTransaction { body: DRTransactionBody { inputs: [Input { output_pointer: 5f0215a96ee91f7f52d294b332318e48cb69bb07692da44cba51a58b60f53c91:0 }], outputs: [ValueTransferOutput { pkh: PublicKeyHash { hash: [67, 103, 66, 172, 250, 40, 99, 246, 83, 194, 251, 57, 95, 157, 209, 84, 63, 243, 158, 31] }, value: 49999998998 }], dr_output: DataRequestOutput { data_request: RADRequest { not_before: 0, retrieve: [RADRetrieve { kind: HttpGet, url: "http://qrng.anu.edu.au/API/jsonI.php?length=1&type=uint8", script: [149, 83, 204, 132, 146, 1, 164, 100, 97, 116, 97, 204, 128, 146, 1, 0] }], aggregate: RADAggregate { script: [145, 146, 102, 32] }, consensus: RADConsensus { script: [145, 146, 102, 32] }, deliver: [RADDeliver { kind: HttpGet, url: "https://hooks.zapier.com/hooks/catch/3860543/l2awcd/" }, RADDeliver { kind: HttpGet, url: "https://hooks.zapier.com/hooks/catch/3860543/l1awcw/" }] }, value: 1002, witnesses: 2, backup_witnesses: 1, commit_fee: 0, reveal_fee: 0, tally_fee: 0, time_lock: 0 }, hash: MemoHash { hash: Cell { value: None } } }, signatures: [KeyedSignature { signature: Secp256k1(Secp256k1Signature { der: [48, 69, 2, 33, 0, 154, 50, 107, 238, 181, 155, 53, 216, 185, 97, 245, 67, 94, 215, 206, 24, 74, 133, 7, 44, 14, 1, 64, 82, 176, 171, 235, 18, 208, 103, 195, 174, 2, 32, 113, 127, 12, 248, 29, 17, 182, 79, 193, 54, 69, 152, 161, 166, 131, 79, 173, 76, 223, 46, 235, 145, 157, 96, 132, 150, 254, 20, 34, 183, 25, 121] }), public_key: PublicKey { compressed: 3, bytes: [72, 74, 168, 219, 78, 21, 163, 208, 250, 222, 158, 97, 228, 147, 66, 170, 57, 229, 40, 142, 158, 3, 176, 144, 130, 143, 225, 123, 45, 63, 60, 167] } }] }], commit_txns: [], reveal_txns: [], tally_txns: [] } }
[2019-06-26T09:53:01Z DEBUG witnet_ethereum_bridge] Proof of inclusion for data request eda132c1eb3afac8d6c83c777feaf5173cff502ec6625552af4f2151d331f294:
Data: [10, 206, 1, 18, 76, 18, 56, 104, 116, 116, 112, 58, 47, 47, 113, 114, 110, 103, 46, 97, 110, 117, 46, 101, 100, 117, 46, 97, 117, 47, 65, 80, 73, 47, 106, 115, 111, 110, 73, 46, 112, 104, 112, 63, 108, 101, 110, 103, 116, 104, 61, 49, 38, 116, 121, 112, 101, 61, 117, 105, 110, 116, 56, 26, 16, 149, 83, 204, 132, 146, 1, 164, 100, 97, 116, 97, 204, 128, 146, 1, 0, 26, 6, 10, 4, 145, 146, 102, 32, 34, 6, 10, 4, 145, 146, 102, 32, 42, 54, 18, 52, 104, 116, 116, 112, 115, 58, 47, 47, 104, 111, 111, 107, 115, 46, 122, 97, 112, 105, 101, 114, 46, 99, 111, 109, 47, 104, 111, 111, 107, 115, 47, 99, 97, 116, 99, 104, 47, 51, 56, 54, 48, 53, 52, 51, 47, 108, 50, 97, 119, 99, 100, 47, 42, 54, 18, 52, 104, 116, 116, 112, 115, 58, 47, 47, 104, 111, 111, 107, 115, 46, 122, 97, 112, 105, 101, 114, 46, 99, 111, 109, 47, 104, 111, 111, 107, 115, 47, 99, 97, 116, 99, 104, 47, 51, 56, 54, 48, 53, 52, 51, 47, 108, 49, 97, 119, 99, 119, 47, 16, 234, 7, 24, 2, 32, 1]
TxInclusionProof { index: 0, lemma: [8401056693a26722bec0861042bb4374588eb6fa4893253761869e830a1e301d] }
```
---------------------------------------------------------------------------------------------------------------