### PR TITLE
Fix another non-deterministic test

### DIFF
--- a/storage/src/backends/crypto.rs
+++ b/storage/src/backends/crypto.rs
@@ -100,6 +100,9 @@ mod tests {
 
         let backend2 = Backend::new(password2, backend1.inner().clone());
 
-        assert!(backend2.get(b"name").is_err());
+        assert_ne!(
+            backend2.get(b"name").unwrap_or(None),
+            Some(b"johnny".to_vec())
+        );
     }
 }


### PR DESCRIPTION
This test sometimes failed because there is a small probability that AES
decrypts to a valid value. Now we check that it decrypts to the same
value as we encrypted. There is also a small probability that this test
will fail, but it should never happen in practice.