### PR TITLE
chore: set testnet-6 consensus constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "witnet"
-version = "0.3.2"
+version = "0.6.0"
 dependencies = [
  "bytecount 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet"
-version = "0.3.2"
+version = "0.6.0"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 publish = false
 repository = "witnet/witnet-rust"

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -140,8 +140,8 @@ pub trait Defaults {
 
     /// Reputation will expire after N witnessing acts
     fn consensus_constants_reputation_expire_alpha_diff(&self) -> u32 {
-        // 20_000 witnessing acts
-        20_000
+        // 500 witnessing acts
+        500
     }
 
     /// Reputation issuance

--- a/witnet.toml
+++ b/witnet.toml
@@ -3,16 +3,16 @@
 [connections]
 server_addr = "0.0.0.0:21337"
 known_peers = ["52.166.178.145:22337", "52.166.178.145:23337", "52.166.178.145:25337"]
-outbound_limit = 2
+outbound_limit = 3
 bootstrap_peers_period_seconds = 1
 
 [storage]
-db_path = ".witnet-rust-testnet-5"
+db_path = ".witnet-rust-testnet-6"
 
 [consensus_constants]
 checkpoints_period = 30
-checkpoint_zero_timestamp = 1567036800
-genesis_hash = "00000000000000000000000000000000000000007769746e65742d302e352e30"
+checkpoint_zero_timestamp = 1577145600
+genesis_hash = "00000000000000000000000000000000000000007769746e65742d302e362e30"
 
 [log]
 level = "debug"


### PR DESCRIPTION
This PR prepares everything for Testnet-6. In particular, it updates multiple consensus constants:
- genesis timestamp
- genesis block hash
- reputation expiration alpha diff period
- number of peers needed to start synchronizing (2 → 3)

This is a partial solution for #925, but it's still missing the WBI/BR deployment.