### PR TITLE
Improve peering process

### DIFF
--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -420,10 +420,13 @@ impl Message for RemovePeers {
 }
 
 /// Message to get a (random) peer address from the list
-pub struct GetRandomPeer;
+pub struct GetRandomPeers {
+    /// Number of random peers
+    pub n: usize,
+}
 
-impl Message for GetRandomPeer {
-    type Result = PeersSocketAddrResult;
+impl Message for GetRandomPeers {
+    type Result = PeersSocketAddrsResult;
 }
 
 /// Message to get all the peer addresses from the list

--- a/node/src/actors/peers_manager/handlers.rs
+++ b/node/src/actors/peers_manager/handlers.rs
@@ -3,7 +3,7 @@ use log;
 
 use super::PeersManager;
 use crate::actors::messages::{
-    AddConsolidatedPeer, AddPeers, GetRandomPeer, PeersSocketAddrResult, PeersSocketAddrsResult,
+    AddConsolidatedPeer, AddPeers, GetRandomPeers, PeersSocketAddrResult, PeersSocketAddrsResult,
     RemovePeers, RequestPeers,
 };
 use witnet_util::timestamp::get_timestamp;
@@ -54,20 +54,16 @@ impl Handler<RemovePeers> for PeersManager {
 }
 
 /// Handler for GetRandomPeer message
-impl Handler<GetRandomPeer> for PeersManager {
-    type Result = PeersSocketAddrResult;
+impl Handler<GetRandomPeers> for PeersManager {
+    type Result = PeersSocketAddrsResult;
 
-    fn handle(&mut self, _msg: GetRandomPeer, _: &mut Context<Self>) -> Self::Result {
-        let result = self.peers.get_random();
+    fn handle(&mut self, msg: GetRandomPeers, _: &mut Context<Self>) -> Self::Result {
+        let result = self.peers.get_random_peers(msg.n);
 
         match result {
-            Ok(Some(address)) => {
-                log::debug!("Selected a random peer address: {:?}", address);
-                result
-            }
-            Ok(None) => {
-                log::warn!("Could not select a random peer address because there were none");
-                result
+            Ok(peers) => {
+                log::debug!("Selected random peer addresses: {:?}", peers);
+                Ok(peers)
             }
             error => {
                 log::error!("Error selecting a random peer address: {:?}", error);

--- a/node/src/actors/peers_manager/mod.rs
+++ b/node/src/actors/peers_manager/mod.rs
@@ -116,7 +116,7 @@ impl PeersManager {
     pub fn feeler(&mut self, ctx: &mut Context<Self>, feeler_peers_period: Duration) {
         // Schedule the discovery_peers with a given period
         ctx.run_later(feeler_peers_period, move |act, ctx| {
-            if let Some((key, peer)) = act.peers.get_new_random() {
+            if let Some((key, peer)) = act.peers.get_new_random_peer() {
                 act.peers.remove_from_new_with_index(&[key]);
                 act.try_peer(ctx, peer);
             }

--- a/node/src/actors/sessions_manager/handlers.rs
+++ b/node/src/actors/sessions_manager/handlers.rs
@@ -7,7 +7,8 @@ use actix::{
     io::FramedWrite, Actor, ActorFuture, Context, ContextFutureSpawner, Handler, Message,
     StreamHandler, System, WrapFuture,
 };
-use log::{debug, error, warn};
+use ansi_term::Color::Cyan;
+use log::{debug, error, info, trace, warn};
 use tokio::{codec::FramedRead, io::AsyncRead};
 
 use super::SessionsManager;
@@ -254,6 +255,16 @@ impl Handler<EpochNotification<()>> for SessionsManager {
         // been executed. We could avoid this by only clearing beacons from past epochs, and
         // accepting beacons for future epochs, but that would add complexity.
         self.clear_beacons();
+
+        info!(
+            "{} Inbound: {} | Outbound: {}",
+            Cyan.bold().paint("[Sessions]"),
+            Cyan.bold()
+                .paint(self.sessions.get_num_inbound_sessions().to_string()),
+            Cyan.bold()
+                .paint(self.sessions.get_num_outbound_sessions().to_string())
+        );
+        trace!("{:#?}", self.sessions.show_ips());
     }
 }
 

--- a/node/src/actors/sessions_manager/mod.rs
+++ b/node/src/actors/sessions_manager/mod.rs
@@ -60,7 +60,9 @@ impl SessionsManager {
                 peers_manager_addr
                     // Send GetPeer message to peers manager actor
                     // This returns a Request Future, representing an asynchronous message sending process
-                    .send(GetRandomPeers { n: 1 })
+                    .send(GetRandomPeers {
+                        n: act.sessions.num_missing_outbound(),
+                    })
                     // Convert a normal future into an ActorFuture
                     .into_actor(act)
                     // Process the response from the peers manager

--- a/node/src/actors/sessions_manager/mod.rs
+++ b/node/src/actors/sessions_manager/mod.rs
@@ -41,18 +41,18 @@ impl SessionsManager {
     fn bootstrap_peers(&self, ctx: &mut Context<Self>, bootstrap_peers_period: Duration) {
         // Schedule the bootstrap with a given period
         ctx.run_later(bootstrap_peers_period, move |act, ctx| {
-            info!(
-                "{} Inbound: {} | Outbound: {}",
-                Cyan.bold().paint("[Sessions]"),
-                Cyan.bold()
-                    .paint(act.sessions.get_num_inbound_sessions().to_string()),
-                Cyan.bold()
-                    .paint(act.sessions.get_num_outbound_sessions().to_string())
-            );
-            trace!("{:#?}", act.sessions.show_ips());
-
             // Check if bootstrap is needed
             if act.sessions.is_outbound_bootstrap_needed() {
+                info!(
+                    "{} Inbound: {} | Outbound: {}",
+                    Cyan.bold().paint("[Sessions]"),
+                    Cyan.bold()
+                        .paint(act.sessions.get_num_inbound_sessions().to_string()),
+                    Cyan.bold()
+                        .paint(act.sessions.get_num_outbound_sessions().to_string())
+                );
+                trace!("{:#?}", act.sessions.show_ips());
+
                 // Get peers manager address
                 let peers_manager_addr = System::current().registry().get::<PeersManager>();
 

--- a/p2p/src/sessions/mod.rs
+++ b/p2p/src/sessions/mod.rs
@@ -166,6 +166,15 @@ where
             .map(|limit| num_outbound_sessions < limit as usize)
             .unwrap_or(true)
     }
+    /// Method to return the diff between limit and outbounds number
+    pub fn num_missing_outbound(&self) -> usize {
+        let num_outbound_sessions = self.get_num_outbound_sessions();
+
+        self.outbound_consolidated
+            .limit
+            .map(|limit| limit as usize - num_outbound_sessions)
+            .unwrap_or(1)
+    }
     /// Method to get a random consolidated outbound session
     pub fn get_random_anycast_session(&self, safu: bool) -> Option<T> {
         // Get iterator over the values of the hashmap

--- a/p2p/tests/peers.rs
+++ b/p2p/tests/peers.rs
@@ -24,10 +24,10 @@ fn p2p_peers_add_to_new() {
     );
 
     // Get a random address (there is only 1)
-    let result = peers.get_random();
+    let result = peers.get_random_peers(1);
 
     // Check that both addresses are the same
-    assert_eq!(result.unwrap(), Some(address));
+    assert_eq!(result.unwrap(), vec![address]);
 
     // There is only 1 address
     assert_eq!(peers.get_all_from_new().unwrap(), vec![address]);
@@ -46,13 +46,38 @@ fn p2p_peers_add_to_tried() {
     assert_eq!(peers.add_to_tried(address).unwrap(), Some(address));
 
     // Get a random address (there is only 1)
-    let result = peers.get_random().unwrap();
+    let result = peers.get_random_peers(1);
 
     // Check that both addresses are the same
-    assert_eq!(result, Some(address));
+    assert_eq!(result.unwrap(), vec![address]);
 
     // There is only 1 address
     assert_eq!(peers.get_all_from_tried().unwrap(), vec![address]);
+}
+
+#[test]
+fn p2p_peers_random() {
+    // Create peers struct
+    let mut peers = Peers::default();
+    let server = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 2, 20)), 8080);
+    peers.set_server(server);
+
+    // Add addresses
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    let src_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 8080);
+    let address2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)), 8080);
+
+    peers.add_to_new(vec![address], src_address).unwrap();
+    peers.add_to_tried(address2).unwrap();
+
+    // Get 2 random address (there is only 2)
+    let result = peers.get_random_peers(2);
+
+    // Check that both addresses are the same
+    assert_eq!(result.unwrap(), vec![address, address2]);
+
+    assert_eq!(peers.get_all_from_new().unwrap(), vec![address]);
+    assert_eq!(peers.get_all_from_tried().unwrap(), vec![address2]);
 }
 
 #[test]
@@ -68,10 +93,10 @@ fn p2p_peers_remove_from_tried() {
     assert_eq!(peers.remove_from_tried(&[address]), vec![address]);
 
     // Get a random address
-    let result = peers.get_random();
+    let result = peers.get_random_peers(1);
 
     // Check that both addresses are the same
-    assert_eq!(result.unwrap(), None);
+    assert_eq!(result.unwrap(), vec![]);
 
     // Remove the same address twice doesn't panic
     assert_eq!(peers.remove_from_tried(&[address, address]), vec![]);
@@ -95,10 +120,10 @@ fn p2p_peers_remove_from_new_with_index() {
     assert_eq!(peers.remove_from_new_with_index(&[index]), vec![address]);
 
     // Get a random address
-    let result = peers.get_random();
+    let result = peers.get_random_peers(1);
 
     // Check that both addresses are the same
-    assert_eq!(result.unwrap(), None);
+    assert_eq!(result.unwrap(), vec![]);
 
     // Remove the same address twice doesn't panic
     assert_eq!(peers.remove_from_new_with_index(&[index]), vec![]);

--- a/witnet.toml
+++ b/witnet.toml
@@ -4,7 +4,7 @@
 server_addr = "0.0.0.0:21337"
 known_peers = ["52.166.178.145:21337"]
 outbound_limit = 1
-bootstrap_peers_period_seconds = 15
+bootstrap_peers_period_seconds = 1
 
 [storage]
 db_path = ".witnet-rust-testnet-4"


### PR DESCRIPTION
Reduced bootstrap periods
Create get_outbound_diff method to obtain the number of peers required to conform a consensus group
Modify GetRandom method to GetRandomPeers to obtain a group of random peers

Close #813 