### PR TITLE
Add send-request command to node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,11 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "hex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "hmac"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3291,6 +3296,7 @@ dependencies = [
  "directories 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3302,6 +3308,8 @@ dependencies = [
  "witnet_config 0.3.2",
  "witnet_data_structures 0.3.2",
  "witnet_node 0.4.0",
+ "witnet_rad 0.3.2",
+ "witnet_validations 0.3.2",
  "witnet_wallet 0.3.2",
 ]
 
@@ -3684,6 +3692,7 @@ dependencies = [
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+"checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 "checksum hmac-sha256 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ca99047b65c78ab7e092993f7f0faf7c5cd2a71a12a6f1ae70f8ae1001138e62"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ directories = "*"
 ctrlc = "3.1.1"
 env_logger = "0.6.0"
 failure = "0.1.5"
+hex = "0.4.0"
 itertools = "0.8.0"
 log = "0.4.6"
 serde_json = "1.0.39"
@@ -39,6 +40,8 @@ witnet_wallet = { path = "./wallet", optional = true }
 witnet_node = { path = "./node", optional = true }
 witnet_config = { path = "./config" }
 witnet_data_structures = { path = "./data_structures" }
+witnet_rad = { path = "./rad" }
+witnet_validations = { path = "./validations" }
 
 [dependencies.serde]
 features = ["derive"]

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -448,12 +448,12 @@ pub struct ResolveRA {
     pub rad_request: RADRequest,
 }
 
-/// Message for running the consensus step of a data request.
+/// Message for running the tally step of a data request.
 #[derive(Debug)]
-pub struct RunConsensus {
-    /// RAD consensus to be executed
+pub struct RunTally {
+    /// RAD tally to be executed
     pub script: RADTally,
-    /// Reveals vector for consensus
+    /// Reveals vector for tally
     pub reveals: Vec<Vec<u8>>,
 }
 
@@ -461,7 +461,7 @@ impl Message for ResolveRA {
     type Result = Result<Vec<u8>, RadError>;
 }
 
-impl Message for RunConsensus {
+impl Message for RunTally {
     type Result = Result<Vec<u8>, RadError>;
 }
 

--- a/node/src/actors/rad_manager/handlers.rs
+++ b/node/src/actors/rad_manager/handlers.rs
@@ -5,7 +5,7 @@ use witnet_rad as rad;
 use witnet_rad::types::RadonTypes;
 
 use super::RadManager;
-use crate::actors::messages::{ResolveRA, RunConsensus};
+use crate::actors::messages::{ResolveRA, RunTally};
 
 impl Handler<ResolveRA> for RadManager {
     type Result = <ResolveRA as Message>::Result;
@@ -29,10 +29,10 @@ impl Handler<ResolveRA> for RadManager {
     }
 }
 
-impl Handler<RunConsensus> for RadManager {
-    type Result = <RunConsensus as Message>::Result;
+impl Handler<RunTally> for RadManager {
+    type Result = <RunTally as Message>::Result;
 
-    fn handle(&mut self, msg: RunConsensus, _ctx: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: RunTally, _ctx: &mut Self::Context) -> Self::Result {
         let packed_script = msg.script;
         let reveals = msg.reveals;
 
@@ -41,6 +41,6 @@ impl Handler<RunConsensus> for RadManager {
             .filter_map(|input| RadonTypes::try_from(input.as_slice()).ok())
             .collect();
 
-        rad::run_consensus(radon_types_vec, &packed_script)
+        rad::run_tally(radon_types_vec, &packed_script)
     }
 }

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -67,16 +67,15 @@ pub fn run_aggregation(
     rad_aggregation.try_into().map_err(Into::into)
 }
 
-/// Run consensus stage of a data request.
-pub fn run_consensus(radon_types_vec: Vec<RadonTypes>, consensus: &RADTally) -> Result<Vec<u8>> {
+/// Run tally stage of a data request.
+pub fn run_tally(radon_types_vec: Vec<RadonTypes>, consensus: &RADTally) -> Result<Vec<u8>> {
     let radon_script = unpack_radon_script(consensus.script.as_slice())?;
 
     let radon_array = RadonArray::from(radon_types_vec);
 
-    let rad_consensus: RadonTypes =
-        execute_radon_script(RadonTypes::from(radon_array), &radon_script)?;
+    let rad_tally: RadonTypes = execute_radon_script(RadonTypes::from(radon_array), &radon_script)?;
 
-    rad_consensus.try_into().map_err(Into::into)
+    rad_tally.try_into().map_err(Into::into)
 }
 
 #[test]
@@ -120,7 +119,7 @@ fn test_run_consensus_and_aggregation() {
             script: packed_script.clone(),
         },
     );
-    let output_consensus = run_consensus(
+    let output_tally = run_tally(
         radon_types_vec,
         &RADTally {
             script: packed_script,
@@ -128,7 +127,7 @@ fn test_run_consensus_and_aggregation() {
     );
 
     assert_eq!(output_aggregate, expected);
-    assert_eq!(output_consensus, expected);
+    assert_eq!(output_tally, expected);
 }
 
 #[test]
@@ -177,7 +176,7 @@ fn test_run_all_risk_premium() {
     )
     .unwrap();
     let tallied =
-        RadonTypes::try_from(run_consensus(vec![aggregated], &tally).unwrap().as_slice()).unwrap();
+        RadonTypes::try_from(run_tally(vec![aggregated], &tally).unwrap().as_slice()).unwrap();
 
     match tallied {
         RadonTypes::Boolean(_) => {}
@@ -210,7 +209,7 @@ fn test_run_all_murders() {
     )
     .unwrap();
     let tallied =
-        RadonTypes::try_from(run_consensus(vec![aggregated], &tally).unwrap().as_slice()).unwrap();
+        RadonTypes::try_from(run_tally(vec![aggregated], &tally).unwrap().as_slice()).unwrap();
 
     match tallied {
         RadonTypes::Boolean(_) => {}
@@ -247,7 +246,7 @@ fn test_run_all_air_quality() {
     )
     .unwrap();
     let tallied =
-        RadonTypes::try_from(run_consensus(vec![aggregated], &tally).unwrap().as_slice()).unwrap();
+        RadonTypes::try_from(run_tally(vec![aggregated], &tally).unwrap().as_slice()).unwrap();
 
     match tallied {
         RadonTypes::Boolean(_) => {}
@@ -281,7 +280,7 @@ fn test_run_all_elections() {
     )
     .unwrap();
     let tallied =
-        RadonTypes::try_from(run_consensus(vec![aggregated], &tally).unwrap().as_slice()).unwrap();
+        RadonTypes::try_from(run_tally(vec![aggregated], &tally).unwrap().as_slice()).unwrap();
 
     match tallied {
         RadonTypes::Float(radon_float) => {

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -40,7 +40,11 @@ pub fn run_retrieval(retrieve: &RADRetrieve) -> Result<RadonTypes> {
                 .text()
                 .map_err(RadError::from)?;
 
-            run_retrieval_with_data(retrieve, response)
+            let result = run_retrieval_with_data(retrieve, response);
+
+            log::debug!("Result for URL {}: {:?}", retrieve.url, result);
+
+            result
         }
     }
 }
@@ -57,6 +61,8 @@ pub fn run_aggregation(
 
     let rad_aggregation: RadonTypes =
         execute_radon_script(RadonTypes::from(radon_array), &radon_script)?;
+
+    log::debug!("aggregation result: {:?}", rad_aggregation);
 
     rad_aggregation.try_into().map_err(Into::into)
 }

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -231,7 +231,7 @@ fn run_dr_locally(dr: &DataRequestOutput) -> Result<RadonTypes, failure::Error> 
         .map(|x| RadonTypes::try_from(x.as_slice()).unwrap())
         .collect();
     log::info!("Running tally with values {:?}", reported_values);
-    let tally_result = witnet_rad::run_consensus(reported_values, &dr.data_request.tally)?;
+    let tally_result = witnet_rad::run_tally(reported_values, &dr.data_request.tally)?;
     log::info!("Tally result: {:?}", tally_result);
 
     Ok(RadonTypes::try_from(tally_result.as_slice())?)

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -41,6 +41,12 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
             fee,
             time_lock.unwrap_or(0),
         ),
+        Command::SendRequest {
+            node,
+            hex,
+            fee,
+            run,
+        } => rpc::send_dr(node.unwrap_or(config.jsonrpc.server_address), hex, fee, run),
         Command::Raw { node } => rpc::raw(node.unwrap_or(config.jsonrpc.server_address)),
         Command::ShowConfig => {
             // TODO: Implementation requires to make Config serializable
@@ -167,6 +173,19 @@ pub enum Command {
         /// Time lock
         #[structopt(long = "time-lock")]
         time_lock: Option<u64>,
+    },
+    #[structopt(name = "send-request", about = "Send a serialized data request")]
+    SendRequest {
+        /// Socket address of the Witnet node to query.
+        #[structopt(short = "n", long = "node")]
+        node: Option<SocketAddr>,
+        #[structopt(long = "hex")]
+        hex: String,
+        #[structopt(long = "fee", default_value = "0")]
+        fee: u64,
+        /// Run the data request locally before sending, to ensure correctness of RADON scripts
+        #[structopt(long = "run")]
+        run: bool,
     },
     #[structopt(
         name = "show-config",

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -25,7 +25,7 @@ use witnet_data_structures::{
     },
     vrf::{BlockEligibilityClaim, DataRequestEligibilityClaim, VrfCtx},
 };
-use witnet_rad::{run_consensus, script::unpack_radon_script, types::RadonTypes};
+use witnet_rad::{run_tally, script::unpack_radon_script, types::RadonTypes};
 
 /// Calculate the sum of the values of the outputs pointed by the
 /// inputs of a transaction. If an input pointed-output is not
@@ -169,7 +169,7 @@ pub fn validate_consensus(
         .filter_map(|&input| RadonTypes::try_from(input).ok())
         .collect();
 
-    let local_tally = run_consensus(radon_types_vec, consensus)?;
+    let local_tally = run_tally(radon_types_vec, consensus)?;
 
     if local_tally == miner_tally {
         Ok(())

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -33,9 +33,9 @@ impl Worker {
                     .and_then(|aggregated| {
                         types::RadonTypes::try_from(aggregated.as_slice())
                             .and_then(|aggregation_result| {
-                                witnet_rad::run_consensus(vec![aggregation_result], &request.tally)
-                                    .and_then(|consensus_result| {
-                                        types::RadonTypes::try_from(consensus_result.as_slice())
+                                witnet_rad::run_tally(vec![aggregation_result], &request.tally)
+                                    .and_then(|tally_result| {
+                                        types::RadonTypes::try_from(tally_result.as_slice())
                                     })
                             })
                             .map_err(Into::into)


### PR DESCRIPTION
With option to try serialized data requests locally:

    cargo run -- node send-request --run --hex=0aa0...

Additionally, renamed run_consensus to run_tally for consistency.