### PR TITLE
Improve node logs

### DIFF
--- a/data_structures/src/types.rs
+++ b/data_structures/src/types.rs
@@ -43,20 +43,27 @@ impl fmt::Display for Command {
             Command::Peers(_) => f.write_str(&"PEERS".to_string()),
             Command::Verack(_) => f.write_str(&"VERACK".to_string()),
             Command::Version(_) => f.write_str(&"VERSION".to_string()),
-            Command::Block(block) => f.write_str(&format!("BLOCK: {}", block.hash())),
+            Command::Block(block) => write!(f, "BLOCK: {}", block.hash()),
             Command::InventoryAnnouncement(_) => f.write_str(&"INVENTORY_ANNOUNCEMENT".to_string()),
             Command::InventoryRequest(_) => f.write_str(&"INVENTORY_REQUEST".to_string()),
-            Command::LastBeacon(_) => f.write_str(&"LAST_BEACON".to_string()),
-            Command::Transaction(tx) => match tx {
-                Transaction::Commit(_) => f.write_str(&"COMMIT_TRANSACTION".to_string()),
-                Transaction::ValueTransfer(_) => {
-                    f.write_str(&"VALUE_TRANSFER_TRANSACTION".to_string())
+            Command::LastBeacon(LastBeacon {
+                highest_block_checkpoint: h,
+            }) => write!(f, "LAST_BEACON: #{}: {}", h.checkpoint, h.hash_prev_block),
+            Command::Transaction(tx) => {
+                match tx {
+                    Transaction::Commit(_) => f.write_str(&"COMMIT_TRANSACTION".to_string())?,
+                    Transaction::ValueTransfer(_) => {
+                        f.write_str(&"VALUE_TRANSFER_TRANSACTION".to_string())?
+                    }
+                    Transaction::DataRequest(_) => {
+                        f.write_str(&"DATA_REQUEST_TRANSACTION".to_string())?
+                    }
+                    Transaction::Reveal(_) => f.write_str(&"REVEAL_TRANSACTION".to_string())?,
+                    Transaction::Tally(_) => f.write_str(&"TALLY_TRANSACTION".to_string())?,
+                    Transaction::Mint(_) => f.write_str(&"MINT_TRANSACTION".to_string())?,
                 }
-                Transaction::DataRequest(_) => f.write_str(&"DATA_REQUEST_TRANSACTION".to_string()),
-                Transaction::Reveal(_) => f.write_str(&"REVEAL_TRANSACTION".to_string()),
-                Transaction::Tally(_) => f.write_str(&"TALLY_TRANSACTION".to_string()),
-                Transaction::Mint(_) => f.write_str(&"MINT_TRANSACTION".to_string()),
-            },
+                write!(f, ": {}", tx.hash())
+            }
         }
     }
 }

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -401,9 +401,6 @@ impl ChainManager {
                             self.persist_data_request(ctx, &dr_report);
                         });
 
-                        log::trace!("{:?}", block);
-                        debug!("Mint transaction hash: {:?}", block.txns.mint.hash());
-
                         let reveals = self
                             .chain_state
                             .data_request_pool

--- a/node/src/actors/codec.rs
+++ b/node/src/actors/codec.rs
@@ -66,10 +66,6 @@ impl Encoder for P2PCodec {
 
     /// Method to encode a response into bytes
     fn encode(&mut self, bytes: BytesMut, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        log::trace!("Encoding {:?}", bytes);
-
-        // let Response(bytes) = resp;
-
         let mut encoded_msg = vec![];
 
         if bytes.len() > u32::max_value() as usize {

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -5,9 +5,8 @@ use actix::{
     ActorContext, ActorFuture, Context, ContextFutureSpawner, Handler, StreamHandler,
     SystemService, WrapFuture,
 };
-use ansi_term::Color::Green;
 use futures::future;
-use log::{debug, error, info, trace, warn};
+use log::{debug, error, info, warn};
 
 use witnet_data_structures::{
     builders::from_address,
@@ -87,13 +86,7 @@ impl StreamHandler<BytesMut, Error> for Session {
         match result {
             Err(err) => error!("Error decoding message: {:?}", err),
             Ok(msg) => {
-                debug!(
-                    "{} Received {} message from session {:?}",
-                    Green.bold().paint("[<]"),
-                    Green.bold().paint(msg.kind.to_string()),
-                    self.remote_addr,
-                );
-                trace!("\t{:?}", msg);
+                self.log_received_message(&msg, &bytes);
 
                 // Consensus constants validation between nodes
                 if msg.magic != self.magic_number {
@@ -262,7 +255,7 @@ impl StreamHandler<BytesMut, Error> for Session {
                     /////////////////////
                     (session_type, session_status, msg_type) => {
                         warn!(
-                            "Message of type \"{:?}\" for session (type: {:?}, status: {:?}) is \
+                            "Message of type {} for session (type: {:?}, status: {:?}) is \
                              not supported",
                             msg_type, session_type, session_status
                         );

--- a/node/src/actors/session/mod.rs
+++ b/node/src/actors/session/mod.rs
@@ -129,13 +129,12 @@ impl Session {
         // Convert WitnetMessage into a vector of bytes
         match ProtobufConvert::to_pb_bytes(&msg) {
             Ok(bytes) => {
-                let msg_size = bytes.len();
                 debug!(
                     "{} Sending  {} message to session {:?} ({} bytes)",
                     Green.bold().paint("[>]"),
                     Green.bold().paint(msg.kind.to_string()),
                     self.remote_addr,
-                    msg_size,
+                    bytes.len(),
                 );
                 trace!("\t{:?}", msg);
                 self.framed.write(bytes.into());
@@ -158,6 +157,6 @@ impl Session {
             self.remote_addr,
             bytes.len(),
         );
-        debug!("\t{:?}", msg);
+        trace!("\t{:?}", msg);
     }
 }


### PR DESCRIPTION
Messages sent through the network now show the size in bytes.
Transaction messages now show the transaction hash, and last_beacon messages show the received beacon.
And logs are aligned so received and sent messages line up.

Sample:

```
[2019-12-03T14:29:30Z DEBUG witnet_node::actors::session] [>] Sending  LAST_BEACON: #278218: 4051c1e27d11fa91c95d60390af14f01154fd5c94c90d229e96f2c4070e58001 message to session V4(192.168.2.204:51350) (51 bytes)
[2019-12-03T14:29:30Z DEBUG witnet_node::actors::session] [<] Received LAST_BEACON: #278218: 4051c1e27d11fa91c95d60390af14f01154fd5c94c90d229e96f2c4070e58001 message from session V4(192.168.2.204:21337) (51 bytes)
[2019-12-03T14:37:30Z DEBUG witnet_node::actors::session] [>] Sending  REVEAL_TRANSACTION: e09f678008d0010ece6a0a718ee5044ca17ce802c0d7a9fad48cea2ab8e4b4f8 message to session V4(192.168.2.204:60280) (202 bytes)
[2019-12-03T14:37:30Z DEBUG witnet_node::actors::session] [<] Received REVEAL_TRANSACTION: e09f678008d0010ece6a0a718ee5044ca17ce802c0d7a9fad48cea2ab8e4b4f8 message from session V4(192.168.2.204:21337) (202 bytes)

```