### PR TITLE
chore: remove parallel jobs restriction

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,7 +4,6 @@ email = "info@witnet.foundation"
 vcs = "none"
 
 [build]
-jobs = 1
 rustc = "rustc"
 rustdoc = "rustdoc"
 target-dir = "target"


### PR DESCRIPTION
The default number of parallel jobs by default is the # of CPUs. Currently, we have `jobs` restricted to 1