### PR TITLE
Forbid dangerous operators in tally stage

### DIFF
--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -6,7 +6,7 @@ use serde_cbor::value::Value as SerdeCborValue;
 
 use witnet_data_structures::radon_error::{ErrorLike, RadonError, RadonErrors};
 
-use crate::types::array::RadonArray;
+use crate::{operators::RadonOpCodes, types::array::RadonArray};
 
 /// RAD errors.
 #[derive(Clone, Debug, PartialEq, Fail)]
@@ -105,6 +105,9 @@ pub enum RadError {
         operator
     )]
     UnsupportedOpNonHomogeneous { operator: String },
+    /// This operator cannot be used in tally stage
+    #[fail(display = "Operator {} cannot be used in tally stage", operator)]
+    UnsupportedOperatorInTally { operator: RadonOpCodes },
     /// There was a tie after applying the mode reducer
     #[fail(
         display = "There was a tie after applying the mode reducer on values: `{:?}`",

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -416,30 +416,6 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_liars4() {
-        use crate::types::integer::RadonInteger;
-
-        let reveals = vec![
-            RadonTypes::Integer(RadonInteger::from(1)),
-            RadonTypes::Integer(RadonInteger::from(0)),
-            RadonTypes::Integer(RadonInteger::from(0)),
-        ];
-        let mode_reducer = RADTally {
-            script: vec![129, 130, 24, 87, 2],
-        };
-        let consensus = run_tally_report(reveals, &mode_reducer).unwrap();
-        let expected_result = RadonTypes::Integer(RadonInteger::from(0));
-        let expected_liars = vec![true, false, false];
-        assert_eq!(consensus.result.unwrap(), expected_result);
-        let tally_metadata = if let Stage::Tally(tm) = consensus.metadata {
-            tm
-        } else {
-            panic!("No tally stage");
-        };
-        assert_eq!(tally_metadata.liars, expected_liars);
-    }
-
-    #[test]
     fn test_run_consensus_with_liar() {
         let f_1 = RadonTypes::Float(RadonFloat::from(1f64));
         let f_3 = RadonTypes::Float(RadonFloat::from(3f64));
@@ -499,8 +475,13 @@ mod tests {
                 Value::Float(1.0),
             ]),
             Value::Array(vec![
+                Value::Integer(RadonOpCodes::ArrayFilter as i128),
+                Value::Integer(RadonFilters::DeviationStandard as i128),
+                Value::Float(1.0),
+            ]),
+            Value::Array(vec![
                 Value::Integer(RadonOpCodes::ArrayReduce as i128),
-                Value::Integer(RadonReducers::Mode as i128),
+                Value::Integer(RadonReducers::AverageMean as i128),
             ]),
         ]);
 

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -510,6 +510,44 @@ mod tests {
     }
 
     #[test]
