### PR TITLE
Show progress during synchronization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3976,6 +3976,7 @@ name = "witnet_util"
 version = "0.3.2"
 dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ntp 0.5.0 (git+https://github.com/witnet/ntp)",

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -13,10 +13,11 @@ use witnet_data_structures::{
 };
 use witnet_validations::validations::{compare_blocks, validate_block, validate_rad_request};
 
-use super::{ChainManager, ChainManagerError, StateMachine};
+use super::{
+    show_sync_progress, transaction_factory, ChainManager, ChainManagerError, StateMachine,
+};
 use crate::{
     actors::{
-        chain_manager::transaction_factory,
         messages::{
             AddBlocks, AddCandidates, AddCommitReveal, AddTransaction, Anycast, Broadcast,
             BuildDrt, BuildVtt, EpochNotification, GetBalance, GetBlocksEpochRange,
@@ -302,7 +303,14 @@ impl Handler<AddBlocks> for ChainManager {
                                 break;
                             }
 
-                            if self.get_chain_beacon() == target_beacon {
+                            let beacon = self.get_chain_beacon();
+                            show_sync_progress(
+                                beacon,
+                                target_beacon,
+                                self.epoch_constants.unwrap(),
+                            );
+
+                            if beacon == target_beacon {
                                 break;
                             }
                         }

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -7,6 +7,7 @@ workspace = ".."
 
 [dependencies]
 chrono = "0.4.9"
+humantime = "1.3.0"
 lazy_static = "1.4.0"
 log = "0.4.8"
 ntp = { git = "https://github.com/witnet/ntp" }


### PR DESCRIPTION
Close #809

This log is printed after consolidating every individual block.

Displays the following information when synchronizing a node:

* Progress in %
* Latest synced checkpoint / top checkpoint
* Age of the latest synced checkpoint

```
[2019-12-24T12:01:31Z INFO  witnet_node::actors::chain_manager] Synchronization progress: 99.33% (336120/338402). Latest synced block is 19h 1m old.
[2019-12-24T12:01:31Z INFO  witnet_node::actors::chain_manager] Synchronization progress: 99.33% (336121/338402). Latest synced block is 19h 30s old.
[2019-12-24T12:01:31Z INFO  witnet_node::actors::chain_manager] Synchronization progress: 99.33% (336122/338402). Latest synced block is 19h old.

[2019-12-24T12:01:40Z INFO  witnet_node::actors::chain_manager] Synchronization progress: 99.99% (338399/338402). Latest synced block is 1m 30s old.
[2019-12-24T12:01:40Z INFO  witnet_node::actors::chain_manager] Synchronization progress: 99.99% (338400/338402). Latest synced block is 1m old.
[2019-12-24T12:01:40Z INFO  witnet_node::actors::chain_manager] Synchronization progress: 100.00% (338402/338402). Latest synced block is 0s old.

```

Blocks older than 1 year only show years, months and days:

```
Latest synced block is 3years 4months 16days old.
```