### PR TITLE
chore: update bootstrap nodes info

### DIFF
--- a/witnet.toml
+++ b/witnet.toml
@@ -2,17 +2,17 @@
 # https://docs.witnet.io/configuration/toml-file/
 [connections]
 server_addr = "0.0.0.0:21337"
-known_peers = ["52.166.178.145:21337"]
-outbound_limit = 1
+known_peers = ["52.166.178.145:22337", "52.166.178.145:23337", "52.166.178.145:25337"]
+outbound_limit = 2
 bootstrap_peers_period_seconds = 1
 
 [storage]
-db_path = ".witnet-rust-testnet-4"
+db_path = ".witnet-rust-testnet-5"
 
 [consensus_constants]
 checkpoints_period = 30
 checkpoint_zero_timestamp = 1567036800
-genesis_hash = "00000000000000000000000000000000000000007769746e65742d302e342e30"
+genesis_hash = "00000000000000000000000000000000000000007769746e65742d302e352e30"
 
 [log]
 level = "debug"


### PR DESCRIPTION
This updates the `witnet.toml` configuration file with the addresses of the new bootstrap nodes for the Testnet 5.