### PR TITLE
fix(node): add missing state transition in PeersBeacons handler

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -706,6 +706,9 @@ impl Handler<PeersBeacons> for ChainManager {
                     // No consensus: unregister all peers
                     log::warn!("No consensus: unregister all peers");
                     let all_peers = pb.into_iter().map(|(p, _b)| p).collect();
+                    // Move to waiting consensus stage
+                    self.sm_state = StateMachine::WaitingConsensus;
+
                     Ok(all_peers)
                 }
             }


### PR DESCRIPTION
Otherwise the node can get stuck in Synchronizing state.