### PR TITLE
getBalance and getPkh methods

### DIFF
--- a/docs/interface/json-rpc.md
+++ b/docs/interface/json-rpc.md
@@ -70,6 +70,24 @@ Response:
 {"jsonrpc":"2.0","result":true,"id":1}
 ```
 
+#### getBalance
+Get the total balance of the given public key hash.
+
+Returns a `u64`, representing balance. The unit is 10^-8 wits.
+
+Example:
+
+```
+{"jsonrpc":"2.0","id":1,"method":"getBalance","params":["2dbf2cefcf626d661a8cb1797be92624ca1835f7"]}
+```
+
+Response:
+
+```
+{"jsonrpc":"2.0","result":428150000000000,"id":1}
+```
+
+
 #### getBlockChain
 
 Get the list of all the known block hashes.
@@ -142,6 +160,23 @@ Response:
 
 ```
 {"jsonrpc":"2.0","result":{"DataRequest":{"backup_witnesses":0,"commit_fee":0,"data_request":{"aggregate":{"script":[0]},"consensus":{"script":[0]},"deliver":[{"kind":"HTTP-GET","url":"https://hooks.zapier.com/hooks/catch/3860543/l2awcd/"}],"not_before":0,"retrieve":[{"kind":"HTTP-GET","script":[0],"url":"https://openweathermap.org/data/2.5/weather?id=2950159&appid=b6907d289e10d714a6e88b30761fae22"}]},"pkh":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"reveal_fee":0,"tally_fee":0,"time_lock":0,"value":0,"witnesses":0}},"id":"1"}
