### PR TITLE
Refactor validations crate

### DIFF
--- a/data_structures/src/error.rs
+++ b/data_structures/src/error.rs
@@ -29,6 +29,8 @@ pub enum BuildersError {
 pub enum TransactionError {
     #[fail(display = "The transaction is invalid")]
     NotValidTransaction,
+    #[fail(display = "Sum of fees overflows")]
+    FeeOverflow,
     /// The transaction creates value
     #[fail(display = "Transaction creates value (its fee is negative)")]
     NegativeFee,
@@ -58,13 +60,10 @@ pub enum TransactionError {
         change, expected_change
     )]
     InvalidTallyChange { change: u64, expected_change: u64 },
-    #[fail(display = "Invalid Data Request reward: {}", reward)]
-    InvalidDataRequestReward { reward: i64 },
-    #[fail(
-        display = "Invalid Data Request reward ({}) for this number of witnesses ({})",
-        dr_value, witnesses
-    )]
-    InvalidDataRequestValue { dr_value: u64, witnesses: u16 },
+    #[fail(display = "The fees of the data request is greater that its value")]
+    NoReward,
+    #[fail(display = "The reward is not the same for each witness")]
+    NonUniformReward,
     #[fail(display = "Data Request witnesses number is not enough")]
     InsufficientWitnesses,
     #[fail(

--- a/data_structures/src/error.rs
+++ b/data_structures/src/error.rs
@@ -60,10 +60,16 @@ pub enum TransactionError {
         change, expected_change
     )]
     InvalidTallyChange { change: u64, expected_change: u64 },
-    #[fail(display = "The fees of the data request is greater that its value")]
-    NoReward,
-    #[fail(display = "The reward is not the same for each witness")]
-    NonUniformReward,
+    #[fail(
+        display = "The value of a data request {} must be greater than its fees: {}",
+        value, fees
+    )]
+    NoReward { value: u64, fees: u64 },
+    #[fail(
+        display = "The reward is not the same for each witness. Reward: {}. Witnesses: {}",
+        reward, witnesses
+    )]
+    NonUniformReward { reward: u64, witnesses: u16 },
     #[fail(display = "Data Request witnesses number is not enough")]
     InsufficientWitnesses,
     #[fail(

--- a/validations/src/lib.rs
+++ b/validations/src/lib.rs
@@ -7,9 +7,4 @@
 pub mod validations;
 
 #[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+mod tests;

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -12,7 +12,8 @@ use witnet_data_structures::{
 };
 use witnet_protected::Protected;
 use witnet_rad::error::RadError;
-use witnet_validations::validations::*;
+
+use crate::validations::*;
 
 static MY_PKH: &str = "3e13996ed18be842d9d4303b428dd30c85db8e9e";
 static MY_PKH_2: &str = "11f66b6ff5ed1ed21200c0a01f22540cd828ca1f";

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -923,7 +923,7 @@ fn data_request_no_value() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NoReward,
+        TransactionError::NoReward { value: 0, fees: 0 },
     );
 }
 
@@ -940,7 +940,10 @@ fn data_request_odd_value() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NonUniformReward
+        TransactionError::NonUniformReward {
+            witnesses: 2,
+            reward: 999
+        }
     );
 }
 
@@ -958,7 +961,10 @@ fn data_request_odd_commit_value() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NonUniformReward
+        TransactionError::NonUniformReward {
+            witnesses: 2,
+            reward: 99
+        }
     );
 }
 
@@ -976,7 +982,10 @@ fn data_request_odd_reveal_value() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NonUniformReward
+        TransactionError::NonUniformReward {
+            witnesses: 2,
+            reward: 99
+        }
     );
 }
 
@@ -994,7 +1003,10 @@ fn data_request_odd_tally_value() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NonUniformReward
+        TransactionError::NonUniformReward {
+            witnesses: 2,
+            reward: 99
+        }
     );
 }
 
@@ -1013,7 +1025,10 @@ fn data_request_invalid_value_commit_fee() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NoReward,
+        TransactionError::NoReward {
+            value: 1000,
+            fees: 1000
+        },
     );
 }
 
@@ -1032,7 +1047,10 @@ fn data_request_invalid_value_reveal_fee() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NoReward,
+        TransactionError::NoReward {
+            value: 1000,
+            fees: 1000
+        },
     );
 }
 
@@ -1051,7 +1069,10 @@ fn data_request_invalid_value_tally_fee() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NoReward,
+        TransactionError::NoReward {
+            value: 1000,
+            fees: 1000
+        },
     );
 }
 
