### PR TITLE
Update wallet details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,6 +3173,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "widestring 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "websocket"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3299,6 +3308,7 @@ dependencies = [
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webbrowser 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_config 0.3.2",
  "witnet_data_structures 0.3.2",
  "witnet_node 0.4.0",
@@ -3909,6 +3919,7 @@ dependencies = [
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum web3 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "076f34ed252d74a8521e3b013254b1a39f94a98f23aae7cfc85cda6e7b395664"
+"checksum webbrowser 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "97d468a911faaaeb783693b004e1c62e0063e646b0afae5c146cd144e566e66d"
 "checksum websocket 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c9faed2bff8af2ea6b9f8b917d3d00b467583f6781fe3def174a9e33c879703"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum widestring 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7157704c2e12e3d2189c507b7482c52820a16dfa4465ba91add92f266667cadb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3359,6 +3359,8 @@ dependencies = [
 name = "witnet_crypto"
 version = "0.3.2"
 dependencies = [
+ "bech32 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ structopt = "0.2.14"
 toml = "0.4.10"
 terminal_size = "0.1.8"
 lazy_static = "1.3.0"
+webbrowser = "0.5.2"
 
 witnet_wallet = { path = "./wallet", optional = true }
 witnet_node = { path = "./node", optional = true }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -11,6 +11,8 @@ default = []
 with-serde = ["serde", "secp256k1/serde"]
 
 [dependencies]
+bech32 = "0.7.1"
+byteorder = "1.3.2"
 failure = "0.1.5"
 hmac = "0.7.0"
 rust-crypto = "0.2.36"

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -453,6 +453,11 @@ impl KeyPath {
     pub fn len(&self) -> usize {
         self.path.len()
     }
+
+    /// Returns true if this key path corresponds to a master key.
+    pub fn is_master(&self) -> bool {
+        self.path.len() == 0
+    }
 }
 
 impl fmt::Display for KeyPath {

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -22,3 +22,6 @@ pub mod signature;
 
 /// Re-export secp256k1 crate
 pub use secp256k1;
+
+#[cfg(test)]
+pub mod test_vectors;

--- a/crypto/src/mnemonic.rs
+++ b/crypto/src/mnemonic.rs
@@ -209,4 +209,14 @@ mod tests {
 
         assert_eq!(bytes, seed.as_bytes());
     }
+
+    #[test]
+    fn test_vectors() {
+        for (phrase, expected_seed) in crate::test_vectors::TREZOR_MNEMONICS {
+            let mnemonic = Mnemonic::from_phrase(phrase.into()).unwrap();
+            let seed = hex::encode(mnemonic.seed(&"TREZOR".into()));
+
+            assert_eq!(expected_seed.as_ref(), seed);
+        }
+    }
 }

--- a/crypto/src/mnemonic.rs
+++ b/crypto/src/mnemonic.rs
@@ -216,7 +216,7 @@ mod tests {
             let mnemonic = Mnemonic::from_phrase(phrase.into()).unwrap();
             let seed = hex::encode(mnemonic.seed(&"TREZOR".into()));
 
-            assert_eq!(expected_seed.as_ref(), seed);
+            assert_eq!(expected_seed.to_string(), seed);
         }
     }
 }

--- a/crypto/src/test_vectors.rs
+++ b/crypto/src/test_vectors.rs
@@ -1,0 +1,101 @@
+/// Trezor test vectors (passpharse is TREZOR)
+///
+/// See https://github.com/trezor/python-mnemonic/blob/master/vectors.json
+pub const TREZOR_MNEMONICS: &[(&str, &str)] = &[
+    (
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+        "c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04",
+    ),
+    (
+        "legal winner thank year wave sausage worth useful legal winner thank yellow",
+        "2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607",
+    ),
+    (
+        "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+        "d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8",
+    ),
+    (
+        "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+        "ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069",
+    ),
+    (
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon agent",
+        "035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa",
+    ),
+    (
+        "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will",
+        "f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd",
+    ),
+    (
+        "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter always",
+        "107d7c02a5aa6f38c58083ff74f04c607c2d2c0ecc55501dadd72d025b751bc27fe913ffb796f841c49b1d33b610cf0e91d3aa239027f5e99fe4ce9e5088cd65",
+    ),
+    (
+        "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo when",
+        "0cd6e5d827bb62eb8fc1e262254223817fd068a74b5b449cc2f667c3f1f985a76379b43348d952e2265b4cd129090758b3e3c2c49103b5051aac2eaeb890a528",
+    ),
+    (
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+        "bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8",
+    ),
+    (
+        "legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth title",
+        "bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87",
+    ),
+    (
+        "letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic avoid letter advice cage absurd amount doctor acoustic bless",
+        "c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f",
+    ),
+    (
+        "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo vote",
+        "dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad",
+    ),
+    (
+        "ozone drill grab fiber curtain grace pudding thank cruise elder eight picnic",
+        "274ddc525802f7c828d8ef7ddbcdc5304e87ac3535913611fbbfa986d0c9e5476c91689f9c8a54fd55bd38606aa6a8595ad213d4c9c9f9aca3fb217069a41028",
+    ),
+    (
+        "gravity machine north sort system female filter attitude volume fold club stay feature office ecology stable narrow fog",
+        "628c3827a8823298ee685db84f55caa34b5cc195a778e52d45f59bcf75aba68e4d7590e101dc414bc1bbd5737666fbbef35d1f1903953b66624f910feef245ac",
+    ),
+    (
+        "hamster diagram private dutch cause delay private meat slide toddler razor book happy fancy gospel tennis maple dilemma loan word shrug inflict delay length",
+        "64c87cde7e12ecf6704ab95bb1408bef047c22db4cc7491c4271d170a1b213d20b385bc1588d9c7b38f1b39d415665b8a9030c9ec653d75e65f847d8fc1fc440",
+    ),
+    (
+        "scheme spot photo card baby mountain device kick cradle pact join borrow",
+        "ea725895aaae8d4c1cf682c1bfd2d358d52ed9f0f0591131b559e2724bb234fca05aa9c02c57407e04ee9dc3b454aa63fbff483a8b11de949624b9f1831a9612",
+    ),
+    (
+        "horn tenant knee talent sponsor spell gate clip pulse soap slush warm silver nephew swap uncle crack brave",
+        "fd579828af3da1d32544ce4db5c73d53fc8acc4ddb1e3b251a31179cdb71e853c56d2fcb11aed39898ce6c34b10b5382772db8796e52837b54468aeb312cfc3d",
+    ),
+    (
+        "panda eyebrow bullet gorilla call smoke muffin taste mesh discover soft ostrich alcohol speed nation flash devote level hobby quick inner drive ghost inside",
+        "72be8e052fc4919d2adf28d5306b5474b0069df35b02303de8c1729c9538dbb6fc2d731d5f832193cd9fb6aeecbc469594a70e3dd50811b5067f3b88b28c3e8d",
+    ),
+    (
+        "cat swing flag economy stadium alone churn speed unique patch report train",
+        "deb5f45449e615feff5640f2e49f933ff51895de3b4381832b3139941c57b59205a42480c52175b6efcffaa58a2503887c1e8b363a707256bdd2b587b46541f5",
+    ),
+    (
+        "light rule cinnamon wrap drastic word pride squirrel upgrade then income fatal apart sustain crack supply proud access",
+        "4cbdff1ca2db800fd61cae72a57475fdc6bab03e441fd63f96dabd1f183ef5b782925f00105f318309a7e9c3ea6967c7801e46c8a58082674c860a37b93eda02",
+    ),
+    (
+        "all hour make first leader extend hole alien behind guard gospel lava path output census museum junior mass reopen famous sing advance salt reform",
+        "26e975ec644423f4a4c4f4215ef09b4bd7ef924e85d1d17c4cf3f136c2863cf6df0a475045652c57eb5fb41513ca2a2d67722b77e954b4b3fc11f7590449191d",
+    ),
+    (
+        "vessel ladder alter error federal sibling chat ability sun glass valve picture",
+        "2aaa9242daafcee6aa9d7269f17d4efe271e1b9a529178d7dc139cd18747090bf9d60295d0ce74309a78852a9caadf0af48aae1c6253839624076224374bc63f",
+    ),
+    (
+        "scissors invite lock maple supreme raw rapid void congress muscle digital elegant little brisk hair mango congress clump",
+        "7b4a10be9d98e6cba265566db7f136718e1398c71cb581e1b2f464cac1ceedf4f3e274dc270003c670ad8d02c4558b2f8e39edea2775c9e232c7cb798b069e88",
+    ),
+    (
+        "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
+        "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998",
+    )
+];

--- a/crypto/src/test_vectors.rs
+++ b/crypto/src/test_vectors.rs
@@ -1,3 +1,5 @@
+use crate::key::KeyPath;
+
 /// Trezor test vectors (passpharse is TREZOR)
 ///
 /// See https://github.com/trezor/python-mnemonic/blob/master/vectors.json
@@ -99,3 +101,58 @@ pub const TREZOR_MNEMONICS: &[(&str, &str)] = &[
         "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998",
     )
 ];
