### PR TITLE
test: enable all warnings in tests

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -2166,7 +2166,7 @@ mod tests {
     #[test]
     fn secp256k1_from_into_secret_keys() {
         use crate::chain::SecretKey;
-        use secp256k1::{Secp256k1, SecretKey as Secp256k1_SecretKey};
+        use secp256k1::SecretKey as Secp256k1_SecretKey;
 
         let secret_key =
             Secp256k1_SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");

--- a/data_structures/src/lib.rs
+++ b/data_structures/src/lib.rs
@@ -1,8 +1,6 @@
 // To enable `#[allow(clippy::all)]`
 //#![feature(tool_lints)]
 
-#![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
-
 #[macro_use]
 extern crate protobuf_convert;
 

--- a/data_structures/src/radon_report.rs
+++ b/data_structures/src/radon_report.rs
@@ -174,10 +174,10 @@ impl TallyMetaData {
 mod tests {
     use super::*;
     use crate::radon_error::{ErrorLike, RadonError, RadonErrors};
-    use core::fmt::Write;
     use failure::Fail;
-    use std::{error::Error, fmt};
+    use std::fmt;
 
+    #[test]
     fn test_encode_not_cbor() {
         #[derive(Default, Debug, Fail)]
         struct Dummy;

--- a/data_structures/src/vrf.rs
+++ b/data_structures/src/vrf.rs
@@ -195,7 +195,6 @@ mod tests {
     use witnet_protected::Protected;
 
     use super::*;
-    use vrf::openssl::CipherSuite;
 
     #[test]
     fn vrf_derived_public_key() {

--- a/validations/src/lib.rs
+++ b/validations/src/lib.rs
@@ -1,8 +1,6 @@
 // To enable `#[allow(clippy::all)]`
 //#![feature(tool_lints)]
 
-#![cfg_attr(test, allow(dead_code, unused_macros, unused_imports))]
-
 /// Module containing validations
 pub mod validations;
 


### PR DESCRIPTION
When you forget to add `#[test]` to a test, cargo prints a warning:
This warning (dead_code) was disabled in some places.
This PR fixes that, and fixes the ignored warnings