@@ -1070,7 +1091,10 @@ fn data_request_invalid_all_fees() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NoReward,
+        TransactionError::NoReward {
+            value: 1000,
+            fees: 1000
+        },
     );
 }
 
@@ -1089,7 +1113,10 @@ fn data_request_negative_value_commit_fee() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NoReward,
+        TransactionError::NoReward {
+            value: 1000,
+            fees: 1001
+        },
     );
 }
 
@@ -1108,7 +1135,10 @@ fn data_request_negative_value_reveal_fee() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NoReward,
+        TransactionError::NoReward {
+            value: 1000,
+            fees: 1001
+        },
     );
 }
 
@@ -1127,7 +1157,10 @@ fn data_request_negative_value_tally_fee() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NoReward,
+        TransactionError::NoReward {
+            value: 1000,
+            fees: 1001
+        },
     );
 }
 
@@ -1146,7 +1179,10 @@ fn data_request_negative_all_fees() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::NoReward,
+        TransactionError::NoReward {
+            value: 1000,
+            fees: 1004
+        },
     );
 }
 

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -255,12 +255,18 @@ pub fn validate_data_request_output(request: &DataRequestOutput) -> Result<(), T
 
     // Calculate reward to be shared between all the witnesses, which must be greater than 0
     if request.value <= sum_fees {
-        Err(TransactionError::NoReward)?
+        Err(TransactionError::NoReward {
+            value: request.value,
+            fees: sum_fees,
+        })?
     }
     let total_witness_reward = request.value - sum_fees;
     // Must be divisible by the number of witnesses
     if (total_witness_reward % u64::from(request.witnesses)) != 0 {
-        Err(TransactionError::NonUniformReward)?
+        Err(TransactionError::NonUniformReward {
+            reward: total_witness_reward,
+            witnesses: request.witnesses,
+        })?
     }
 
     Ok(())

--- a/validations/tests/validations.rs
+++ b/validations/tests/validations.rs
@@ -922,7 +922,7 @@ fn data_request_no_value() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestReward { reward: 0 },
+        TransactionError::NoReward,
     );
 }
 
@@ -939,10 +939,7 @@ fn data_request_odd_value() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestValue {
-            dr_value: 999,
-            witnesses: 2,
-        }
+        TransactionError::NonUniformReward
     );
 }
 
@@ -960,10 +957,7 @@ fn data_request_odd_commit_value() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestValue {
-            dr_value: 99,
-            witnesses: 2,
-        }
+        TransactionError::NonUniformReward
     );
 }
 
@@ -981,10 +975,7 @@ fn data_request_odd_reveal_value() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestValue {
-            dr_value: 99,
-            witnesses: 2,
-        }
+        TransactionError::NonUniformReward
     );
 }
 
@@ -1002,10 +993,7 @@ fn data_request_odd_tally_value() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestValue {
-            dr_value: 99,
-            witnesses: 2,
-        }
+        TransactionError::NonUniformReward
     );
 }
 
@@ -1024,7 +1012,7 @@ fn data_request_invalid_value_commit_fee() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestReward { reward: 0 },
+        TransactionError::NoReward,
     );
 }
 
@@ -1043,7 +1031,7 @@ fn data_request_invalid_value_reveal_fee() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestReward { reward: 0 },
+        TransactionError::NoReward,
     );
 }
 
@@ -1062,7 +1050,7 @@ fn data_request_invalid_value_tally_fee() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestReward { reward: 0 },
+        TransactionError::NoReward,
     );
 }
 
@@ -1081,7 +1069,7 @@ fn data_request_invalid_all_fees() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestReward { reward: 0 },
+        TransactionError::NoReward,
     );
 }
 
@@ -1100,7 +1088,7 @@ fn data_request_negative_value_commit_fee() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestReward { reward: -1 },
+        TransactionError::NoReward,
     );
 }
 
@@ -1119,7 +1107,7 @@ fn data_request_negative_value_reveal_fee() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestReward { reward: -1 },
+        TransactionError::NoReward,
     );
 }
 
@@ -1138,7 +1126,7 @@ fn data_request_negative_value_tally_fee() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestReward { reward: -1 },
+        TransactionError::NoReward,
     );
 }
 
@@ -1157,7 +1145,7 @@ fn data_request_negative_all_fees() {
     });
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
-        TransactionError::InvalidDataRequestReward { reward: -4 },
+        TransactionError::NoReward,
     );
 }
 


### PR DESCRIPTION
## What

1. Create new function `validate_data_request_output` which is used by the wallet
2. Add more descriptive errors: `NoReward` (*The fees of the data request is greater that its value*) and `NonUniformReward` (*The reward is not the same for each witness*)
3. Move tests inside the crate since they are unit and not integration tests.