+
+/// Slip32 test vectors (passpharse is empty "")
+///
+/// mnemonic phrase is: abandon abandon abandon abandon abandon
+/// abandon abandon abandon abandon abandon abandon about
+///
+/// See: https://github.com/satoshilabs/slips/blob/master/slip-0032.md#test-vectors
+pub fn slip32_vectors() -> Vec<(&'static str, KeyPath)> {
+    vec![
+        (
+            "xprv1qpujxsyd4hfu0dtwa524vac84e09mjsgnh5h9crl8wrqg58z5wmsuqqcxlqmar3fjhkprndzkpnp2xlze76g4hu7g7c4r4r2m2e6y8xlvu566tn6",
+            KeyPath::default(),
+        ),
+        (
+            "xprv1qyqqqqqqurn9qwkq2l84m3mwqu672mw5f5vnkt57yuwv94rtcavunxczrc7qpw4gn29a6cw9ug4e7yrqrkrerj0cl39jlfkln45dxdhsavpmqm4krfqykk",
+            KeyPath::default().index(0)
+        ),
+        (
+            "xprv1qyqqqqqpt3yfzltg8zmxdt43r6k8cnuclqrh0x6hcafzuwzsjuv7av085kfqpsd74lcvfkucgec2grrfc228h8fne4lkuayuvlsledwxzxxa5y5zefalyg",
+            KeyPath::default().index(1)
+        ),
+        (
+            "xprv1qxqqqqqq78qr7hlewyyfzt74vasa87k63pu7g9e6hfzlzrdyh0v5k8zfw9sqpsyv7vcejeyzcpkm85jel7vmujlhpquzf4f3sh3nry0w0n4jh7t0jhc039",
+            KeyPath::default().hardened(0)
+        ),
+        (
+            "xprv1qxqqqqqpg0xyhjjecen2taujv52gzfvq9mfva3rd78zu4rn2qkx6k5j6w0csq0hs9lznqqr59zgleyz93w57mjpk8k837fn7xf43q7r3p37mxn095hysnx",
+            KeyPath::default().hardened(1)
+        ),
+        (
+            "xprv1qwqqqqpvsqqqqqyqqqqqq0dyhsvs5f5qzywnr7klmjg972nldnnhcmcsnyv3zme984p5g5seqrlxftuztddhs42vxw3gkgcgtlqg9a53k0r39nqafenwzvef0k585enml6g",
+            KeyPath::default().hardened(44).hardened(0).hardened(0)
+        ),
+        (
+            "xprv1qwqqqqpvsqqqqqyqqqqqz2t3lgkmpl6ad8skdfqxsya28k0dp8z2mtpwpn3n2g7633tqna85qzy9th76xllxvwllcqfkvxzsfc7t6lveyy6xp880vxguw2fnn4wx2mhtjy8",
+            KeyPath::default().hardened(44).hardened(0).hardened(1)
+        ),
+        (
+            "xprv1qwqqqqpvsqqqqq5qqqqqpp5u2pz7tlrcjert40x3jcd3qx7rre6lu5xl3fv9c7dsth9q436cqzvre5gd352pvzcshxjtkceq062c2p22xyekr82hk782n4d2xprdysp4gxc",
+            KeyPath::default().hardened(44).hardened(2).hardened(0)
+        ),
+        (
+            "xprv1qwqqqqp3sqqqqqyqqqqqqm42udj6urs2p24cgvjule7dwmpmjzgrt7yfulflrwz84xs8jlktqzyq65t490dyryrq0cretzxn7ezdj6l6qdzxhn5neh0a50z2n8r7vumvllf",
+            KeyPath::default().hardened(49).hardened(0).hardened(0)
+        ),
+        (
+            "xprv1qwqqqqp3sqqqqq5qqqqqqeahu8w9cu9fx5zzrrx0grz844rdf2wgtqvkxakwp6zn4jnmupycqr8jytxzuztsf8lzefmxymqecln68muhrv0kgx2htz4neqeyv070gg6dcn7",
+            KeyPath::default().hardened(49).hardened(2).hardened(0)
+        ),
+        (
+            "xprv1qwqqqqz5sqqqqqyqqqqqqjjn5z4jrwwujkrfcn5j59s3jnsrcrhnlagpftrf9apnc3m9fy8uqrs57f6dzm9qmygrrwvtzcnpspsaqwfslgup4ak5et6ykqvpn2mdggeaxrp",
+            KeyPath::default().hardened(84).hardened(0).hardened(0)
+        )
+    ]
+}

