### PR TITLE
Test add transaction

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -422,12 +422,19 @@ impl Handler<AddTransaction> for ChainManager {
                 let dr_pointer = tx.body.dr_pointer;
                 let pkh = PublicKeyHash::from_public_key(&tx.signatures[0].public_key);
 
-                if self
+                match self
                     .transactions_pool
                     .commit_contains(&dr_pointer, &pkh, &tx_hash)
                 {
-                    log::debug!("Transaction is already in the pool: {}", tx_hash);
-                    return Ok(());
+                    Ok(true) => {
+                        log::debug!("Transaction is already in the pool: {}", tx_hash);
+                        return Ok(());
+                    }
+                    Ok(false) => {}
+                    Err(e) => {
+                        log::debug!("Cannot add transaction: {}", e);
+                        return Ok(());
+                    }
                 }
 
                 match (
@@ -470,12 +477,19 @@ impl Handler<AddTransaction> for ChainManager {
                 let dr_pointer = tx.body.dr_pointer;
                 let pkh = PublicKeyHash::from_public_key(&tx.signatures[0].public_key);
 
-                if self
+                match self
                     .transactions_pool
                     .reveal_contains(&dr_pointer, &pkh, &tx_hash)
                 {
-                    log::debug!("Transaction is already in the pool: {}", tx_hash);
-                    return Ok(());
+                    Ok(true) => {
+                        log::debug!("Transaction is already in the pool: {}", tx_hash);
+                        return Ok(());
+                    }
+                    Ok(false) => {}
+                    Err(e) => {
+                        log::debug!("Cannot add transaction: {}", e);
+                        return Ok(());
+                    }
                 }
 
                 validate_reveal_transaction(tx, &self.chain_state.data_request_pool).map(|_| ())


### PR DESCRIPTION
Add generic `TransactionPool::contains` method.
Changed the return type of `commit_contains` and `reveal_contains` from `bool` to `Result<bool, TransactionError>`, to handle the case where there are two commits with different hash but equal pkh for the same data request. We only accept the first one and ignore the rest as duplicates. Same with reveals.
This fixes an issue where one commit can overwrite another and we enter an infinite loop since the received commit is always considered new.

Move `AddTransaction` logic from handler to its own method in `chain_manager/mod.rs`
And move generic transaction validation function to validations crate.
Add tests for handling commits and reveals with no signatures.
Add tests for handling invalid transaction types.

Close #875 