### PR TITLE
fix(rad): subscripts should be inside an array

### DIFF
--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -155,6 +155,19 @@ pub enum RadError {
         first: usize,
         second: usize,
     },
+    /// Subscripts should be an array
+    #[fail(display = "Subscript should be an array but is: {:?}", value)]
+    BadSubscriptFormat { value: Value },
+    /// Error while executing subscript
+    #[fail(
+        display = "`{}::{}()`: Error in subscript: {}",
+        input_type, operator, inner
+    )]
+    Subscript {
+        input_type: String,
+        operator: String,
+        inner: Box<RadError>,
+    },
 }
 
 impl From<reqwest::Error> for RadError {

--- a/rad/src/script.rs
+++ b/rad/src/script.rs
@@ -67,6 +67,19 @@ fn unpack_compound_call(array: &[Value]) -> Result<RadonCall, RadError> {
         .unwrap_or_else(Err)
 }
 
+pub fn unpack_subscript(value: &Value) -> Result<Vec<RadonCall>, RadError> {
+    let mut subscript = vec![];
+    let subscript_arg = match value {
+        Value::Array(x) => x,
+        x => return Err(RadError::BadSubscriptFormat { value: x.clone() }),
+    };
+    for arg in subscript_arg {
+        subscript.push(unpack_radon_call(arg)?)
+    }
+
+    Ok(subscript)
+}
+
 fn errorify(kind: RadError) -> RadError {
     error!("Error unpacking a RADON script: {:?}", kind);
 

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -219,7 +219,10 @@ fn test_operate_map_float_multiply() {
     let call = (
         RadonOpCodes::ArrayMap,
         Some(vec![
-            Value::Array(vec![Value::Integer(0x38), Value::Integer(2i128)]), // [ OP_FLOAT_MULTIPLY, 2 ]
+            Value::Array(vec![Value::Array(vec![
+                Value::Integer(0x38),
+                Value::Integer(2i128),
+            ])]), // [ OP_FLOAT_MULTIPLY, 2 ]
         ]),
     );
     let expected = RadonTypes::from(RadonArray::from(vec![


### PR DESCRIPTION
Before this PR, RADON subscripts were deserialized as:

    // Old
    [83, [85, "symbol"], 117]

But we actually want them to be inside one array:

    // New
    [83, [[85, "symbol"], 117]]