+    fn test_mode_reducer_not_affecting_liars() {
+        let f_1 = RadonTypes::Float(RadonFloat::from(1f64));
+        let f_2 = RadonTypes::Float(RadonFloat::from(3f64));
+        let f_3 = RadonTypes::Float(RadonFloat::from(3f64));
+        let f_out = RadonTypes::Float(RadonFloat::from(10000f64));
+
+        let radon_types_vec = vec![f_1, f_2, f_3, f_out];
+
+        let script = Value::Array(vec![Value::Array(vec![
+            Value::Integer(RadonOpCodes::ArrayReduce as i128),
+            Value::Integer(RadonReducers::Mode as i128),
+        ])]);
+
+        let packed_script = serde_cbor::to_vec(&script).unwrap();
+
+        let expected = RadonTypes::Float(RadonFloat::from(3f64));
+
+        let report = run_tally_report(
+            radon_types_vec,
+            &RADTally {
+                script: packed_script,
+            },
+        )
+        .unwrap();
+
+        let output_tally = report.clone().into_inner().unwrap();
+        assert_eq!(output_tally, expected);
+
+        let expected_liars = vec![false, false, false, false];
+        let tally_metadata = if let Stage::Tally(tm) = report.metadata {
+            tm
+        } else {
+            panic!("No tally stage");
+        };
+        assert_eq!(tally_metadata.liars, expected_liars);
+    }
+
+    #[test]
     fn test_error_sort_in_tally_stage() {
         let f_1 = RadonTypes::Integer(RadonInteger::from(1));
         let f_3 = RadonTypes::Integer(RadonInteger::from(3));

--- a/rad/src/operators/array.rs
+++ b/rad/src/operators/array.rs
@@ -15,11 +15,7 @@ pub fn count(input: &RadonArray) -> RadonInteger {
     RadonInteger::from(input.value().len() as i128)
 }
 
-pub fn reduce(
-    input: &RadonArray,
-    args: &[Value],
-    context: &mut ReportContext,
-) -> Result<RadonTypes, RadError> {
+pub fn reduce(input: &RadonArray, args: &[Value]) -> Result<RadonTypes, RadError> {
     let wrong_args = || RadError::WrongArguments {
         input_type: "RadonArray".to_string(),
         operator: "Reduce".to_string(),
@@ -34,7 +30,7 @@ pub fn reduce(
     let reducer_integer = from_value::<u8>(arg).map_err(|_| wrong_args())?;
     let reducer_code = RadonReducers::try_from(reducer_integer).map_err(|_| wrong_args())?;
 
-    reducers::reduce(input, reducer_code, context)
+    reducers::reduce(input, reducer_code)
 }
 
 pub fn get(input: &RadonArray, args: &[Value]) -> Result<RadonTypes, RadError> {
@@ -282,7 +278,7 @@ fn test_reduce_no_args() {
     ]);
     let args = &[];
 
-    let result = reduce(input, args, &mut ReportContext::default());
+    let result = reduce(input, args);
 
     assert_eq!(
         &result.unwrap_err().to_string(),
@@ -300,7 +296,7 @@ fn test_reduce_wrong_args() {
     ]);
     let args = &[Value::Text(String::from("wrong"))]; // This is RadonReducers::AverageMean
 
-    let result = reduce(input, args, &mut ReportContext::default());
+    let result = reduce(input, args);
 
     assert_eq!(
         &result.unwrap_err().to_string(),
@@ -318,7 +314,7 @@ fn test_reduce_unknown_reducer() {
     ]);
     let args = &[Value::Integer(-1)]; // This doesn't match any reducer code in RadonReducers
 
-    let result = reduce(input, args, &mut ReportContext::default());
+    let result = reduce(input, args);
 
     assert_eq!(
         &result.unwrap_err().to_string(),

--- a/rad/src/operators/mod.rs
+++ b/rad/src/operators/mod.rs
@@ -163,7 +163,12 @@ pub fn identity(input: RadonTypes) -> Result<RadonTypes, RadError> {
 pub fn check_valid_operator_for_tally_stage(call: &RadonCall) -> Result<(), RadError> {
     // List of forbidden operators.
     // When this list grows and performance starts to be a concern, use a bitset instead
-    const FORBIDDEN_IN_TALLY: [RadonOpCodes; 2] = [RadonOpCodes::ArraySort, RadonOpCodes::ArrayGet];
+    const FORBIDDEN_IN_TALLY: [RadonOpCodes; 4] = [
+        RadonOpCodes::ArrayCount,
+        RadonOpCodes::ArrayGet,
+        RadonOpCodes::ArrayMap,
+        RadonOpCodes::ArraySort,
+    ];
 
     if FORBIDDEN_IN_TALLY.contains(&call.0) {
         Err(RadError::UnsupportedOperatorInTally { operator: call.0 })

--- a/rad/src/operators/mod.rs
+++ b/rad/src/operators/mod.rs
@@ -154,29 +154,6 @@ pub fn identity(input: RadonTypes) -> Result<RadonTypes, RadError> {
     Ok(input)
 }
 
-/// Check if the operator can be used in a tally script.
-///
-/// Some operators cannot be used in the tally stage because they are considered to be
-/// "consensus unsafe".
-///
-/// For example, sorting the input is forbidden.
-pub fn check_valid_operator_for_tally_stage(call: &RadonCall) -> Result<(), RadError> {
-    // List of forbidden operators.
-    // When this list grows and performance starts to be a concern, use a bitset instead
-    const FORBIDDEN_IN_TALLY: [RadonOpCodes; 4] = [
-        RadonOpCodes::ArrayCount,
-        RadonOpCodes::ArrayGet,
-        RadonOpCodes::ArrayMap,
-        RadonOpCodes::ArraySort,
-    ];
-
-    if FORBIDDEN_IN_TALLY.contains(&call.0) {
-        Err(RadError::UnsupportedOperatorInTally { operator: call.0 })
-    } else {
-        Ok(())
-    }
-}
-
 #[test]
 pub fn test_identity() {
     use crate::types::string::RadonString;

--- a/rad/src/operators/mod.rs
+++ b/rad/src/operators/mod.rs
@@ -163,7 +163,7 @@ pub fn identity(input: RadonTypes) -> Result<RadonTypes, RadError> {
 pub fn check_valid_operator_for_tally_stage(call: &RadonCall) -> Result<(), RadError> {
     // List of forbidden operators.
     // When this list grows and performance starts to be a concern, use a bitset instead
-    const FORBIDDEN_IN_TALLY: [RadonOpCodes; 1] = [RadonOpCodes::ArraySort];
+    const FORBIDDEN_IN_TALLY: [RadonOpCodes; 2] = [RadonOpCodes::ArraySort, RadonOpCodes::ArrayGet];
 
     if FORBIDDEN_IN_TALLY.contains(&call.0) {
         Err(RadError::UnsupportedOperatorInTally { operator: call.0 })

--- a/rad/src/reducers/average.rs
+++ b/rad/src/reducers/average.rs
@@ -73,7 +73,6 @@ mod tests {
         types::{float::RadonFloat, integer::RadonInteger, string::RadonString},
     };
     use serde_cbor::Value;
-    use witnet_data_structures::radon_report::ReportContext;
 
     #[test]
     fn test_reduce_average_mean_float() {
@@ -84,7 +83,7 @@ mod tests {
         let args = &[Value::Integer(0x03)]; // This is RadonReducers::AverageMean
         let expected = RadonTypes::from(RadonFloat::from(1.5f64));
 
-        let output = reduce(input, args, &mut ReportContext::default()).unwrap();
+        let output = reduce(input, args).unwrap();
 
         assert_eq!(output, expected);
     }
@@ -107,7 +106,7 @@ mod tests {
         ]));
 
         let args = &[Value::Integer(0x03)]; // This is RadonReducers::AverageMean
-        let output = reduce(&input, args, &mut ReportContext::default()).unwrap();
+        let output = reduce(&input, args).unwrap();
 
         assert_eq!(output, expected);
     }
@@ -132,7 +131,7 @@ mod tests {
         };
 
         let args = &[Value::Integer(0x03)]; // This is RadonReducers::AverageMean
-        let output = reduce(&input, args, &mut ReportContext::default()).unwrap_err();
+        let output = reduce(&input, args).unwrap_err();
 
         assert_eq!(output, expected);
     }
@@ -183,7 +182,7 @@ mod tests {
         let expected = RadonTypes::from(RadonArray::from(vec![array_e1, array_e2, array_e3]));
 
         let args = &[Value::Integer(0x03)]; // This is RadonReducers::AverageMean
-        let output = reduce(&input, args, &mut ReportContext::default()).unwrap();
+        let output = reduce(&input, args).unwrap();
 
         assert_eq!(output, expected);
     }
@@ -204,7 +203,7 @@ mod tests {
         let args = &[Value::Integer(0x03)]; // This is RadonReducers::AverageMean
         let expected = RadonTypes::from(RadonFloat::from(1.5f64));
 
-        let output = reduce(input, args, &mut ReportContext::default()).unwrap();
+        let output = reduce(input, args).unwrap();
 
         assert_eq!(output, expected);
     }
@@ -227,7 +226,7 @@ mod tests {
         ]));
 
         let args = &[Value::Integer(0x03)]; // This is RadonReducers::AverageMean
-        let output = reduce(&input, args, &mut ReportContext::default()).unwrap();
+        let output = reduce(&input, args).unwrap();
 
         assert_eq!(output, expected);
     }
@@ -239,7 +238,7 @@ mod tests {
             RadonString::from("world").into(),
         ]);
         let args = &[Value::Integer(0x03)]; // This is RadonReducers::AverageMean
-        let output = reduce(input, args, &mut ReportContext::default()).unwrap_err();
+        let output = reduce(input, args).unwrap_err();
 
         let expected = RadError::UnsupportedReducer {
             inner_type: "RadonString".to_string(),
@@ -268,7 +267,7 @@ mod tests {
         };
 
         let args = &[Value::Integer(0x03)]; // This is RadonReducers::AverageMean
-        let output = reduce(&input, args, &mut ReportContext::default()).unwrap_err();
+        let output = reduce(&input, args).unwrap_err();
 
         assert_eq!(output, expected);
     }

--- a/rad/src/reducers/mod.rs
+++ b/rad/src/reducers/mod.rs
@@ -6,7 +6,6 @@ use crate::{
     error::RadError,
     types::{array::RadonArray, RadonType, RadonTypes},
 };
-use witnet_data_structures::radon_report::ReportContext;
 
 pub mod average;
 pub mod deviation;
@@ -34,11 +33,7 @@ impl fmt::Display for RadonReducers {
     }
 }
 
-pub fn reduce(
-    input: &RadonArray,
-    reducer_code: RadonReducers,
-    context: &mut ReportContext,
-) -> Result<RadonTypes, RadError> {
+pub fn reduce(input: &RadonArray, reducer_code: RadonReducers) -> Result<RadonTypes, RadError> {
     let error = || {
         Err(RadError::UnsupportedReducer {
             inner_type: format!("{:?}", input.inner_type()),
@@ -49,7 +44,7 @@ pub fn reduce(
     if input.is_homogeneous() || input.value().is_empty() {
         match reducer_code {
             RadonReducers::AverageMean => average::mean(input),
-            RadonReducers::Mode => mode::mode(input, context),
+            RadonReducers::Mode => mode::mode(input),
             RadonReducers::DeviationStandard => deviation::standard(input),
             _ => error(),
         }

--- a/rad/src/reducers/mode.rs
+++ b/rad/src/reducers/mode.rs
@@ -3,16 +3,15 @@ use crate::{
     types::{array::RadonArray, RadonType, RadonTypes},
 };
 use std::collections::HashMap;
-use witnet_data_structures::radon_report::{ReportContext, Stage};
 
-pub fn mode(input: &RadonArray, context: &mut ReportContext) -> Result<RadonTypes, RadError> {
-    let array = input.value();
+pub fn mode(input: &RadonArray) -> Result<RadonTypes, RadError> {
+    let value = input.value();
 
     let mut counter: HashMap<RadonTypes, i8> = HashMap::new();
 
     // Count how many times does each different item appear in the input array
-    for item in array.iter() {
-        *counter.entry(item.clone()).or_insert(0) += 1;
+    for item in value {
+        *counter.entry(item).or_insert(0) += 1;
     }
 
     let temp_counter = counter.clone();
@@ -36,143 +35,96 @@ pub fn mode(input: &RadonArray, context: &mut ReportContext) -> Result<RadonType
             values: input.clone(),
         })
     } else {
-        let mode = mode_vector[0].clone();
-
-        if let Stage::Tally(ref mut metadata) = context.stage {
-            let liars: Vec<bool> = array.iter().map(|item| item != &mode).collect();
-
-            metadata.update_liars(liars);
-        }
-
-        Ok(mode)
+        Ok(mode_vector[0].clone())
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use witnet_data_structures::radon_report::TallyMetaData;
+#[test]
+fn test_operate_reduce_mode_float() {
+    use crate::types::float::RadonFloat;
 
-    #[test]
-    fn test_operate_reduce_mode_float() {
-        use crate::types::float::RadonFloat;
+    let input = RadonArray::from(vec![
+        RadonFloat::from(1f64).into(),
+        RadonFloat::from(2f64).into(),
+        RadonFloat::from(2f64).into(),
+    ]);
+    let _expected = RadonTypes::from(RadonFloat::from(2f64));
+    let output = mode(&input).unwrap();
+    assert_eq!(output, _expected);
+}
 
-        let input = RadonArray::from(vec![
-            RadonFloat::from(1f64).into(),
-            RadonFloat::from(2f64).into(),
-            RadonFloat::from(2f64).into(),
-        ]);
-        let expected = RadonTypes::from(RadonFloat::from(2f64));
+#[test]
+fn test_operate_reduce_mode_float_invalid() {
+    use crate::types::float::RadonFloat;
 
-        let mut context = ReportContext::default();
-        context.stage = Stage::Tally(TallyMetaData::default());
+    let input = RadonArray::from(vec![
+        RadonFloat::from(1f64).into(),
+        RadonFloat::from(2f64).into(),
+    ]);
 
-        let output = mode(&input, &mut context).unwrap();
+    let output = mode(&input).unwrap_err();
 
-        assert_eq!(output, expected);
+    assert_eq!(output.to_string(), "There was a tie after applying the mode reducer on values: `RadonArray { value: [Float(RadonFloat { value: 1.0 }), Float(RadonFloat { value: 2.0 })], inner_type: Discriminant(3) }`".to_string());
+}
 
-        if let Stage::Tally(metadata) = context.stage {
-            assert_eq!(metadata.liars, vec![true, false, false]);
-        } else {
-            panic!("Not tally stage");
-        }
-    }
+#[test]
+fn test_operate_reduce_mode_int() {
+    use crate::types::integer::RadonInteger;
 
-    #[test]
-    fn test_operate_reduce_mode_float_invalid() {
-        use crate::types::float::RadonFloat;
+    let input = RadonArray::from(vec![
+        RadonInteger::from(1i128).into(),
+        RadonInteger::from(2i128).into(),
+        RadonInteger::from(2i128).into(),
+    ]);
+    let _expected = RadonTypes::from(RadonInteger::from(2i128));
+    let output = mode(&input).unwrap();
+    assert_eq!(output, _expected);
+}
 
-        let input = RadonArray::from(vec![
-            RadonFloat::from(1f64).into(),
-            RadonFloat::from(2f64).into(),
-        ]);
+#[test]
+fn test_operate_reduce_mode_int_invalid() {
+    use crate::types::integer::RadonInteger;
 
-        let output = mode(&input, &mut ReportContext::default()).unwrap_err();
+    let input = RadonArray::from(vec![
+        RadonInteger::from(1i128).into(),
+        RadonInteger::from(2i128).into(),
+    ]);
+    let output = mode(&input).unwrap_err();
+    assert_eq!(output.to_string(), "There was a tie after applying the mode reducer on values: `RadonArray { value: [Integer(RadonInteger { value: 1 }), Integer(RadonInteger { value: 2 })], inner_type: Discriminant(4) }`".to_string());
+}
 
-        assert_eq!(output.to_string(), "There was a tie after applying the mode reducer on values: `RadonArray { value: [Float(RadonFloat { value: 1.0 }), Float(RadonFloat { value: 2.0 })], inner_type: Discriminant(3) }`".to_string());
-    }
+#[test]
+fn test_operate_reduce_mode_str() {
+    use crate::types::string::RadonString;
 
-    #[test]
-    fn test_operate_reduce_mode_int() {
-        use crate::types::integer::RadonInteger;
+    let input = RadonArray::from(vec![
+        RadonString::from("Hello world!").into(),
+        RadonString::from("Hello world!").into(),
+        RadonString::from("Bye world!").into(),
+    ]);
+    let expected = RadonString::from("Hello world!").into();
+    let output = mode(&input).unwrap();
+    assert_eq!(output, expected);
+}
 
-        let input = RadonArray::from(vec![
-            RadonInteger::from(1i128).into(),
-            RadonInteger::from(2i128).into(),
-            RadonInteger::from(2i128).into(),
-        ]);
-        let expected = RadonTypes::from(RadonInteger::from(2i128));
+#[test]
+fn test_operate_reduce_mode_str_invalid() {
+    use crate::types::string::RadonString;
 
-        let mut context = ReportContext::default();
-        context.stage = Stage::Tally(TallyMetaData::default());
+    let input = RadonArray::from(vec![
+        RadonString::from("Hello world!").into(),
+        RadonString::from("Bye world!").into(),
+    ]);
+    let output = mode(&input).unwrap_err();
+    assert_eq!(output.to_string(), "There was a tie after applying the mode reducer on values: `RadonArray { value: [String(RadonString { value: \"Hello world!\" }), String(RadonString { value: \"Bye world!\" })], inner_type: Discriminant(8) }`");
+}
 
-        let output = mode(&input, &mut context).unwrap();
-
-        assert_eq!(output, expected);
-
-        if let Stage::Tally(metadata) = context.stage {
-            assert_eq!(metadata.liars, vec![true, false, false]);
-        } else {
-            panic!("Not tally stage");
-        }
-    }
-
-    #[test]
-    fn test_operate_reduce_mode_int_invalid() {
-        use crate::types::integer::RadonInteger;
-
-        let input = RadonArray::from(vec![
-            RadonInteger::from(1i128).into(),
-            RadonInteger::from(2i128).into(),
-        ]);
-        let output = mode(&input, &mut ReportContext::default()).unwrap_err();
-        assert_eq!(output.to_string(), "There was a tie after applying the mode reducer on values: `RadonArray { value: [Integer(RadonInteger { value: 1 }), Integer(RadonInteger { value: 2 })], inner_type: Discriminant(4) }`".to_string());
-    }
-
-    #[test]
-    fn test_operate_reduce_mode_str() {
-        use crate::types::string::RadonString;
-
-        let input = RadonArray::from(vec![
-            RadonString::from("Hello world!").into(),
-            RadonString::from("Hello world!").into(),
-            RadonString::from("Bye world!").into(),
-        ]);
-        let expected = RadonString::from("Hello world!").into();
-
-        let mut context = ReportContext::default();
-        context.stage = Stage::Tally(TallyMetaData::default());
-
-        let output = mode(&input, &mut context).unwrap();
-
-        assert_eq!(output, expected);
-
-        if let Stage::Tally(metadata) = context.stage {
-            assert_eq!(metadata.liars, vec![false, false, true]);
-        } else {
-            panic!("Not tally stage");
-        }
-    }
-
-    #[test]
-    fn test_operate_reduce_mode_str_invalid() {
-        use crate::types::string::RadonString;
-
-        let input = RadonArray::from(vec![
-            RadonString::from("Hello world!").into(),
-            RadonString::from("Bye world!").into(),
-        ]);
-        let output = mode(&input, &mut ReportContext::default()).unwrap_err();
-        assert_eq!(output.to_string(), "There was a tie after applying the mode reducer on values: `RadonArray { value: [String(RadonString { value: \"Hello world!\" }), String(RadonString { value: \"Bye world!\" })], inner_type: Discriminant(8) }`");
-    }
-
-    #[test]
-    fn test_operate_reduce_mode_empty() {
-        let input = RadonArray::from(vec![]);
-        let output = mode(&input, &mut ReportContext::default()).unwrap_err();
-        assert_eq!(
-            output.to_string(),
-            "Tried to apply mode reducer on an empty array"
-        );
-    }
+#[test]
+fn test_operate_reduce_mode_empty() {
+    let input = RadonArray::from(vec![]);
+    let output = mode(&input).unwrap_err();
+    assert_eq!(
+        output.to_string(),
+        "Tried to apply mode reducer on an empty array"
+    );
 }

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -153,7 +153,7 @@ impl Operable for RadonArray {
             }
             (RadonOpCodes::ArrayMap, Some(args)) => array_operators::map(self, args.as_slice()),
             (RadonOpCodes::ArrayReduce, Some(args)) => {
-                array_operators::reduce(self, args.as_slice(), &mut ReportContext::default())
+                array_operators::reduce(self, args.as_slice())
             }
             (RadonOpCodes::ArraySort, Some(args)) => {
                 array_operators::sort(self, args.as_slice()).map(RadonTypes::from)
@@ -179,9 +179,6 @@ impl Operable for RadonArray {
         match call {
             (RadonOpCodes::ArrayFilter, Some(args)) => {
                 array_operators::filter(self, args.as_slice(), context)
-            }
-            (RadonOpCodes::ArrayReduce, Some(args)) => {
-                array_operators::reduce(self, args.as_slice(), context)
             }
             other => self.operate(other),
         }

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -180,6 +180,13 @@ impl Operable for RadonArray {
             (RadonOpCodes::ArrayFilter, Some(args)) => {
                 array_operators::filter(self, args.as_slice(), context)
             }
+            (RadonOpCodes::ArrayReduce, Some(args)) => {
+                if let Stage::Tally(tm) = &mut context.stage {
+                    // Stop updating the liars vector after the first reduce
+                    tm.freeze_liars();
+                }
+                array_operators::reduce(self, args.as_slice())
+            }
             other => self.operate(other),
         }
     }

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -7,11 +7,14 @@ use std::{
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use serde_cbor::value::{from_value, Value};
 
-use witnet_data_structures::radon_report::ReportContext;
+use witnet_data_structures::radon_report::{ReportContext, Stage};
 
 use crate::{
     error::RadError,
-    operators::{array as array_operators, identity, Operable, RadonOpCodes},
+    operators::{
+        array as array_operators, check_valid_operator_for_tally_stage, identity, Operable,
+        RadonOpCodes,
+    },
     script::RadonCall,
     types::{
         float::RadonFloat, map::RadonMap, mixed::RadonMixed, string::RadonString, RadonType,
@@ -168,6 +171,9 @@ impl Operable for RadonArray {
         call: &RadonCall,
         context: &mut ReportContext,
     ) -> Result<RadonTypes, RadError> {
+        if let Stage::Tally { .. } = context.stage {
+            check_valid_operator_for_tally_stage(call)?;
+        }
         // Intercept filter operations for performing the filters in a context, otherwise use
         // context-free execution.
         match call {


### PR DESCRIPTION
The following operators are now forbidden from being used during the tally stage:

* All the array operators except `ArrayFilter` and `ArrayReduce`

This does not affect subscripts, only top-level operators, so for example `ArrayGet` can still be used inside an `ArrayFilter`.

Important change: reducers lose the ability to modify the liars vector. If a user wants to punish all the reveals different from the mode, they should use a filter instead.

Another important change: the liars vector is now frozen after the first reduce. This prevents an issue where running filters after a call to reduce resulted in an invalid liars vector. It also makes a lot of sense: we only want to penalize liars based on the values of the input array. Since a reduce consumes the input array, it does not make sense to penalize after that.

Close #904 