### PR TITLE
test: parse and run data requests in examples/ folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
     - RUST_BACKTRACE="1"
 
 before_script:
-  - just || curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git casey/just --target x86_64-unknown-linux-musl --to ~/.cargo/bin
+  - which just || curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git casey/just --target x86_64-unknown-linux-musl --to ~/.cargo/bin
 
 script:
   - just ci

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,6 +954,11 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "globset"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3475,6 +3480,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 14.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-pubsub 14.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3735,6 +3741,7 @@ dependencies = [
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum globset 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "925aa2cac82d8834e2b2a4415b6f6879757fb5c0928fc445ae76461a12eed8f2"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum half 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ff54597ea139063f4225f1ec47011b03c9de4a486957ff3fc506881dac951d0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -37,3 +37,6 @@ witnet_validations = { path = "../validations" }
 [dependencies.serde]
 features = ["derive"]
 version = "1.0.101"
+
+[dev-dependencies]
+glob = "0.3.0"

--- a/node/tests/data_request_examples.rs
+++ b/node/tests/data_request_examples.rs
@@ -1,0 +1,101 @@
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::convert::{TryFrom, TryInto};
+use std::fs;
+use witnet_data_structures::chain::DataRequestOutput;
+use witnet_node::actors::messages::BuildDrt;
+use witnet_rad::types::float::RadonFloat;
+use witnet_rad::types::RadonTypes;
+
+/// Id. Can be null, a number, or a string
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum Id<'a> {
+    Null,
+    Number(u64),
+    String(&'a str),
+}
+/// Generic request
+#[derive(Debug, Deserialize)]
+struct JsonRpcRequest<'a, T> {
+    jsonrpc: &'a str,
+    method: &'a str,
+    id: Id<'a>,
+    params: T,
+}
+
+#[test]
+fn parse_examples() {
+    let mut existing_examples: HashSet<&str> = vec!["bitcoin_price.json", "random_source.json"]
+        .into_iter()
+        .collect();
+    for path in glob::glob("../examples/*.json").unwrap() {
+        let path = path.unwrap();
+        let v = path.file_name().unwrap().to_string_lossy();
+        if !existing_examples.remove(v.as_ref()) {
+            // The value did not exist before
+            // Please create a test for it below and then manually add it to existing examples
+            panic!("New example does not have test: {}", v);
+        }
+        println!("{}", path.display());
+        let a = fs::read_to_string(path).unwrap();
+        serde_json::from_str::<JsonRpcRequest<'_, BuildDrt>>(&a).unwrap();
+    }
+
+    if !existing_examples.is_empty() {
+        panic!("Old examples no longer exist: {:?}", existing_examples);
+    }
+}
+
+fn run_dr_locally_with_data(
+    dr: &DataRequestOutput,
+    data: &[&str],
+) -> Result<RadonTypes, failure::Error> {
+    let mut retrieval_results = vec![];
+    for (r, d) in dr.data_request.retrieve.iter().zip(data.iter()) {
+        log::info!("Running retrieval for {}", r.url);
+        retrieval_results.push(witnet_rad::run_retrieval_with_data(r, d.to_string())?);
+    }
+
+    log::info!("Running aggregation with values {:?}", retrieval_results);
+    let aggregation_result =
+        witnet_rad::run_aggregation(retrieval_results, &dr.data_request.aggregate)?;
+    log::info!("Aggregation result: {:?}", aggregation_result);
+
+    // Assume that all the required witnesses will report the same value
+    let reported_values = vec![aggregation_result; dr.witnesses.try_into().unwrap()]
+        .into_iter()
+        .map(|x| RadonTypes::try_from(x.as_slice()).unwrap())
+        .collect();
+    log::info!("Running tally with values {:?}", reported_values);
+    let tally_result = witnet_rad::run_tally(reported_values, &dr.data_request.tally)?;
+    log::info!("Tally result: {:?}", tally_result);
+
+    Ok(RadonTypes::try_from(tally_result.as_slice())?)
+}
+
+fn test_dr(path: &str, data: &[&str], expected_result: RadonTypes) {
+    let path = format!("../{}", path);
+    let a = fs::read_to_string(&path).unwrap();
+    let r = serde_json::from_str::<JsonRpcRequest<'_, BuildDrt>>(&a).unwrap();
+    let x = run_dr_locally_with_data(&r.params.dro, data).unwrap();
+    assert_eq!(x, expected_result);
+}
+
+#[test]
+fn run_examples_bitcoin_price() {
+    test_dr(
+        "examples/bitcoin_price.json",
+        &[r#"{"bpi":{"USD":{"rate_float":89279.0567}}}"#],
+        RadonTypes::Float(RadonFloat::from(89279.0567)),
+    );
+}
+
+#[test]
+fn run_examples_random_source() {
+    test_dr(
+        "examples/random_source.json",
+        &[r#"{"data":[5]}"#],
+        RadonTypes::Float(RadonFloat::from(5.0)),
+    );
+}


### PR DESCRIPTION
This ensures that our examples always work.

* Added a test which iterates over the json files in `examples/` and tries to parse them as data requests.
* Added tests which execute the request radon scripts locally, with fake input data, but they have to be added manually.
* To avoid untested data requests, there is a hardcoded list of filenames and if that list does not match the filenames in `examples/`, the test fails.