--- a/src/cli/wallet/with_wallet.rs
+++ b/src/cli/wallet/with_wallet.rs
@@ -33,6 +33,10 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
             );
             Ok(())
         }
+        Command::Doc => {
+            webbrowser::open("https://github.com/witnet/witnet-rust/wiki/Wallet")?;
+            Ok(())
+        }
     }
 }
 
@@ -49,6 +53,11 @@ pub enum Command {
         about = "Dump the loaded config in Toml format to stdout."
     )]
     ShowConfig,
+    #[structopt(
+        name = "doc",
+        about = "Opens Wallet Wiki page with the default browser."
+    )]
+    Doc,
 }
 
 #[derive(Debug, StructOpt)]

--- a/wallet/src/actors/app/handlers/create_wallet.rs
+++ b/wallet/src/actors/app/handlers/create_wallet.rs
@@ -64,7 +64,7 @@ fn validate(req: CreateWalletRequest) -> Result<Validated, app::ValidationErrors
     let caption = req.caption;
     let seed_data = req.seed_data;
     let source = match req.seed_source.as_ref() {
-        "xprv" => Ok(types::SeedSource::Xprv),
+        "xprv" => Ok(types::SeedSource::Xprv(seed_data)),
         "mnemonics" => Mnemonic::from_phrase(seed_data)
             .map_err(|err| app::field_error("seed_data", format!("{}", err)))
             .map(types::SeedSource::Mnemonics),

--- a/wallet/src/actors/app/handlers/mod.rs
+++ b/wallet/src/actors/app/handlers/mod.rs
@@ -23,6 +23,7 @@ mod stop;
 mod subscribe;
 mod unlock_wallet;
 mod unsubscribe;
+mod update_wallet;
 
 pub use close_session::*;
 pub use create_data_req::*;
@@ -49,3 +50,4 @@ pub use stop::*;
 pub use subscribe::*;
 pub use unlock_wallet::*;
 pub use unsubscribe::*;
+pub use update_wallet::*;

--- a/wallet/src/actors/app/handlers/update_wallet.rs
+++ b/wallet/src/actors/app/handlers/update_wallet.rs
@@ -1,0 +1,30 @@
+use actix::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::actors::app;
+use crate::types;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateWalletRequest {
+    session_id: types::SessionId,
+    wallet_id: String,
+    name: Option<String>,
+    caption: Option<String>,
+}
+
+impl Message for UpdateWalletRequest {
+    type Result = app::Result<bool>;
+}
+
+impl Handler<UpdateWalletRequest> for app::App {
+    type Result = app::ResponseActFuture<bool>;
+
+    fn handle(&mut self, req: UpdateWalletRequest, _ctx: &mut Self::Context) -> Self::Result {
+        let f = self
+            .update_wallet(req.session_id, req.wallet_id, req.name, req.caption)
+            .map(|(), _, _| true);
+
+        Box::new(f)
+    }
+}

--- a/wallet/src/actors/app/routes.rs
+++ b/wallet/src/actors/app/routes.rs
@@ -155,6 +155,7 @@ pub fn connect_routes<T, S>(
         ),
         ("Import-Seed", "importSeed", ImportSeedRequest),
         ("Create-Wallet", "createWallet", CreateWalletRequest),
+        ("Update-Wallet", "updateWallet", UpdateWalletRequest),
         ("Lock-Wallet", "lockWallet", LockWalletRequest),
         ("Unlock-Wallet", "unlockWallet", UnlockWalletRequest),
         ("Lock-Wallet", "lockWallet", LockWalletRequest),

--- a/wallet/src/actors/worker/error.rs
+++ b/wallet/src/actors/worker/error.rs
@@ -1,8 +1,6 @@
 use failure::Fail;
 
-use witnet_crypto as crypto;
-
-use crate::{db, repository};
+use crate::{crypto, db, repository};
 
 #[derive(Debug, Fail)]
 #[fail(display = "error")]
@@ -12,7 +10,7 @@ pub enum Error {
     #[fail(display = "{}", _0)]
     Mailbox(#[cause] actix::MailboxError),
     #[fail(display = "master key generation failed: {}", _0)]
-    MasterKeyGen(#[cause] crypto::key::MasterKeyGenError),
+    KeyGen(#[cause] crypto::Error),
     #[fail(display = "repository failed: {}", _0)]
     Repository(#[cause] repository::Error),
     #[fail(display = "{}", _0)]
@@ -27,9 +25,9 @@ pub enum Error {
     Send(#[cause] futures::sync::mpsc::SendError<std::string::String>),
 }
 
-impl From<crypto::key::MasterKeyGenError> for Error {
-    fn from(err: crypto::key::MasterKeyGenError) -> Self {
-        Error::MasterKeyGen(err)
+impl From<crypto::Error> for Error {
+    fn from(err: crypto::Error) -> Self {
+        Self::KeyGen(err)
     }
 }
 

--- a/wallet/src/actors/worker/handlers/mod.rs
+++ b/wallet/src/actors/worker/handlers/mod.rs
@@ -14,6 +14,8 @@ pub mod notify_balance;
 pub mod run_rad_request;
 pub mod set;
 pub mod unlock_wallet;
+pub mod update_wallet;
+pub mod update_wallet_info;
 pub mod wallet_infos;
 
 pub use create_data_req::*;
@@ -32,4 +34,6 @@ pub use notify_balance::*;
 pub use run_rad_request::*;
 pub use set::*;
 pub use unlock_wallet::*;
+pub use update_wallet::*;
+pub use update_wallet_info::*;
 pub use wallet_infos::*;

--- a/wallet/src/actors/worker/handlers/update_wallet.rs
+++ b/wallet/src/actors/worker/handlers/update_wallet.rs
@@ -1,0 +1,28 @@
+use actix::prelude::*;
+
+use crate::actors::worker;
+use crate::types;
+
+pub struct UpdateWallet(
+    pub types::SessionWallet,
+    /// Wallet name
+    pub Option<String>,
+    /// Wallet caption
+    pub Option<String>,
+);
+
+impl Message for UpdateWallet {
+    type Result = worker::Result<()>;
+}
+
+impl Handler<UpdateWallet> for worker::Worker {
+    type Result = <UpdateWallet as Message>::Result;
+
+    fn handle(
+        &mut self,
+        UpdateWallet(wallet, name, caption): UpdateWallet,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        self.update_wallet(&wallet, name, caption)
+    }
+}

--- a/wallet/src/actors/worker/handlers/update_wallet_info.rs
+++ b/wallet/src/actors/worker/handlers/update_wallet_info.rs
@@ -1,0 +1,28 @@
+use actix::prelude::*;
+
+use crate::actors::worker;
+
+pub struct UpdateWalletInfo(
+    /// Wallet id
+    pub String,
+    /// Wallet name
+    pub Option<String>,
+    /// Wallet caption
+    pub Option<String>,
+);
+
+impl Message for UpdateWalletInfo {
+    type Result = worker::Result<()>;
+}
+
+impl Handler<UpdateWalletInfo> for worker::Worker {
+    type Result = <UpdateWalletInfo as Message>::Result;
+
+    fn handle(
+        &mut self,
+        UpdateWalletInfo(wallet_id, name, caption): UpdateWalletInfo,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        self.update_wallet_info(&wallet_id, name, caption)
+    }
+}

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -114,6 +114,30 @@ impl Worker {
         Ok(id)
     }
 
+    /// Update a wallet details.
+    pub fn update_wallet(
+        &self,
+        wallet: &types::Wallet,
+        name: Option<String>,
+        caption: Option<String>,
+    ) -> Result<()> {
+        wallet.update(name, caption)?;
+
+        Ok(())
+    }
+
+    /// Update the wallet information in the infos database.
+    pub fn update_wallet_info(
+        &self,
+        wallet_id: &str,
+        name: Option<String>,
+        caption: Option<String>,
+    ) -> Result<()> {
+        self.wallets.update_info(wallet_id, name, caption)?;
+
+        Ok(())
+    }
+
     pub fn unlock_wallet(
         &mut self,
         wallet_id: &str,

--- a/wallet/src/crypto.rs
+++ b/wallet/src/crypto.rs
@@ -50,7 +50,7 @@ pub fn gen_master_key(
             let (key, path) =
                 ExtendedSK::from_slip32(slip32.as_ref()).map_err(Error::Deserialization)?;
             if !path.is_master() {
-                Err(Error::InvalidKeyPath(format!("{}", path)))?;
+                return Err(Error::InvalidKeyPath(format!("{}", path)));
             }
 
             key

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -67,7 +67,7 @@ pub fn run(conf: Config) -> Result<(), Error> {
     let node_jsonrpc_server_address = conf.jsonrpc.server_address;
     let client = node_url.clone().map_or_else(
         || {
-            log::error!("No node url in config! To connect to a Witnet node, you must manually add the address to the configuration file as follows:\n\
+            log::warn!("No node url in config! To connect to a Witnet node, you must manually add the address to the configuration file as follows:\n\
                         [wallet]\n\
                         node_url = \"{}\"\n", node_jsonrpc_server_address);
             Ok(None)

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -288,6 +288,26 @@ where
         Ok(())
     }
 
+    /// Update a wallet's name and/or caption
+    pub fn update(&self, name: Option<String>, caption: Option<String>) -> Result<()> {
+        let mut batch = self.db.batch();
+        let mut state = self.state.write()?;
+
+        state.name = name;
+        if let Some(ref name) = state.name {
+            batch.put(keys::wallet_name(), name)?;
+        }
+
+        state.caption = caption;
+        if let Some(ref caption) = state.caption {
+            batch.put(keys::wallet_caption(), caption)?;
+        }
+
+        self.db.write(batch)?;
+
+        Ok(())
+    }
+
     /// Index transactions in a block received from a node.
     pub fn index_transactions(
         &self,

--- a/wallet/src/repository/wallet/tests/mod.rs
+++ b/wallet/src/repository/wallet/tests/mod.rs
@@ -843,3 +843,49 @@ fn test_index_transaction_vtt_created_by_wallet() {
             .unwrap()
     );
 }
+
+#[test]
+fn test_update_wallet_with_empty_values() {
+    let (wallet, db) = factories::wallet(None);
+    let wallet_data = wallet.public_data().unwrap();
+
+    assert!(wallet_data.name.is_none());
+    assert!(wallet_data.caption.is_none());
+    assert!(!db.contains(&keys::wallet_name()).unwrap());
+    assert!(!db.contains(&keys::wallet_caption()).unwrap());
+
+    wallet.update(None, None).unwrap();
+
+    let wallet_data = wallet.public_data().unwrap();
+
+    assert!(wallet_data.name.is_none());
+    assert!(wallet_data.caption.is_none());
+    assert!(!db.contains(&keys::wallet_name()).unwrap());
+    assert!(!db.contains(&keys::wallet_caption()).unwrap());
+}
+
+#[test]
+fn test_update_wallet_with_values() {
+    let (wallet, db) = factories::wallet(None);
+    let wallet_data = wallet.public_data().unwrap();
+
+    assert!(wallet_data.name.is_none());
+    assert!(wallet_data.caption.is_none());
+    assert!(!db.contains(&keys::wallet_name()).unwrap());
+    assert!(!db.contains(&keys::wallet_caption()).unwrap());
+
+    let name = Some("wallet name".to_string());
+    let caption = Some("wallet caption".to_string());
+
+    wallet.update(name.clone(), caption.clone()).unwrap();
+
+    let wallet_data = wallet.public_data().unwrap();
+
+    assert_eq!(name, wallet_data.name);
+    assert_eq!(caption, wallet_data.caption);
+    assert_eq!(name, db.get_opt::<_, String>(&keys::wallet_name()).unwrap());
+    assert_eq!(
+        caption,
+        db.get_opt::<_, String>(&keys::wallet_caption()).unwrap()
+    );
+}

--- a/wallet/src/repository/wallets/mod.rs
+++ b/wallet/src/repository/wallets/mod.rs
@@ -7,6 +7,9 @@ use crate::{
     model, types,
 };
 
+#[cfg(test)]
+mod tests;
+
 pub struct Wallets<T> {
     db: T,
     wallets_mutex: Mutex<()>,
@@ -38,6 +41,28 @@ impl<T: Database> Wallets<T> {
         }
 
         Ok(wallets)
+    }
+
+    /// Update a wallet's public info.
+    pub fn update_info(
+        &self,
+        id: &str,
+        name: Option<String>,
+        caption: Option<String>,
+    ) -> Result<()> {
+        let mut batch = self.db.batch();
+
+        if let Some(name) = name {
+            batch.put(keys::wallet_id_name(id), name)?;
+        }
+
+        if let Some(caption) = caption {
+            batch.put(keys::wallet_id_caption(id), caption)?;
+        }
+
+        self.db.write(batch)?;
+
+        Ok(())
     }
 
     pub fn create<'a, D: Database>(

--- a/wallet/src/repository/wallets/tests/factories.rs
+++ b/wallet/src/repository/wallets/tests/factories.rs
@@ -1,0 +1,11 @@
+use std::{cell::RefCell, rc::Rc};
+
+use super::*;
+
+pub fn wallets(data: Option<HashMap<Vec<u8>, Vec<u8>>>) -> (Wallets<db::HashMapDb>, db::HashMapDb) {
+    let storage = Rc::new(RefCell::new(data.unwrap_or_default()));
+    let db = db::HashMapDb::new(storage);
+    let wallets = Wallets::new(db.clone());
+
+    (wallets, db)
+}

--- a/wallet/src/repository/wallets/tests/mod.rs
+++ b/wallet/src/repository/wallets/tests/mod.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+use std::iter::FromIterator;
+
+use super::*;
+use crate::*;
+
+mod factories;
+
+#[test]
+fn test_wallet_infos_when_no_wallets() {
+    let (wallets, _db) = factories::wallets(None);
+
+    let infos = wallets.infos().unwrap();
+
+    assert!(infos.is_empty());
+}
+
+#[test]
+fn test_wallet_infos_when_wallets() {
+    let data = HashMap::from_iter(vec![(
+        keys::wallet_ids().as_bytes().to_vec(),
+        bincode::serialize(&vec!["a-wallet-id".to_string()]).unwrap(),
+    )]);
+    let (wallets, _db) = factories::wallets(Some(data));
+
+    let infos = wallets.infos().unwrap();
+
+    assert_eq!(1, infos.len());
+}
+
+#[test]
+fn test_update_wallet_info() {
+    let id = "a-wallet-id".to_string();
+    let data = HashMap::from_iter(vec![(
+        keys::wallet_ids().as_bytes().to_vec(),
+        bincode::serialize(&vec![id.clone()]).unwrap(),
+    )]);
+    let (wallets, db) = factories::wallets(Some(data));
+
+    let wallet_info = &wallets.infos().unwrap()[0];
+
+    assert!(wallet_info.name.is_none());
+    assert!(wallet_info.caption.is_none());
+    assert!(!db.contains(&keys::wallet_id_name(&id)).unwrap());
+    assert!(!db.contains(&keys::wallet_id_caption(&id)).unwrap());
+
+    let name = Some("Testing".to_string());
+    let caption = Some("A testing wallet".to_string());
+
+    wallets
+        .update_info(&id, name.clone(), caption.clone())
+        .unwrap();
+
+    let wallet_info = &wallets.infos().unwrap()[0];
+
+    assert_eq!(name, wallet_info.name);
+    assert_eq!(caption, wallet_info.caption);
+    assert_eq!(
+        name,
+        db.get_opt::<_, String>(&keys::wallet_id_name(&id)).unwrap()
+    );
+    assert_eq!(
+        caption,
+        db.get_opt::<_, String>(&keys::wallet_id_caption(&id))
+            .unwrap()
+    );
+}

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -131,6 +131,7 @@ pub struct Balance {
 pub struct TransactionComponents {
     pub value: u64,
     pub change: u64,
+    pub balance: u64,
     pub inputs: Vec<TransactionInput>,
     pub outputs: Vec<VttOutput>,
     pub sign_keys: Vec<SK>,

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -71,7 +71,7 @@ impl From<String> for SessionId {
 
 pub enum SeedSource {
     Mnemonics(Mnemonic),
-    Xprv,
+    Xprv(ProtectedString),
 }
 
 pub struct UnlockedSessionWallet {


### PR DESCRIPTION
## What

Add new endpoint `updateWallet` which can be used to modify a wallet's name and/or caption.

## Examples

### Request

```json
{
  "params": {
    "caption": "My testing wallet",
    "name": "Testing",
    "sessionId": "273518861f799d2f6cd82caba7d2cd6d416dffbf4ab8c7a2550c31695557ac09",
    "walletId": "6c344625884c2f910065ab170dc18ad3cbbc03c7234507c7c22dbd78e3b26667"
  },
  "method": "updateWallet",
  "id": "1",
  "jsonrpc": "2.0"
}
```

### Response

```json
{
  "id": "1",
  "jsonrpc": "2.0",
  "result": true
}
```