### PR TITLE
Prev block hash genesis hash

### DIFF
--- a/data_structures/src/error.rs
+++ b/data_structures/src/error.rs
@@ -190,10 +190,10 @@ pub enum BlockError {
         block_epoch: Epoch,
     },
     #[fail(
-        display = "Ignoring block because previous hash (\"{}\") is unknown",
-        hash
+        display = "Ignoring block because previous hash (\"{}\") is different from our top block hash (\"{}\")",
+        block_hash, our_hash
     )]
-    PreviousHashNotKnown { hash: Hash },
+    PreviousHashMismatch { block_hash: Hash, our_hash: Hash },
     #[fail(
         display = "Block candidate's epoch differs from current epoch ({} != {})",
         block_epoch, current_epoch

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -146,7 +146,6 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                             &block_candidate,
                             current_epoch,
                             chain_info.highest_block_checkpoint,
-                            self.genesis_block_hash,
                             &self.chain_state.unspent_outputs_pool,
                             &self.chain_state.data_request_pool,
                             self.vrf_ctx.as_mut().unwrap(),

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -154,7 +154,6 @@ impl ChainManager {
                         &block,
                         current_epoch,
                         beacon,
-                        act.genesis_block_hash,
                         &act.chain_state.unspent_outputs_pool,
                         &act.chain_state.data_request_pool,
                         // The unwrap is safe because if there is no VRF context,

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -248,7 +248,6 @@ impl ChainManager {
                 block,
                 current_epoch,
                 chain_beacon,
-                self.genesis_block_hash,
                 &self.chain_state.unspent_outputs_pool,
                 &self.chain_state.data_request_pool,
                 self.vrf_ctx.as_mut().unwrap(),

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -801,8 +801,9 @@ pub fn validate_block(
             block_epoch,
         })?
     } else if chain_beacon.hash_prev_block != hash_prev_block {
-        Err(BlockError::PreviousHashNotKnown {
-            hash: hash_prev_block,
+        Err(BlockError::PreviousHashMismatch {
+            block_hash: hash_prev_block,
+            our_hash: chain_beacon.hash_prev_block,
         })?
     } else {
         let total_identities = rep_eng.ars.active_identities_number() as u32;

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -781,7 +781,6 @@ pub fn validate_block(
     block: &Block,
     current_epoch: Epoch,
     chain_beacon: CheckpointBeacon,
-    _genesis_block_hash: Hash,
     utxo_set: &UnspentOutputsPool,
     data_request_pool: &DataRequestPool,
     vrf: &mut VrfCtx,

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -781,7 +781,7 @@ pub fn validate_block(
     block: &Block,
     current_epoch: Epoch,
     chain_beacon: CheckpointBeacon,
-    genesis_block_hash: Hash,
+    _genesis_block_hash: Hash,
     utxo_set: &UnspentOutputsPool,
     data_request_pool: &DataRequestPool,
     vrf: &mut VrfCtx,
@@ -800,9 +800,7 @@ pub fn validate_block(
             chain_epoch: chain_beacon.checkpoint,
             block_epoch,
         })?
-    } else if hash_prev_block != genesis_block_hash
-        && chain_beacon.hash_prev_block != hash_prev_block
-    {
+    } else if chain_beacon.hash_prev_block != hash_prev_block {
         Err(BlockError::PreviousHashNotKnown {
             hash: hash_prev_block,
         })?

--- a/validations/tests/validations.rs
+++ b/validations/tests/validations.rs
@@ -2500,7 +2500,6 @@ fn test_block<F: FnMut(&mut Block) -> bool>(mut mut_block: F) -> Result<(), fail
         bytes: Protected::from(vec![0xcd; 32]),
     };
     let current_epoch = 1000;
-    let genesis_block_hash = Hash::default();
     let last_block_hash = LAST_BLOCK_HASH.parse().unwrap();
     let chain_beacon = CheckpointBeacon {
         checkpoint: current_epoch,
@@ -2550,7 +2549,6 @@ fn test_block<F: FnMut(&mut Block) -> bool>(mut mut_block: F) -> Result<(), fail
         &b,
         current_epoch,
         chain_beacon,
-        genesis_block_hash,
         &utxo_set,
         &dr_pool,
         vrf,
@@ -2716,7 +2714,6 @@ fn block_difficult_proof() {
         bytes: Protected::from(vec![0xcd; 32]),
     };
     let current_epoch = 1000;
-    let genesis_block_hash = Hash::default();
     let last_block_hash = LAST_BLOCK_HASH.parse().unwrap();
     let chain_beacon = CheckpointBeacon {
         checkpoint: current_epoch,
@@ -2762,7 +2759,6 @@ fn block_difficult_proof() {
                 &b,
                 current_epoch,
                 chain_beacon,
-                genesis_block_hash,
                 &utxo_set,
                 &dr_pool,
                 vrf,
@@ -2958,7 +2954,6 @@ fn test_blocks(txns: Vec<(BlockTransactions, u64)>) -> Result<(), failure::Error
         bytes: Protected::from(vec![0xcd; 32]),
     };
     let mut current_epoch = 1000;
-    let genesis_block_hash = Hash::default();
     let mut last_block_hash = LAST_BLOCK_HASH.parse().unwrap();
     let my_pkh = PublicKeyHash::default();
 
@@ -3007,7 +3002,6 @@ fn test_blocks(txns: Vec<(BlockTransactions, u64)>) -> Result<(), failure::Error
             &b,
             current_epoch,
             chain_beacon,
-            genesis_block_hash,
             &utxo_set,
             &dr_pool,
             vrf,

--- a/validations/tests/validations.rs
+++ b/validations/tests/validations.rs
@@ -2479,6 +2479,8 @@ fn block_signatures() {
 static MILLION_TX_OUTPUT: &str =
     "0f0f000000000000000000000000000000000000000000000000000000000000:0";
 
+static LAST_BLOCK_HASH: &str = "62adde3e36db3f22774cc255215b2833575f66bf2204011f80c03d34c7c9ea41";
+
 fn test_block<F: FnMut(&mut Block) -> bool>(mut mut_block: F) -> Result<(), failure::Error> {
     let dr_pool = DataRequestPool::default();
     let vrf = &mut VrfCtx::secp256k1().unwrap();
@@ -2499,9 +2501,7 @@ fn test_block<F: FnMut(&mut Block) -> bool>(mut mut_block: F) -> Result<(), fail
     };
     let current_epoch = 1000;
     let genesis_block_hash = Hash::default();
-    let last_block_hash = "62adde3e36db3f22774cc255215b2833575f66bf2204011f80c03d34c7c9ea41"
-        .parse()
-        .unwrap();
+    let last_block_hash = LAST_BLOCK_HASH.parse().unwrap();
     let chain_beacon = CheckpointBeacon {
         checkpoint: current_epoch,
         hash_prev_block: last_block_hash,
@@ -2620,6 +2620,7 @@ fn block_unknown_hash_prev_block() {
     let unknown_hash = "2222222222222222222222222222222222222222222222222222222222222222"
         .parse()
         .unwrap();
+    let last_block_hash = LAST_BLOCK_HASH.parse().unwrap();
 
     let x = test_block(|b| {
         assert_ne!(unknown_hash, b.block_header.beacon.hash_prev_block);
@@ -2638,7 +2639,10 @@ fn block_unknown_hash_prev_block() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<BlockError>().unwrap(),
-        BlockError::PreviousHashNotKnown { hash: unknown_hash },
+        BlockError::PreviousHashMismatch {
+            block_hash: unknown_hash,
+            our_hash: last_block_hash,
+        },
     );
 }
 
@@ -2681,9 +2685,7 @@ fn block_difficult_proof() {
     };
     let current_epoch = 1000;
     let genesis_block_hash = Hash::default();
-    let last_block_hash = "62adde3e36db3f22774cc255215b2833575f66bf2204011f80c03d34c7c9ea41"
-        .parse()
-        .unwrap();
+    let last_block_hash = LAST_BLOCK_HASH.parse().unwrap();
     let chain_beacon = CheckpointBeacon {
         checkpoint: current_epoch,
         hash_prev_block: last_block_hash,
@@ -2925,9 +2927,7 @@ fn test_blocks(txns: Vec<(BlockTransactions, u64)>) -> Result<(), failure::Error
     };
     let mut current_epoch = 1000;
     let genesis_block_hash = Hash::default();
-    let mut last_block_hash = "62adde3e36db3f22774cc255215b2833575f66bf2204011f80c03d34c7c9ea41"
-        .parse()
-        .unwrap();
+    let mut last_block_hash = LAST_BLOCK_HASH.parse().unwrap();
     let my_pkh = PublicKeyHash::default();
 
     for (mut txns, fees) in txns {


### PR DESCRIPTION
Close #797

There was a mistake in the validation code which always accepted blocks whose `prev_block_hash` was the `genesis_block_hash`.