### PR TITLE
GetTransaction method

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1380,6 +1380,19 @@ impl TransactionsPool {
             retain
         });
     }
+
+    /// Get transaction by hash
+    // FIXME(#918): only vtt and drt are supported, commits and reveals are not indexed by hash
+    pub fn get(&self, hash: &Hash) -> Option<Transaction> {
+        self.vt_transactions
+            .get(hash)
+            .map(|(_weight, vtt)| Transaction::ValueTransfer(vtt.clone()))
+            .or_else(|| {
+                self.dr_transactions
+                    .get(hash)
+                    .map(|drt| Transaction::DataRequest(drt.clone()))
+            })
+    }
 }
 
 /// Unspent output data structure (equivalent of Bitcoin's UTXO)

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1440,7 +1440,7 @@ pub enum InventoryEntry {
     Block(Hash),
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, Serialize, Deserialize)]
 pub enum TransactionPointer {
     ValueTransfer(u32),
     DataRequest(u32),

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -20,9 +20,9 @@ use crate::{
         messages::{
             AddBlocks, AddCandidates, AddCommitReveal, AddTransaction, Anycast, Broadcast,
             BuildDrt, BuildVtt, EpochNotification, GetBalance, GetBlocksEpochRange,
-            GetDataRequestReport, GetHighestCheckpointBeacon, GetReputation, GetReputationAll,
-            GetReputationStatus, GetReputationStatusResult, GetState, PeersBeacons, SendLastBeacon,
-            SessionUnitResult, StoreInventoryItem, TryMineBlock,
+            GetDataRequestReport, GetHighestCheckpointBeacon, GetMemoryTransaction, GetReputation,
+            GetReputationAll, GetReputationStatus, GetReputationStatusResult, GetState,
+            PeersBeacons, SendLastBeacon, SessionUnitResult, StoreInventoryItem, TryMineBlock,
         },
         sessions_manager::SessionsManager,
     },
@@ -891,5 +891,13 @@ impl Handler<AddCommitReveal> for ChainManager {
         ) {
             log::warn!("Failed to add commit transaction: {}", e);
         }
+    }
+}
+
+impl Handler<GetMemoryTransaction> for ChainManager {
+    type Result = Result<Transaction, ()>;
+
+    fn handle(&mut self, msg: GetMemoryTransaction, _ctx: &mut Self::Context) -> Self::Result {
+        self.transactions_pool.get(&msg.hash).ok_or(())
     }
 }

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -496,11 +496,11 @@ impl Handler<PeersBeacons> for ChainManager {
                                 Ok(()) => {
                                     log::info!("Consolidate consensus candidate. Synced state");
                                     log::info!("{}", SYNCED_BANNER);
-                                    self.persist_item(
+                                    self.persist_items(
                                         ctx,
-                                        StoreInventoryItem::Block(Box::new(
+                                        vec![StoreInventoryItem::Block(Box::new(
                                             consensus_block.clone(),
-                                        )),
+                                        ))],
                                     );
                                     StateMachine::Synced
                                 }

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -6,7 +6,7 @@ use std::{cmp::Ordering, collections::HashMap};
 use witnet_data_structures::{
     chain::{
         ChainState, CheckpointBeacon, DataRequestInfo, DataRequestReport, Epoch, Hash, Hashable,
-        InventoryItem, PublicKeyHash, Reputation,
+        PublicKeyHash, Reputation,
     },
     error::{ChainInfoError, TransactionError::DataRequestNotFound},
     transaction::{DRTransaction, Transaction, VTTransaction},
@@ -22,7 +22,7 @@ use crate::{
             BuildDrt, BuildVtt, EpochNotification, GetBalance, GetBlocksEpochRange,
             GetDataRequestReport, GetHighestCheckpointBeacon, GetReputation, GetReputationAll,
             GetReputationStatus, GetReputationStatusResult, GetState, PeersBeacons, SendLastBeacon,
-            SessionUnitResult, TryMineBlock,
+            SessionUnitResult, StoreInventoryItem, TryMineBlock,
         },
         sessions_manager::SessionsManager,
     },
@@ -498,7 +498,9 @@ impl Handler<PeersBeacons> for ChainManager {
                                     log::info!("{}", SYNCED_BANNER);
                                     self.persist_item(
                                         ctx,
-                                        InventoryItem::Block(consensus_block.clone()),
+                                        StoreInventoryItem::Block(Box::new(
+                                            consensus_block.clone(),
+                                        )),
                                     );
                                     StateMachine::Synced
                                 }

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -60,7 +60,9 @@ use crate::{
     actors::{
         inventory_manager::InventoryManager,
         json_rpc::JsonRpcServer,
-        messages::{AddItem, AddTransaction, Broadcast, NewBlock, SendInventoryItem},
+        messages::{
+            AddItem, AddTransaction, Broadcast, NewBlock, SendInventoryItem, StoreInventoryItem,
+        },
         sessions_manager::SessionsManager,
         storage_keys::CHAIN_STATE_KEY,
     },
@@ -185,7 +187,7 @@ impl ChainManager {
     }
 
     /// Method to Send an Item to Inventory Manager
-    fn persist_item(&self, ctx: &mut Context<Self>, item: InventoryItem) {
+    fn persist_item(&self, ctx: &mut Context<Self>, item: StoreInventoryItem) {
         // Get InventoryManager address
         let inventory_manager_addr = InventoryManager::from_registry();
 
@@ -319,7 +321,7 @@ impl ChainManager {
     ) {
         for block in blocks {
             let block_hash = block.hash();
-            self.persist_item(ctx, InventoryItem::Block(block));
+            self.persist_item(ctx, StoreInventoryItem::Block(Box::new(block)));
 
             if block_hash == target_beacon.hash_prev_block {
                 break;
@@ -415,7 +417,7 @@ impl ChainManager {
                                 transaction: Transaction::Reveal(reveal),
                             })
                         }
-                        self.persist_item(ctx, InventoryItem::Block(block.clone()));
+                        self.persist_item(ctx, StoreInventoryItem::Block(Box::new(block.clone())));
 
                         // Persist chain_info into storage
                         self.persist_chain_state(ctx);

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -38,7 +38,7 @@ use actix::{
 use ansi_term::Color::{Purple, White, Yellow};
 use failure::Fail;
 use itertools::Itertools;
-use log::{debug, error, info, warn};
+use log::{error, info, trace, warn};
 
 use witnet_data_structures::{
     chain::{
@@ -173,7 +173,7 @@ impl ChainManager {
         storage_mngr::put(&CHAIN_STATE_KEY, &self.last_chain_state)
             .into_actor(self)
             .and_then(|_, _, _| {
-                debug!("Successfully persisted chain_info into storage");
+                trace!("Successfully persisted chain_info into storage");
                 fut::ok(())
             })
             .map_err(|err, _, _| error!("Failed to persist chain_info into storage: {}", err))
@@ -217,7 +217,7 @@ impl ChainManager {
             .into_actor(self)
             .map_err(|e, _, _| error!("Failed to persist data request report into storage: {}", e))
             .and_then(move |_, _, _| {
-                debug!(
+                trace!(
                     "Successfully persisted report for data request {} into storage",
                     dr_pointer_string
                 );

--- a/node/src/actors/inventory_manager/handlers.rs
+++ b/node/src/actors/inventory_manager/handlers.rs
@@ -3,9 +3,9 @@ use actix::{ActorFuture, Context, Handler, ResponseActFuture, WrapFuture};
 use log;
 
 use super::{InventoryManager, InventoryManagerError};
-use crate::actors::messages::{AddItem, GetItem};
+use crate::actors::messages::{AddItem, GetItem, StoreInventoryItem};
 use crate::storage_mngr;
-use witnet_data_structures::chain::{Hash, Hashable, InventoryItem};
+use witnet_data_structures::chain::{Block, Hash, Hashable, InventoryItem, PointerToBlock};
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // ACTOR MESSAGE HANDLERS
@@ -16,26 +16,59 @@ impl Handler<AddItem> for InventoryManager {
     type Result = ResponseActFuture<Self, (), InventoryManagerError>;
 
     fn handle(&mut self, msg: AddItem, _ctx: &mut Context<Self>) -> Self::Result {
-        let hash = match &msg.item {
-            InventoryItem::Block(item) => item.hash(),
-            InventoryItem::Transaction(item) => item.hash(),
-        };
+        match msg.item {
+            StoreInventoryItem::Block(block) => {
+                let block_hash = block.hash();
+                let mut key = match block_hash {
+                    Hash::SHA256(h) => h.to_vec(),
+                };
+                // Add prefix to key to avoid confusing blocks with transactions
+                key.insert(0, b'B');
+                let fut = storage_mngr::put(&key, &block)
+                    .into_actor(self)
+                    .map_err(|e, _, _| {
+                        log::error!("Couldn't persist block in storage: {}", e);
+                        InventoryManagerError::MailBoxError(e)
+                    })
+                    .and_then(move |_, _, ctx| {
+                        log::debug!("Successfully persisted block in storage");
+                        // Store all the transactions as well
+                        let items_to_add = block.txns.create_pointers_to_transactions(block_hash);
 
-        let key = match hash {
-            Hash::SHA256(h) => h.to_vec(),
-        };
-        let fut = storage_mngr::put(&key, &msg.item)
-            .into_actor(self)
-            .map_err(|e, _, _| {
-                log::error!("Couldn't persist item in storage: {}", e);
-                InventoryManagerError::MailBoxError(e)
-            })
-            .and_then(|_, _, _| {
-                log::debug!("Successfully persisted item in storage");
-                fut::ok(())
-            });
+                        for (tx_hash, pointer_to_block) in items_to_add {
+                            // TODO: is it a good idea to saturate the actor this way?
+                            // TODO: implement AddItems
+                            ctx.notify(AddItem {
+                                item: StoreInventoryItem::Transaction(tx_hash, pointer_to_block),
+                            });
+                        }
 
-        Box::new(fut)
+                        fut::ok(())
+                    });
+
+                Box::new(fut)
+            }
+            StoreInventoryItem::Transaction(hash, pointer_to_block) => {
+                log::info!("Saving transaction {}", hash);
+                let mut key = match hash {
+                    Hash::SHA256(h) => h.to_vec(),
+                };
+                // Add prefix to key to avoid confusing blocks with transactions
+                key.insert(0, b'T');
+                let fut = storage_mngr::put(&key, &pointer_to_block)
+                    .into_actor(self)
+                    .map_err(|e, _, _| {
+                        log::error!("Couldn't persist transaction in storage: {}", e);
+                        InventoryManagerError::MailBoxError(e)
+                    })
+                    .and_then(|_, _, _| {
+                        log::debug!("Successfully persisted transaction in storage");
+                        fut::ok(())
+                    });
+
+                Box::new(fut)
+            }
+        }
     }
 }
 
@@ -44,19 +77,76 @@ impl Handler<GetItem> for InventoryManager {
     type Result = ResponseActFuture<Self, InventoryItem, InventoryManagerError>;
 
     fn handle(&mut self, msg: GetItem, _ctx: &mut Context<Self>) -> Self::Result {
-        let key = match msg.hash {
+        log::info!("Called GetItem {}", msg.hash);
+        let mut key_block = match msg.hash {
             Hash::SHA256(x) => x.to_vec(),
         };
+        // First try to read block
+        key_block.insert(0, b'B');
+        let mut key_transaction = key_block.clone();
+        key_transaction[0] = b'T';
 
-        let fut = storage_mngr::get::<_, InventoryItem>(&key)
+        let fut = storage_mngr::get::<_, Block>(&key_block)
             .into_actor(self)
-            .map_err(|e, _, _| {
-                log::error!("Couldn't get item from storage: {}", e);
-                InventoryManagerError::MailBoxError(e)
-            })
-            .and_then(|opt, _, _| match opt {
-                None => fut::err(InventoryManagerError::ItemNotFound),
-                Some(item) => fut::ok(item),
+            .then(move |res, act, _| match res {
+                Ok(opt) => match opt {
+                    None => {
+                        // If there is no block with that hash, assume it is a transaction
+                        let fut = storage_mngr::get::<_, PointerToBlock>(&key_transaction)
+                            .into_actor(act)
+                            .then(|res, act, ctx| match res {
+                                Ok(opt) => match opt {
+                                    None => { let fut: Self::Result = Box::new(fut::err(InventoryManagerError::ItemNotFound)); fut},
+                                    Some(pointer_to_block) => {
+                                        // Recursion
+                                        let fut = act.handle(GetItem { hash: pointer_to_block.block_hash }, ctx ).then(move |res, _, _| {
+                                            match res {
+                                                Ok(item) => {
+                                                    match item {
+                                                        InventoryItem::Block(block) => {
+                                                            // Read transaction from block
+                                                            let tx = block.txns.get(pointer_to_block.transaction_index);
+                                                            match tx {
+                                                                Some(tx) => fut::ok(InventoryItem::Transaction(tx)),
+                                                                // TODO: custom error
+                                                                None => fut::err(InventoryManagerError::ItemNotFound),
+                                                            }
+                                                        },
+                                                        InventoryItem::Transaction(_) => {
+                                                            // TODO: custom error
+                                                            fut::err(InventoryManagerError::ItemNotFound)
+                                                        },
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    log::error!("Couldn't get item from storage: {}", e);
+                                                    fut::err(e)
+                                                }
+                                            }
+                                        });
+
+                                        Box::new(fut)
+                                    },
+                                },
+                                Err(e) => {
+                                    log::error!("Couldn't get item from storage: {}", e);
+                                    let fut: Self::Result = Box::new(
+                                        fut::err(InventoryManagerError::MailBoxError(e))
+                                    );
+                                    fut
+                                }
+                            });
+                        Box::new(fut)
+                    }
+                    Some(block) => { let fut: Self::Result = Box::new(fut::ok(InventoryItem::Block(block))); fut }
+                }
+                Err(e) => {
+                    log::error!("Couldn't get item from storage: {}", e);
+                    let fut: Self::Result = Box::new(
+                        fut::err(InventoryManagerError::MailBoxError(e))
+                    );
+                    fut
+                }
             });
 
         Box::new(fut)

--- a/node/src/actors/inventory_manager/handlers.rs
+++ b/node/src/actors/inventory_manager/handlers.rs
@@ -36,7 +36,7 @@ impl Handler<AddItem> for InventoryManager {
                         InventoryManagerError::MailBoxError(e)
                     })
                     .and_then(move |_, _, ctx| {
-                        log::debug!("Successfully persisted block in storage");
+                        log::trace!("Successfully persisted block in storage");
                         // Store all the transactions as well
                         let items_to_add = block.txns.create_pointers_to_transactions(block_hash);
                         let items = items_to_add
@@ -65,7 +65,7 @@ impl Handler<AddItem> for InventoryManager {
                         InventoryManagerError::MailBoxError(e)
                     })
                     .and_then(|_, _, _| {
-                        log::debug!("Successfully persisted transaction in storage");
+                        log::trace!("Successfully persisted transaction in storage");
                         fut::ok(())
                     });
 

--- a/node/src/actors/inventory_manager/mod.rs
+++ b/node/src/actors/inventory_manager/mod.rs
@@ -3,6 +3,7 @@
 //! It acts as a single entry point for getting and putting inventory items from and into StorageManager. This creates one more degree of abstraction between how storage works and the node business logic of the app.mod actor;
 
 use failure::Fail;
+use witnet_data_structures::chain::PointerToBlock;
 
 mod actor;
 mod handlers;
@@ -17,6 +18,18 @@ pub enum InventoryManagerError {
     /// An item does not exist
     #[fail(display = "Item not found")]
     ItemNotFound,
+    /// A transaction pointer exists, but the corresponding block does not
+    #[fail(
+        display = "A transaction pointer exists, but the corresponding block does not: {:?}",
+        _0
+    )]
+    NoPointedBlock(PointerToBlock),
+    /// A transaction pointer exists, but the corresponding block does not contain that transaction
+    #[fail(
+        display = "A transaction pointer exists, but the corresponding block does not contain that transaction: {:?}",
+        _0
+    )]
+    NoTransactionInPointedBlock(PointerToBlock),
     /// MailBoxError
     #[fail(display = "{}", _0)]
     MailBoxError(failure::Error),

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -403,8 +403,8 @@ impl Message for AddItem {
 
 /// Ask for an item identified by its hash
 pub struct GetItem {
-    /// item hash
-    pub hash: Hash,
+    /// item kind and hash
+    pub item: InventoryEntry,
 }
 
 impl Message for GetItem {

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -15,8 +15,8 @@ use witnet_data_structures::radon_report::RadonReport;
 use witnet_data_structures::{
     chain::{
         Block, CheckpointBeacon, DataRequestInfo, DataRequestOutput, Epoch, EpochConstants, Hash,
-        InventoryEntry, InventoryItem, PublicKeyHash, RADRequest, RADTally, Reputation,
-        ValueTransferOutput,
+        InventoryEntry, InventoryItem, PointerToBlock, PublicKeyHash, RADRequest, RADTally,
+        Reputation, ValueTransferOutput,
     },
     transaction::{CommitTransaction, RevealTransaction, Transaction},
 };
@@ -382,10 +382,19 @@ impl Message for GetEpochConstants {
 // MESSAGES FROM INVENTORY MANAGER
 ////////////////////////////////////////////////////////////////////////////////////////
 
+/// Inventory element: block, txns
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum StoreInventoryItem {
+    /// Blocks are stored with all the transactions inside
+    Block(Box<Block>),
+    /// Transactions are stored as pointers to blocks
+    Transaction(Hash, PointerToBlock),
+}
+
 /// Add a new item
 pub struct AddItem {
     /// Item
-    pub item: InventoryItem,
+    pub item: StoreInventoryItem,
 }
 
 impl Message for AddItem {

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -259,6 +259,16 @@ impl Message for AddCommitReveal {
     type Result = ();
 }
 
+/// Get transaction from mempool by hash
+pub struct GetMemoryTransaction {
+    /// item hash
+    pub hash: Hash,
+}
+
+impl Message for GetMemoryTransaction {
+    type Result = Result<Transaction, ()>;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // MESSAGES FROM CONNECTIONS MANAGER
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -411,6 +411,16 @@ impl Message for AddItem {
     type Result = Result<(), InventoryManagerError>;
 }
 
+/// Add a new item
+pub struct AddItems {
+    /// Item
+    pub items: Vec<StoreInventoryItem>,
+}
+
+impl Message for AddItems {
+    type Result = ();
+}
+
 /// Ask for an item identified by its hash
 pub struct GetItem {
     /// item kind and hash

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -448,7 +448,7 @@ pub struct GetItemTransaction {
 }
 
 impl Message for GetItemTransaction {
-    type Result = Result<Transaction, InventoryManagerError>;
+    type Result = Result<(Transaction, PointerToBlock), InventoryManagerError>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -411,6 +411,26 @@ impl Message for GetItem {
     type Result = Result<InventoryItem, InventoryManagerError>;
 }
 
+/// Ask for an item identified by its hash
+pub struct GetItemBlock {
+    /// item hash
+    pub hash: Hash,
+}
+
+impl Message for GetItemBlock {
+    type Result = Result<Block, InventoryManagerError>;
+}
+
+/// Ask for an item identified by its hash
+pub struct GetItemTransaction {
+    /// item hash
+    pub hash: Hash,
+}
+
+impl Message for GetItemTransaction {
+    type Result = Result<Transaction, InventoryManagerError>;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // MESSAGES FROM PEERS MANAGER
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/node/src/actors/peers_manager/mod.rs
+++ b/node/src/actors/peers_manager/mod.rs
@@ -51,7 +51,7 @@ impl PeersManager {
             storage_mngr::put(&PEERS_KEY, &act.peers)
                 .into_actor(act)
                 .and_then(|_, _, _| {
-                    log::debug!("PeersManager successfully persisted peers to storage");
+                    log::trace!("PeersManager successfully persisted peers to storage");
                     fut::ok(())
                 })
                 .map_err(|err, _, _| {

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -165,11 +165,7 @@ impl StreamHandler<BytesMut, Error> for Session {
                         let inventory_mngr = InventoryManager::from_registry();
                         let item_requests: Vec<_> = inventory
                             .iter()
-                            .map(|item| match item {
-                                InventoryEntry::Block(hash) | InventoryEntry::Tx(hash) => {
-                                    inventory_mngr.send(GetItem { hash: *hash })
-                                }
-                            })
+                            .map(|item| inventory_mngr.send(GetItem { item: item.clone() }))
                             .collect();
 
                         future::join_all(item_requests)

--- a/node/src/signature_mngr.rs
+++ b/node/src/signature_mngr.rs
@@ -107,7 +107,7 @@ fn persist_master_key(master_key: ExtendedSK) -> impl Future<Item = (), Error = 
     let master_key = ExtendedSecretKey::from(master_key);
 
     storage_mngr::put(&MASTER_KEY, &master_key).inspect(|_| {
-        log::debug!("Successfully persisted the extended secret key into storage");
+        log::trace!("Successfully persisted the extended secret key into storage");
     })
 }
 

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -170,6 +170,19 @@ pub fn get_block(addr: SocketAddr, hash: String) -> Result<(), failure::Error> {
     Ok(())
 }
 
+pub fn get_transaction(addr: SocketAddr, hash: String) -> Result<(), failure::Error> {
+    let mut stream = start_client(addr)?;
+    let request = format!(
+        r#"{{"jsonrpc": "2.0","method": "getTransaction", "params": [{:?}], "id": "1"}}"#,
+        hash,
+    );
+    let response = send_request(&mut stream, &request)?;
+
+    println!("{}", response);
+
+    Ok(())
+}
+
 pub fn get_output(addr: SocketAddr, pointer: String) -> Result<(), failure::Error> {
     let mut _stream = start_client(addr)?;
     let output_pointer = OutputPointer::from_str(&pointer)?;

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -13,6 +13,9 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
         Command::Block { node, hash } => {
             rpc::get_block(node.unwrap_or(config.jsonrpc.server_address), hash)
         }
+        Command::GetTransaction { node, hash } => {
+            rpc::get_transaction(node.unwrap_or(config.jsonrpc.server_address), hash)
+        }
         Command::BlockChain { node, epoch, limit } => {
             rpc::get_blockchain(node.unwrap_or(config.jsonrpc.server_address), epoch, limit)
         }
@@ -113,6 +116,14 @@ pub enum Command {
         #[structopt(short = "n", long = "node")]
         node: Option<SocketAddr>,
         #[structopt(name = "hash", help = "SHA-256 block hash in hex format")]
+        hash: String,
+    },
+    #[structopt(name = "getTransaction", about = "Find a transaction by its hash ")]
+    GetTransaction {
+        /// Socket address of the Witnet node to query.
+        #[structopt(short = "n", long = "node")]
+        node: Option<SocketAddr>,
+        #[structopt(name = "hash", help = "SHA-256 transaction hash in hex format")]
         hash: String,
     },
     #[structopt(name = "getBalance", about = "Get total balance of the given account")]

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -10,7 +10,7 @@ use super::json_rpc_client as rpc;
 
 pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Error> {
     match command {
-        Command::Block { node, hash } => {
+        Command::GetBlock { node, hash } => {
             rpc::get_block(node.unwrap_or(config.jsonrpc.server_address), hash)
         }
         Command::GetTransaction { node, hash } => {
@@ -110,15 +110,23 @@ pub enum Command {
         #[structopt(long = "limit", default_value = "0")]
         limit: u32,
     },
-    #[structopt(name = "block", about = "Find a block by its hash ")]
-    Block {
+    #[structopt(
+        name = "getBlock",
+        alias = "block",
+        about = "Find a block by its hash "
+    )]
+    GetBlock {
         /// Socket address of the Witnet node to query.
         #[structopt(short = "n", long = "node")]
         node: Option<SocketAddr>,
         #[structopt(name = "hash", help = "SHA-256 block hash in hex format")]
         hash: String,
     },
-    #[structopt(name = "getTransaction", about = "Find a transaction by its hash ")]
+    #[structopt(
+        name = "getTransaction",
+        alias = "transaction",
+        about = "Find a transaction by its hash "
+    )]
     GetTransaction {
         /// Socket address of the Witnet node to query.
         #[structopt(short = "n", long = "node")]


### PR DESCRIPTION
Close #457, close #498

Note: since this changes the format of stored blocks, the storage needs to be erased to avoid errors. Specifically, blocks were stored as `InventoryItem`, but are now stored as simply `Block`.

Works with value transfer and data request transactions even if they are not included in a block
Only works with commits and reveals if they are already included in consolidated blocks (issue #918)

The format of the result of `getTransaction` includes the block hash: `{"blockHash": "...", "transaction": {}}`

There is a JSON-RPC `getTransaction` method and also a CLI `getTransaction` method:

```
$ cargo run -- node getTransaction ea057a62adcee2903aa3e1a78d44f67da0cc7f7946d3eb1402445154c0eae7fb
```

However the CLI method just prints the JSON, it is not using a human friendly format yet.

Sample output

```
{"jsonrpc":"2.0","result":{"blockHash":"7130b8ea8305f1f6fc2fae9e60548843212975cdd28a8e6129b2fc4a2cbe5690","transaction":{"ValueTransfer":{"body":{"inputs":[{"output_pointer":"ced28d0dab128a1c6ed4a44bb29872692b83dc9e30e89c3e553e4b07f699ce58:0"}],"outputs":[{"pkh":"twit1ghladw0m9kyvl75ufthar0rzrmmzm9p62alrrn","time_lock":0,"value":1},{"pkh":"twit1ghladw0m9kyvl75ufthar0rzrmmzm9p62alrrn","time_lock":0,"value":49999997725}]},"signatures":[{"public_key":{"bytes":[181,133,29,222,114,236,53,4,201,31,254,93,175,41,82,83,114,159,113,122,207,155,98,191,250,182,121,88,20,228,192,138],"compressed":2},"signature":{"Secp256k1":{"der":[48,69,2,33,0,200,2,218,162,82,188,98,5,181,247,91,128,52,203,149,231,156,66,178,203,58,106,247,189,24,215,39,87,11,33,131,186,2,32,97,234,46,39,102,129,31,97,191,159,233,21,252,136,156,111,178,62,140,200,152,28,144,46,206,157,239,51,83,224,112,243]}}}]}}},"id":"1"}
```