+```
+
+#### getPkh
+Get the public key hash of the node. This pkh is used for mining blocks and resolving data requests.
+
+Returns a `PublicKeyHash`.
+
+Example:
+
+```
+{"jsonrpc":"2.0","id":1,"method":"getPkh"}
+```
+
+Response:
+
+```
+{"jsonrpc":"2.0","result":"121747ea4a2103b38b7213ac6d67e949add96cfb","id":1}
 ```
 
 #### sendRequest

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -17,7 +17,7 @@ use witnet_validations::validations::{
 };
 
 use super::{ChainManager, ChainManagerError, StateMachine};
-use crate::actors::messages::GetDataRequestReport;
+use crate::actors::messages::{GetBalance, GetDataRequestReport};
 use crate::{
     actors::{
         chain_manager::transaction_factory,
@@ -833,5 +833,20 @@ impl Handler<GetDataRequestReport> for ChainManager {
 
             Box::new(fut)
         }
+    }
+}
+
+impl Handler<GetBalance> for ChainManager {
+    type Result = Result<u64, failure::Error>;
+
+    fn handle(&mut self, GetBalance { pkh }: GetBalance, _ctx: &mut Self::Context) -> Self::Result {
+        if self.sm_state != StateMachine::Synced {
+            return Err(ChainManagerError::NotSynced.into());
+        }
+
+        Ok(transaction_factory::get_total_balance(
+            &self.chain_state.unspent_outputs_pool,
+            pkh,
+        ))
     }
 }

--- a/node/src/actors/chain_manager/transaction_factory.rs
+++ b/node/src/actors/chain_manager/transaction_factory.rs
@@ -54,6 +54,21 @@ pub fn take_enough_utxos<S: std::hash::BuildHasher>(
     }
 }
 
+/// Get total balance
+pub fn get_total_balance(all_utxos: &UnspentOutputsPool, pkh: PublicKeyHash) -> u64 {
+    // FIXME: this does not scale, we need to be able to get UTXOs by PKH
+    all_utxos
+        .iter()
+        .filter_map(|(_output_pointer, vto)| {
+            if vto.pkh == pkh {
+                Some(vto.value)
+            } else {
+                None
+            }
+        })
+        .sum()
+}
+
 /// If the change_amount is greater than 0, insert a change output using the supplied `pkh`.
 pub fn insert_change_output(
     outputs: &mut Vec<ValueTransferOutput>,

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -58,6 +58,7 @@ pub fn jsonrpc_io_handler(subscriptions: Subscriptions) -> PubSubHandler<Arc<Ses
     io.add_method("sendValue", |params: Params| send_value(params.parse()));
     io.add_method("status", |_params: Params| status());
     io.add_method("getPublicKey", |_params: Params| get_public_key());
+    io.add_method("getPkh", |_params: Params| get_pkh());
     io.add_method("sign", |params: Params| sign_data(params.parse()));
     io.add_method("createVRF", |params: Params| create_vrf(params.parse()));
     io.add_method("dataRequestReport", |params: Params| {
@@ -558,6 +559,15 @@ pub fn get_public_key() -> JsonRpcResultAsync {
             log::debug!("{:?}", pk);
             pk.to_bytes().to_vec().into()
         });
+
+    Box::new(fut)
+}
+
+/// Get public key hash
+pub fn get_pkh() -> JsonRpcResultAsync {
+    let fut = signature_mngr::pkh()
+        .map_err(internal_error)
+        .map(|pkh| Value::String(pkh.to_string()));
 
     Box::new(fut)
 }

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -13,7 +13,7 @@ use tokio::net::TcpStream;
 use witnet_data_structures::{
     chain::{
         Block, CheckpointBeacon, DataRequestInfo, DataRequestOutput, Epoch, Hash, InventoryEntry,
-        InventoryItem, RADConsensus, RADRequest, ValueTransferOutput,
+        InventoryItem, PublicKeyHash, RADConsensus, RADRequest, ValueTransferOutput,
     },
     transaction::Transaction,
 };
@@ -184,6 +184,17 @@ pub struct GetDataRequestReport {
 
 impl Message for GetDataRequestReport {
     type Result = Result<DataRequestInfo, failure::Error>;
+}
+
+/// Get Balance
+#[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct GetBalance {
+    /// Public key hash
+    pub pkh: PublicKeyHash,
+}
+
+impl Message for GetBalance {
+    type Result = Result<u64, failure::Error>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -53,6 +53,21 @@ pub fn get_blockchain(addr: SocketAddr, epoch: u32, limit: u32) -> Result<(), fa
     Ok(())
 }
 
+pub fn get_balance(addr: SocketAddr, pkh: PublicKeyHash) -> Result<(), failure::Error> {
+    let mut stream = start_client(addr)?;
+    let request = format!(
+        r#"{{"jsonrpc": "2.0","method": "getBalance", "params": [{}], "id": "1"}}"#,
+        serde_json::to_string(&pkh)?,
+    );
+    let response = send_request(&mut stream, &request)?;
+    log::info!("{}", response);
+    let amount = parse_response::<u64>(&response)?;
+
+    println!("{}", amount);
+
+    Ok(())
+}
+
 pub fn get_block(addr: SocketAddr, hash: String) -> Result<(), failure::Error> {
     let mut stream = start_client(addr)?;
     let request = format!(

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -17,6 +17,9 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
         Command::BlockChain { node, epoch, limit } => {
             rpc::get_blockchain(node.unwrap_or(config.jsonrpc.server_address), epoch, limit)
         }
+        Command::GetBalance { node, pkh } => {
+            rpc::get_balance(node.unwrap_or(config.jsonrpc.server_address), pkh)
+        }
         Command::Output { node, pointer } => {
             rpc::get_output(node.unwrap_or(config.jsonrpc.server_address), pointer)
         }
@@ -99,6 +102,15 @@ pub enum Command {
         #[structopt(name = "hash", help = "SHA-256 block hash in hex format")]
         hash: String,
     },
+    #[structopt(name = "getBalance", about = "Get total balance of the node")]
+    GetBalance {
+        /// Socket address of the Witnet node to query.
+        #[structopt(short = "n", long = "node")]
+        node: Option<SocketAddr>,
+        /// Public key hash for which to get balance
+        #[structopt(long = "pkh")]
+        pkh: PublicKeyHash,
+    },
     #[structopt(name = "output", about = "Find an output of a transaction ")]
     Output {
         /// Socket address of the Witnet node to query.
@@ -115,7 +127,7 @@ pub enum Command {
         /// Socket address of the Witnet node to query.
         #[structopt(short = "n", long = "node")]
         node: Option<SocketAddr>,
-        /// Pkh of the destination
+        /// Public key hash of the destination
         #[structopt(long = "pkh")]
         pkh: PublicKeyHash,
         /// Value

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -20,6 +20,7 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
         Command::GetBalance { node, pkh } => {
             rpc::get_balance(node.unwrap_or(config.jsonrpc.server_address), pkh)
         }
+        Command::GetPkh { node } => rpc::get_pkh(node.unwrap_or(config.jsonrpc.server_address)),
         Command::Output { node, pointer } => {
             rpc::get_output(node.unwrap_or(config.jsonrpc.server_address), pointer)
         }
@@ -107,9 +108,15 @@ pub enum Command {
         /// Socket address of the Witnet node to query.
         #[structopt(short = "n", long = "node")]
         node: Option<SocketAddr>,
-        /// Public key hash for which to get balance
+        /// Public key hash for which to get balance. If omitted, defaults to the node pkh.
         #[structopt(long = "pkh")]
-        pkh: PublicKeyHash,
+        pkh: Option<PublicKeyHash>,
+    },
+    #[structopt(name = "getPkh", about = "Get the public key hash of the node")]
+    GetPkh {
+        /// Socket address of the Witnet node to query.
+        #[structopt(short = "n", long = "node")]
+        node: Option<SocketAddr>,
     },
     #[structopt(name = "output", about = "Find an output of a transaction ")]
     Output {


### PR DESCRIPTION
Add JSON-RPC and CLI methods to getBalance and getPkh. Usage:

```
witnet node getPkh
witnet node getBalance --pkh=2dbf2cefcf626d661a8cb1797be92624ca1835f7
```

Calling getBalance with no pkh will default to the node pkh.