### PR TITLE
Support interception, serialization and commitment of all `RadonError`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3943,7 +3943,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "surf 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3943,6 +3943,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "surf 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/data_structures/src/radon_error.rs
+++ b/data_structures/src/radon_error.rs
@@ -92,12 +92,8 @@ where
             .encode_cbor_array()
             .into_iter()
             .map(|scv| {
-                // FIXME(#953): impl TryFrom<SerdeCborValue> for <CborValue>
-                let mut decoder = cbor::decoder::GenericDecoder::new(
-                    cbor::Config::default(),
-                    std::io::Cursor::new(serde_cbor::to_vec(&scv).unwrap()),
-                );
-                decoder.value().unwrap()
+                // FIXME(#953): remove this conversion
+                try_from_serde_cbor_value_for_cbor_value(scv)
             })
             .collect();
 
@@ -127,4 +123,22 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "RadonError({:?})", self.inner)
     }
+}
+
+pub fn try_from_serde_cbor_value_for_cbor_value(serde_cbor_value: SerdeCborValue) -> CborValue {
+    // FIXME(#953): impl TryFrom<SerdeCborValue> for <CborValue>
+    let mut decoder = cbor::decoder::GenericDecoder::new(
+        cbor::Config::default(),
+        std::io::Cursor::new(serde_cbor::to_vec(&serde_cbor_value).unwrap()),
+    );
+    decoder.value().unwrap()
+}
+
+pub fn try_from_cbor_value_for_serde_cbor_value(cbor_value: CborValue) -> SerdeCborValue {
+    // FIXME(#953): impl TryFrom<CborValue> for <SerdeCborValue>
+    let mut encoder = cbor::encoder::GenericEncoder::new(Cursor::new(Vec::new()));
+    encoder.value(&cbor_value).unwrap();
+    let buffer = encoder.into_inner().into_writer().into_inner();
+
+    serde_cbor::from_slice(&buffer).unwrap()
 }

--- a/data_structures/src/radon_error.rs
+++ b/data_structures/src/radon_error.rs
@@ -48,6 +48,9 @@ pub enum RadonErrors {
     InsufficientConsensus = 0x51,
     /// There was a tie after applying the mode reducer
     ModeTie = 0x52,
+    // This should not exist:
+    /// Some tally error is not intercepted but should
+    UnhandledIntercept = 0xFF,
 }
 
 /// Use `RadonErrors::Unknown` as the default value of `RadonErrors`.

--- a/data_structures/src/radon_error.rs
+++ b/data_structures/src/radon_error.rs
@@ -50,6 +50,8 @@ pub enum RadonErrors {
     ModeTie = 0x52,
     /// Generic error during tally execution
     TallyExecution = 0x53,
+    /// Invalid reveal serialization (malformed reveals are converted to this value)
+    MalformedReveal = 0x60,
     // This should not exist:
     /// Some tally error is not intercepted but should
     UnhandledIntercept = 0xFF,

--- a/data_structures/src/radon_error.rs
+++ b/data_structures/src/radon_error.rs
@@ -66,6 +66,9 @@ impl Default for RadonErrors {
 /// `RadonReport`.
 pub trait ErrorLike: Clone + Fail {
     fn encode_cbor_array(&self) -> Result<Vec<SerdeCborValue>, failure::Error>;
+    fn decode_cbor_array(
+        serde_cbor_array: Vec<SerdeCborValue>,
+    ) -> Result<RadonError<Self>, failure::Error>;
 }
 
 /// This structure is aimed to be the error type for the `result` field of `witnet_data_structures::radon_report::Report`.

--- a/data_structures/src/radon_error.rs
+++ b/data_structures/src/radon_error.rs
@@ -3,7 +3,7 @@ use std::{convert::TryFrom, io::Cursor};
 use cbor::{types::Tag, value::Value, GenericEncoder};
 use failure::Fail;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
-use serde::{Serialize, Serializer};
+use serde::Serialize;
 
 #[derive(Clone, Copy, Debug, Eq, IntoPrimitive, PartialEq, Serialize, TryFromPrimitive)]
 #[repr(u8)]
@@ -85,18 +85,6 @@ where
     /// Allow CBOR encoding of `RadonError` structures.
     pub fn encode(&self) -> Result<Vec<u8>, IE> {
         Vec::<u8>::try_from((*self).clone())
-    }
-}
-
-impl<IE> Serialize for RadonError<IE>
-where
-    IE: ErrorLike,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.kind.serialize(serializer)
     }
 }
 

--- a/data_structures/src/radon_error.rs
+++ b/data_structures/src/radon_error.rs
@@ -46,8 +46,6 @@ pub enum RadonErrors {
     NoReveals = 0x50,
     /// Insufficient consensus in tally precondition clause
     InsufficientConsensus = 0x51,
-    /// There was a tie after applying the mode reducer
-    ModeTie = 0x52,
     /// Generic error during tally execution
     TallyExecution = 0x53,
     /// Invalid reveal serialization (malformed reveals are converted to this value)

--- a/data_structures/src/radon_error.rs
+++ b/data_structures/src/radon_error.rs
@@ -43,6 +43,10 @@ pub enum RadonErrors {
     // Other errors
     /// Received zero reveals
     NoReveals = 0x50,
+    /// Insufficient consensus in tally precondition clause
+    InsufficientConsensus = 0x51,
+    /// There was a tie after applying the mode reducer
+    ModeTie = 0x52,
 }
 
 /// Use `RadonErrors::Unknown` as the default value of `RadonErrors`.

--- a/data_structures/src/radon_error.rs
+++ b/data_structures/src/radon_error.rs
@@ -31,6 +31,8 @@ pub enum RadonErrors {
     // Retrieval-specific errors
     /// At least one of the sources could not be retrieved, but returned HTTP error.
     HTTPError = 0x30,
+    /// Al least one of the sources could not be retrieved, timeout reached
+    RetrieveTimeout = 0x31,
     // Math errors
     /// Math operator caused an underflow.
     Underflow = 0x40,

--- a/data_structures/src/radon_error.rs
+++ b/data_structures/src/radon_error.rs
@@ -110,6 +110,14 @@ where
 
         Ok(encoder.into_inner().into_writer().into_inner())
     }
+
+    pub fn inner(&self) -> &IE {
+        &self.inner
+    }
+
+    pub fn into_inner(self) -> IE {
+        self.inner
+    }
 }
 
 impl<IE> std::fmt::Display for RadonError<IE>

--- a/data_structures/src/radon_error.rs
+++ b/data_structures/src/radon_error.rs
@@ -48,6 +48,8 @@ pub enum RadonErrors {
     InsufficientConsensus = 0x51,
     /// There was a tie after applying the mode reducer
     ModeTie = 0x52,
+    /// Generic error during tally execution
+    TallyExecution = 0x53,
     // This should not exist:
     /// Some tally error is not intercepted but should
     UnhandledIntercept = 0xFF,

--- a/data_structures/src/radon_report.rs
+++ b/data_structures/src/radon_report.rs
@@ -203,14 +203,14 @@ mod tests {
 
         // Satisfy the trait bound `Dummy: radon_error::ErrorLike` required by `radon_error::RadonError`
         impl ErrorLike for Dummy {
-            fn encode_cbor_array(&self) -> Vec<SerdeCborValue> {
+            fn encode_cbor_array(&self) -> Result<Vec<SerdeCborValue>, failure::Error> {
                 let kind = u8::from(RadonErrors::SourceScriptNotCBOR);
                 let arg0 = 2;
 
-                vec![
+                Ok(vec![
                     SerdeCborValue::Integer(kind.into()),
                     SerdeCborValue::Integer(arg0.into()),
-                ]
+                ])
             }
         }
 

--- a/data_structures/src/radon_report.rs
+++ b/data_structures/src/radon_report.rs
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_encode_not_cbor() {
-        #[derive(Default, Debug, Fail)]
+        #[derive(Clone, Default, Debug, Fail)]
         struct Dummy;
 
         // Satisfy the trait bound `Dummy: fmt::Display` required by `failure::Fail`

--- a/data_structures/src/radon_report.rs
+++ b/data_structures/src/radon_report.rs
@@ -212,6 +212,12 @@ mod tests {
                     SerdeCborValue::Integer(arg0.into()),
                 ])
             }
+
+            fn decode_cbor_array(
+                _serde_cbor_array: Vec<SerdeCborValue>,
+            ) -> Result<RadonError<Self>, failure::Error> {
+                unimplemented!()
+            }
         }
 
         // Satisfy the trait bound `(): std::convert::From<cbor::encoder::EncodeError>`

--- a/data_structures/src/radon_report.rs
+++ b/data_structures/src/radon_report.rs
@@ -31,17 +31,14 @@ where
 {
     /// Factory for constructing a `RadonReport` from the `Result` of something that could be
     /// `ErrorLike` plus a `ReportContext`.
-    pub fn from_result(
-        result: Result<RT, RT::Error>,
-        context: &ReportContext,
-    ) -> Result<Self, RT::Error> {
-        let intercepted = RT::intercept(result)?;
+    pub fn from_result(result: Result<RT, RT::Error>, context: &ReportContext) -> Self {
+        let intercepted = RT::intercept(result);
 
-        Ok(RadonReport {
+        RadonReport {
             result: intercepted,
             metadata: context.stage.clone(),
             running_time: context.duration(),
-        })
+        }
     }
 
     /// Recover the inner result as a `RT` from a `RadonReport`.
@@ -69,7 +66,7 @@ pub trait TypeLike: std::marker::Sized {
     type Error: ErrorLike;
 
     fn encode(&self) -> Result<Vec<u8>, Self::Error>;
-    fn intercept(result: Result<Self, Self::Error>) -> Result<Self, Self::Error>;
+    fn intercept(result: Result<Self, Self::Error>) -> Self;
 }
 
 /// A generic structure for bubbling up any kind of metadata that may be generated during the

--- a/data_structures/src/radon_report.rs
+++ b/data_structures/src/radon_report.rs
@@ -190,7 +190,7 @@ mod tests {
     use crate::radon_error::{ErrorLike, RadonError, RadonErrors};
 
     use super::*;
-    use cbor::value::Value as CborValue;
+    use serde_cbor::Value as SerdeCborValue;
 
     #[test]
     fn test_encode_not_cbor() {
@@ -206,11 +206,14 @@ mod tests {
 
         // Satisfy the trait bound `Dummy: radon_error::ErrorLike` required by `radon_error::RadonError`
         impl ErrorLike for Dummy {
-            fn encode_cbor_array(&self) -> Vec<CborValue> {
+            fn encode_cbor_array(&self) -> Vec<SerdeCborValue> {
                 let kind = u8::from(RadonErrors::SourceScriptNotCBOR);
                 let arg0 = 2;
 
-                vec![CborValue::U8(kind), CborValue::U8(arg0)]
+                vec![
+                    SerdeCborValue::Integer(kind.into()),
+                    SerdeCborValue::Integer(arg0.into()),
+                ]
             }
         }
 

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -13,14 +13,13 @@ use witnet_data_structures::{
         Hashable, PublicKeyHash, TransactionsPool, UnspentOutputsPool, ValueTransferOutput,
     },
     data_request::{create_tally, DataRequestPool},
-    radon_report::{RadonReport, ReportContext},
     transaction::{
         CommitTransaction, CommitTransactionBody, MintTransaction, RevealTransaction,
         RevealTransactionBody, TallyTransaction,
     },
     vrf::{BlockEligibilityClaim, DataRequestEligibilityClaim, VrfMessage},
 };
-use witnet_rad::{error::RadError, types::serial_iter_decode};
+use witnet_rad::types::serial_iter_decode;
 use witnet_validations::validations::{
     block_reward, calculate_randpoe_threshold, calculate_reppoe_threshold, dr_transaction_fee,
     merkle_tree_root, update_utxo_diff, validate_block, vt_transaction_fee, UtxoDiff,
@@ -378,16 +377,7 @@ impl ChainManager {
                     let reports = serial_iter_decode(
                         &mut reveals
                             .iter()
-                            .map(|reveal_tx| (reveal_tx.body.reveal.as_slice(), reveal_tx)),
-                        |e: RadError, slice: &[u8], reveal_tx: &RevealTransaction| {
-                            log::warn!(
-                            "Could not decode reveal from {:?} (revealed bytes were `{:?}`): {:?}",
-                            reveal_tx,
-                            &slice,
-                            e
-                        );
-                            Some(RadonReport::from_result(Err(e), &ReportContext::default()))
-                        },
+                            .map(|reveal_tx| reveal_tx.body.reveal.as_slice()),
                     );
 
                     let min_consensus_ratio =

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -391,14 +391,9 @@ impl ChainManager {
                             script: dr_state.data_request.data_request.tally.clone(),
                         })
                         .then(|result| match result {
-                            // If the result of `RunTally` is `Ok`, it will be published as tally
-                            Ok(Some(value)) => futures::future::ok(value),
-                            // If the result of `RunTally` is `Err`, we ignore this data request.
-                            // If a data request has an invalid tally script, it will never resolve.
-                            // The Radon engine should return `Ok(RadonError)` for errors which should
-                            // be published as the result of the data request, or we could use a
-                            // special radon value to indicate "generic error"
-                            Ok(None) => unreachable!("Couldn't run tally"),
+                            // The result of `RunTally` will be published as tally
+                            Ok(value) => futures::future::ok(value),
+                            // Mailbox error
                             Err(e) => {
                                 log::error!("Couldn't run tally: {}", e);
                                 futures::future::err(())

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -416,7 +416,7 @@ impl ChainManager {
                                         Yellow.bold().paint(&dr_pointer.to_string()),
                                         Yellow
                                             .bold()
-                                            .paint(format!("{:?}", &tally_result.into_inner())),
+                                            .paint(format!("{}", &tally_result.into_inner())),
                                         White.bold().paint(
                                             reports.into_iter().map(|result| result).fold(
                                                 String::from("Reveals:"),

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -13,13 +13,14 @@ use witnet_data_structures::{
         Hashable, PublicKeyHash, TransactionsPool, UnspentOutputsPool, ValueTransferOutput,
     },
     data_request::{create_tally, DataRequestPool},
+    radon_report::{RadonReport, ReportContext},
     transaction::{
         CommitTransaction, CommitTransactionBody, MintTransaction, RevealTransaction,
         RevealTransactionBody, TallyTransaction,
     },
     vrf::{BlockEligibilityClaim, DataRequestEligibilityClaim, VrfMessage},
 };
-use witnet_rad::types::serial_iter_decode;
+use witnet_rad::{error::RadError, types::serial_iter_decode};
 use witnet_validations::validations::{
     block_reward, calculate_randpoe_threshold, calculate_reppoe_threshold, dr_transaction_fee,
     merkle_tree_root, update_utxo_diff, validate_block, vt_transaction_fee, UtxoDiff,
@@ -377,7 +378,19 @@ impl ChainManager {
                     let reports = serial_iter_decode(
                         &mut reveals
                             .iter()
-                            .map(|reveal_tx| reveal_tx.body.reveal.as_slice()),
+                            .map(|reveal_tx| (reveal_tx.body.reveal.as_slice(), reveal_tx)),
+                        |e: RadError, slice: &[u8], reveal_tx: &RevealTransaction| {
+                            log::warn!(
+                            "Could not decode reveal from {:?} (revealed bytes were `{:?}`): {:?}",
+                            reveal_tx,
+                            &slice,
+                            e
+                        );
+                            Some(RadonReport::from_result(
+                                Err(RadError::MalformedReveal),
+                                &ReportContext::default(),
+                            ))
+                        },
                     );
 
                     let min_consensus_ratio =

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -829,8 +829,8 @@ fn update_reputation(
 fn show_tally_info(tally_tx: &TallyTransaction, block_epoch: Epoch) {
     let result = RadonTypes::try_from(tally_tx.tally.as_slice());
     let result_str = RadonReport::from_result(result, &ReportContext::default())
-        .map(|x| x.into_inner().to_string())
-        .unwrap_or_else(|e| format!("Unexpected RADError: {}", e));
+        .into_inner()
+        .to_string();
     info!(
         "{} {} completed at epoch #{} with result: {}",
         Yellow.bold().paint("[Data Request]"),

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -520,8 +520,6 @@ impl Message for RequestPeers {
 pub struct ResolveRA {
     /// RAD request to be executed
     pub rad_request: RADRequest,
-    /// Data request hash
-    pub dr_pointer: Hash,
     /// Timeout: if the execution does not finish before the timeout, it is cancelled.
     pub timeout: Option<Duration>,
 }
@@ -542,7 +540,7 @@ impl Message for ResolveRA {
 }
 
 impl Message for RunTally {
-    type Result = Result<RadonReport<RadonTypes>, RadError>;
+    type Result = Option<RadonReport<RadonTypes>>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/node/src/actors/rad_manager/handlers.rs
+++ b/node/src/actors/rad_manager/handlers.rs
@@ -109,6 +109,7 @@ impl Handler<RunTally> for RadManager {
             construct_report_from_clause_result(clause_result, &packed_script, reports_len)
         };
 
+        // TODO: how to return `RadonReport`?
         Some(inner())
     }
 }

--- a/node/src/actors/rad_manager/handlers.rs
+++ b/node/src/actors/rad_manager/handlers.rs
@@ -98,18 +98,12 @@ impl Handler<RunTally> for RadManager {
     type Result = <RunTally as Message>::Result;
 
     fn handle(&mut self, msg: RunTally, _ctx: &mut Self::Context) -> Self::Result {
-        let inner = || {
-            let packed_script = msg.script;
-            let reports = msg.reports;
+        let packed_script = msg.script;
+        let reports = msg.reports;
 
-            let reports_len = reports.len();
-            let clause_result =
-                evaluate_tally_precondition_clause(reports, msg.min_consensus_ratio);
+        let reports_len = reports.len();
+        let clause_result = evaluate_tally_precondition_clause(reports, msg.min_consensus_ratio);
 
-            construct_report_from_clause_result(clause_result, &packed_script, reports_len)
-        };
-
-        // TODO: how to return `RadonReport`?
-        Some(inner())
+        construct_report_from_clause_result(clause_result, &packed_script, reports_len)
     }
 }

--- a/rad/Cargo.toml
+++ b/rad/Cargo.toml
@@ -14,7 +14,6 @@ json = "0.12.0"
 log = "0.4.8"
 num_enum = "0.4.2"
 reqwest = "0.9.22"
-serde = "1.0.101"
 serde_cbor = "0.10.2"
 surf = { version = "1.0.3", default-features = false, features = ["native-client"] }
 url = "2.1.0"

--- a/rad/Cargo.toml
+++ b/rad/Cargo.toml
@@ -14,6 +14,7 @@ json = "0.12.0"
 log = "0.4.8"
 num_enum = "0.4.2"
 reqwest = "0.9.22"
+serde = "1.0.101"
 serde_cbor = "0.10.2"
 surf = { version = "1.0.3", default-features = false, features = ["native-client"] }
 url = "2.1.0"

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -332,7 +332,7 @@ impl TryFrom<RadError> for RadonError<RadError> {
             RadError::HttpStatus { status_code } => Ok(RadonError::new(
                 RadonErrors::HTTPError,
                 Some(rad_error),
-                vec![CborValue::U8(status_code as u8)],
+                vec![CborValue::U16(status_code)],
             )),
             RadError::NoReveals => Ok(RadonError::new(
                 RadonErrors::NoReveals,

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -520,8 +520,8 @@ impl RadError {
 /// Satisfy the `ErrorLike` trait that ensures generic compatibility of `witnet_rad` and
 /// `witnet_data_structures`.
 impl ErrorLike for RadError {
-    fn encode_cbor_array(&self) -> Vec<SerdeCborValue> {
-        self.try_into_cbor_array().unwrap()
+    fn encode_cbor_array(&self) -> Result<Vec<SerdeCborValue>, failure::Error> {
+        self.try_into_cbor_array().map_err(Into::into)
     }
 }
 

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -2,7 +2,6 @@
 
 use std::convert::TryFrom;
 
-use cbor::value::Value as CborValue;
 use failure::{self, Fail};
 use serde_cbor::value::Value as SerdeCborValue;
 
@@ -330,7 +329,7 @@ impl RadError {
                     message: e.to_string(),
                 }
             })
-        };
+        }
 
         fn deserialize_radon_types_arg(bytes: Vec<u8>) -> Result<RadonTypes, RadError> {
             // FIXME(#953): since RadonTypes does not implement serialize because of the
@@ -465,19 +464,8 @@ impl RadError {
 /// Satisfy the `ErrorLike` trait that ensures generic compatibility of `witnet_rad` and
 /// `witnet_data_structures`.
 impl ErrorLike for RadError {
-    fn encode_cbor_array(&self) -> Vec<CborValue> {
-        self.try_into_cbor_array()
-            .unwrap()
-            .into_iter()
-            .map(|scv| {
-                // FIXME(#953): impl TryFrom<SerdeCborValue> for <CborValue>
-                let mut decoder = cbor::decoder::GenericDecoder::new(
-                    cbor::Config::default(),
-                    std::io::Cursor::new(serde_cbor::to_vec(&scv).unwrap()),
-                );
-                decoder.value().unwrap()
-            })
-            .collect()
+    fn encode_cbor_array(&self) -> Vec<SerdeCborValue> {
+        self.try_into_cbor_array().unwrap()
     }
 }
 

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -127,7 +127,7 @@ pub enum RadError {
         display = "There was a tie after applying the mode reducer on values: `{:?}`",
         values
     )]
-    ModeTie { values: RadonArray },
+    ModeTie { values: RadonArray, max_count: u16 },
     /// Tried to apply mod reducer on an empty array
     #[fail(display = "Tried to apply mode reducer on an empty array")]
     ModeEmpty,
@@ -435,7 +435,10 @@ impl RadError {
                         })
                     }
                 };
-                RadError::ModeTie { values }
+                RadError::ModeTie {
+                    values,
+                    max_count: 0,
+                }
             }
             RadonErrors::TallyExecution => {
                 let (message,) = deserialize_args(error_args)?;
@@ -483,7 +486,7 @@ impl RadError {
             RadError::InsufficientConsensus { achieved, required } => {
                 Some(serialize_args((achieved, required))?)
             }
-            RadError::ModeTie { values } => {
+            RadError::ModeTie { values, .. } => {
                 let values = serialize_radon_types_arg(RadonTypes::from((*values).clone()))?;
                 Some(serialize_args((values,))?)
             }
@@ -690,6 +693,8 @@ mod tests {
                     RadonTypes::Integer(RadonInteger::from(3)),
                     RadonTypes::Integer(RadonInteger::from(3)),
                 ]),
+                // TODO: this is wrong but RadonErrors::ModeTie will be removed
+                max_count: 0,
             },
             RadonErrors::TallyExecution => RadError::TallyExecution {
                 inner: None,

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -342,6 +342,16 @@ impl RadError {
                 let (status_code,) = deserialize_args(error_args)?;
                 RadError::HttpStatus { status_code }
             }
+            RadonErrors::InsufficientConsensus => {
+                let (achieved, required) = deserialize_args(error_args)?;
+                RadError::InsufficientConsensus { achieved, required }
+            }
+            RadonErrors::ModeTie => {
+                // TODO: we need to serialize RadonArray T_T
+                let values = RadonArray::from(vec![]);
+                //let (values,) = deserialize_args(error_args)?;
+                RadError::ModeTie { values }
+            }
         })
     }
 
@@ -363,6 +373,12 @@ impl RadError {
                 args,
             } => Some(serialize_args((input_type, operator, args))?),
             RadError::HttpStatus { status_code } => Some(serialize_args((status_code,))?),
+            RadError::InsufficientConsensus { achieved, required } => {
+                Some(serialize_args((achieved, required))?)
+            }
+            // TODO: serialize ModeTie args
+            RadError::ModeTie { .. } => None,
+            //RadError::ModeTie { values } => Some(serialize_args((values,))?),
             _ => None,
         };
 
@@ -400,6 +416,8 @@ impl RadError {
             RadError::DivisionByZero => RadonErrors::DivisionByZero,
             RadError::NoReveals => RadonErrors::NoReveals,
             RadError::RetrieveTimeout => RadonErrors::RetrieveTimeout,
+            RadError::InsufficientConsensus { .. } => RadonErrors::InsufficientConsensus,
+            RadError::ModeTie { .. } => RadonErrors::ModeTie,
             _ => return Err(RadError::EncodeRadonErrorUnknownCode),
         })
     }

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -324,6 +324,9 @@ pub enum RadError {
         inner: Option<Box<RadError>>,
         message: Option<String>,
     },
+    /// Invalid reveal serialization (malformed reveals are converted to this value)
+    #[fail(display = "The reveal was not serialized correctly")]
+    MalformedReveal,
 }
 
 impl RadError {
@@ -403,6 +406,7 @@ impl RadError {
             RadonErrors::Underflow => RadError::Underflow,
             RadonErrors::DivisionByZero => RadError::DivisionByZero,
             RadonErrors::RetrieveTimeout => RadError::RetrieveTimeout,
+            RadonErrors::MalformedReveal => RadError::MalformedReveal,
             RadonErrors::UnsupportedOperator => {
                 let (input_type, operator, args) = deserialize_args(error_args)?;
                 RadError::UnsupportedOperator {
@@ -547,6 +551,7 @@ impl RadError {
             RadError::ModeTie { .. } => RadonErrors::ModeTie,
             RadError::TallyExecution { .. } => RadonErrors::TallyExecution,
             RadError::UnhandledIntercept { .. } => RadonErrors::UnhandledIntercept,
+            RadError::MalformedReveal => RadonErrors::MalformedReveal,
             _ => return Err(RadError::EncodeRadonErrorUnknownCode),
         })
     }

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -329,6 +329,7 @@ impl RadError {
             RadonErrors::SourceScriptNotRADON => RadError::SourceScriptNotRADON,
             RadonErrors::Underflow => RadError::Underflow,
             RadonErrors::DivisionByZero => RadError::DivisionByZero,
+            RadonErrors::RetrieveTimeout => RadError::RetrieveTimeout,
             RadonErrors::UnsupportedOperator => {
                 let (input_type, operator, args) = deserialize_args(error_args)?;
                 RadError::UnsupportedOperator {
@@ -398,6 +399,7 @@ impl RadError {
             RadError::Overflow => RadonErrors::Overflow,
             RadError::DivisionByZero => RadonErrors::DivisionByZero,
             RadError::NoReveals => RadonErrors::NoReveals,
+            RadError::RetrieveTimeout => RadonErrors::RetrieveTimeout,
             _ => return Err(RadError::EncodeRadonErrorUnknownCode),
         })
     }

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -306,6 +306,12 @@ pub enum RadError {
         display = "`RadError` cannot be converted to `RadonError` because the error code is not defined"
     )]
     EncodeRadonErrorUnknownCode,
+    /// `RadError` cannot be converted to `RadonError` but it should, because it is needed for the tally result
+    #[fail(
+        display = "`RadError` cannot be converted to `RadonError` but it should, because it is needed for the tally result. Inner: {:?}",
+        error
+    )]
+    UnhandledIntercept { error: Option<Box<RadError>> },
 }
 
 impl RadError {
@@ -381,6 +387,7 @@ impl RadError {
                 };
                 RadError::ModeTie { values }
             }
+            RadonErrors::UnhandledIntercept => RadError::UnhandledIntercept { error: None },
         })
     }
 
@@ -456,6 +463,7 @@ impl RadError {
             RadError::RetrieveTimeout => RadonErrors::RetrieveTimeout,
             RadError::InsufficientConsensus { .. } => RadonErrors::InsufficientConsensus,
             RadError::ModeTie { .. } => RadonErrors::ModeTie,
+            RadError::UnhandledIntercept { .. } => RadonErrors::UnhandledIntercept,
             _ => return Err(RadError::EncodeRadonErrorUnknownCode),
         })
     }

--- a/rad/src/filters/mode.rs
+++ b/rad/src/filters/mode.rs
@@ -96,6 +96,7 @@ mod tests {
                 RadonInteger::from(1).into(),
                 RadonInteger::from(2).into(),
             ]),
+            max_count: 1,
         };
 
         let mut ctx = ReportContext::default();
@@ -171,6 +172,7 @@ mod tests {
                 RadonString::from("Hello").into(),
                 RadonString::from("World").into(),
             ]),
+            max_count: 1,
         };
 
         let mut ctx = ReportContext::default();

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -174,6 +174,7 @@ mod tests {
     };
 
     use super::*;
+    use std::convert::TryFrom;
 
     #[test]
     fn test_run_retrieval() {
@@ -732,7 +733,7 @@ mod tests {
         )
         .unwrap()
         .into_inner();
-        let expected = RadonTypes::from(RadonError::from(RadonErrors::NoReveals));
+        let expected = RadonTypes::from(RadonError::try_from(RadError::NoReveals).unwrap());
 
         assert_eq!(report, expected);
     }
@@ -745,7 +746,11 @@ mod tests {
         // RadonInteger with value 0
         let int = RadonTypes::from(RadonInteger::from(0));
         // RadonError with error code 0
-        let err = RadonTypes::from(RadonError::from(RadonErrors::try_from(0).unwrap()));
+        let kind = RadonErrors::try_from(0).unwrap();
+        let err = RadonTypes::from(
+            RadonError::try_from(RadError::try_from_kind_and_cbor_args(kind, None).unwrap())
+                .unwrap(),
+        );
         // Ensure they encoded differently (errors are tagged using `39` as CBOR tag)
         assert_ne!(int.encode(), err.encode());
         // And they are not equal in runtime either

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -144,7 +144,7 @@ pub fn run_tally_report(
     let radon_script = create_radon_script_from_filters_and_reducer(filters, reducer)?;
 
     if radon_types_vec.is_empty() {
-        return RadonReport::from_result(Err(RadError::NoReveals), context);
+        return Ok(RadonReport::from_result(Err(RadError::NoReveals), context));
     }
 
     let items_to_tally = RadonTypes::from(RadonArray::from(radon_types_vec));

--- a/rad/src/reducers/mode.rs
+++ b/rad/src/reducers/mode.rs
@@ -33,6 +33,7 @@ pub fn mode(input: &RadonArray) -> Result<RadonTypes, RadError> {
     if mode_vector.len() > 1 {
         Err(RadError::ModeTie {
             values: input.clone(),
+            max_count: *max_count as u16,
         })
     } else {
         Ok(mode_vector[0].clone())
@@ -68,7 +69,10 @@ mod tests {
         ]);
 
         let output = mode(&input).unwrap_err();
-        let expected_error = ModeTie { values: input };
+        let expected_error = ModeTie {
+            values: input,
+            max_count: 1,
+        };
         assert_eq!(output, expected_error);
     }
 
@@ -91,7 +95,10 @@ mod tests {
             RadonInteger::from(2i128).into(),
         ]);
         let output = mode(&input).unwrap_err();
-        let expected_error = ModeTie { values: input };
+        let expected_error = ModeTie {
+            values: input,
+            max_count: 1,
+        };
         assert_eq!(output, expected_error);
     }
 
@@ -114,7 +121,10 @@ mod tests {
             RadonString::from("Bye world!").into(),
         ]);
         let output = mode(&input).unwrap_err();
-        let expected_error = ModeTie { values: input };
+        let expected_error = ModeTie {
+            values: input,
+            max_count: 1,
+        };
         assert_eq!(output, expected_error);
     }
 

--- a/rad/src/script.rs
+++ b/rad/src/script.rs
@@ -41,7 +41,7 @@ pub fn execute_radon_script(
     context.complete();
 
     // Return a report as constructed from the result and the context
-    RadonReport::from_result(result, context)
+    Ok(RadonReport::from_result(result, context))
 }
 
 /// Run any RADON script on given input data, and return `RadonTypes`.

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -1,4 +1,3 @@
-use serde::Serialize;
 use serde_cbor::value::{from_value, Value};
 use std::{
     convert::{TryFrom, TryInto},
@@ -16,7 +15,7 @@ use crate::{
 
 pub const RADON_ARRAY_TYPE_NAME: &str = "RadonArray";
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RadonArray {
     value: Vec<RadonTypes>,
     is_homogeneous: bool,

--- a/rad/src/types/boolean.rs
+++ b/rad/src/types/boolean.rs
@@ -1,7 +1,6 @@
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 
-use serde::{Deserialize, Serialize};
 use serde_cbor::value::{from_value, Value};
 
 use crate::{
@@ -14,7 +13,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 pub const RADON_BOOLEAN_TYPE_NAME: &str = "RadonBoolean";
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct RadonBoolean {
     value: bool,
 }

--- a/rad/src/types/bytes.rs
+++ b/rad/src/types/bytes.rs
@@ -4,7 +4,6 @@ use crate::{
     script::RadonCall,
     types::{RadonType, RadonTypes},
 };
-use serde::{Serialize, Serializer};
 use serde_cbor::value::Value;
 use std::{
     convert::{TryFrom, TryInto},
@@ -22,15 +21,6 @@ pub struct RadonBytes {
 impl Default for RadonBytes {
     fn default() -> Self {
         Self { value: vec![] }
-    }
-}
-
-impl Serialize for RadonBytes {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.value().serialize(serializer)
     }
 }
 

--- a/rad/src/types/float.rs
+++ b/rad/src/types/float.rs
@@ -4,7 +4,6 @@ use std::{
     str::FromStr,
 };
 
-use serde::{Deserialize, Serialize};
 use serde_cbor::value::Value;
 
 use crate::{
@@ -17,7 +16,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 pub const RADON_FLOAT_TYPE_NAME: &str = "RadonFloat";
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct RadonFloat {
     value: f64,
 }

--- a/rad/src/types/integer.rs
+++ b/rad/src/types/integer.rs
@@ -4,7 +4,6 @@ use std::{
     str::FromStr,
 };
 
-use serde::{Deserialize, Serialize};
 use serde_cbor::value::Value;
 
 use crate::{
@@ -17,7 +16,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 pub const RADON_INTEGER_TYPE_NAME: &str = "RadonInteger";
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Default)]
 pub struct RadonInteger {
     value: i128,
 }

--- a/rad/src/types/map.rs
+++ b/rad/src/types/map.rs
@@ -1,4 +1,3 @@
-use serde::Serialize;
 use serde_cbor::value::{from_value, to_value, Value};
 use std::{
     collections::{btree_map::BTreeMap, HashMap},
@@ -16,7 +15,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 pub const RADON_MAP_TYPE_NAME: &str = "RadonMap";
 
-#[derive(Clone, Debug, PartialEq, Serialize, Default)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct RadonMap {
     value: HashMap<String, RadonTypes>,
 }

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use cbor::value::Value as CborValue;
-use serde::Serialize;
 use serde_cbor::{to_vec, Value};
 
 use witnet_crypto::hash::calculate_sha256;
@@ -42,7 +41,7 @@ where
     fn radon_type_name() -> String;
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 pub enum RadonTypes {
     Array(RadonArray),
     Boolean(RadonBoolean),

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -431,15 +431,9 @@ impl TryFrom<CborValue> for RadonTypes {
     }
 }
 
-/// Decode a vector of instances of RadonTypes from any iterator that yields `(&[u8], &T)`.
-/// The `err_action` argument allows the caller of this function to decide whether
-/// it should act in a lossy way, i.e. ignoring items that cannot be decoded or replacing them with
-/// default values.
-pub fn serial_iter_decode<T>(
-    iter: &mut dyn Iterator<Item = (&[u8], &T)>,
-    _err_action: fn(RadError, &[u8], &T) -> Option<RadonReport<RadonTypes>>,
-) -> Vec<RadonReport<RadonTypes>> {
-    iter.map(|(slice, _inner)| {
+/// Decode a vector of instances of RadonTypes from any iterator that yields `&[u8]`.
+pub fn serial_iter_decode(iter: &mut dyn Iterator<Item = &[u8]>) -> Vec<RadonReport<RadonTypes>> {
+    iter.map(|slice| {
         RadonReport::from_result(RadonTypes::try_from(slice), &ReportContext::default())
     })
     .collect()

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -170,7 +170,8 @@ impl TypeLike for RadonTypes {
             Err(rad_error) => {
                 RadonTypes::RadonError(RadonError::try_from(rad_error).unwrap_or_else(|error| {
                     let unhandled_rad_error = RadError::UnhandledIntercept {
-                        error: Some(Box::new(error)),
+                        inner: Some(Box::new(error)),
+                        message: None,
                     };
                     log::warn!("{}", unhandled_rad_error);
                     RadonError::new(unhandled_rad_error)

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -18,11 +18,9 @@ use crate::{
         integer::RadonInteger, map::RadonMap, string::RadonString,
     },
 };
-use std::io::Cursor;
-use witnet_data_structures::radon_error::RadonError;
 use witnet_data_structures::{
     chain::Hash,
-    radon_error::RadonErrors,
+    radon_error::{try_from_cbor_value_for_serde_cbor_value, RadonError, RadonErrors},
     radon_report::{RadonReport, ReportContext, TypeLike},
 };
 
@@ -125,13 +123,10 @@ impl RadonTypes {
                         let serde_cbor_error_args = if tail.is_empty() {
                             None
                         } else {
-                            // FIXME(#953): impl TryFrom<CborValue> for <SerdeCborValue>
-                            let mut encoder =
-                                cbor::encoder::GenericEncoder::new(Cursor::new(Vec::new()));
-                            encoder.value(&CborValue::Array(tail.to_vec()))?;
-                            let buffer = encoder.into_inner().into_writer().into_inner();
-
-                            Some(serde_cbor::from_slice(&buffer).unwrap())
+                            // FIXME(#953): remove this conversion
+                            Some(try_from_cbor_value_for_serde_cbor_value(CborValue::Array(
+                                tail.to_vec(),
+                            )))
                         };
 
                         Ok(RadonTypes::RadonError(

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -134,9 +134,9 @@ impl RadonTypes {
                             Some(serde_cbor::from_slice(&buffer).unwrap())
                         };
 
-                        Ok(RadonTypes::RadonError(RadonError::new(
+                        Ok(RadonTypes::RadonError(
                             RadError::try_from_kind_and_cbor_args(kind, serde_cbor_error_args)?,
-                        )))
+                        ))
                     } else {
                         Err(RadError::DecodeRadonErrorBadCode {
                             actual_type: format!("{:?}", head),

--- a/rad/src/types/string.rs
+++ b/rad/src/types/string.rs
@@ -3,7 +3,6 @@ use std::{
     fmt,
 };
 
-use serde::Serialize;
 use serde_cbor::value::{from_value, Value};
 
 use crate::{
@@ -16,7 +15,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 pub const RADON_STRING_TYPE_NAME: &str = "RadonString";
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Serialize, Default)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Default)]
 pub struct RadonString {
     value: String,
 }

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -290,6 +290,7 @@ pub fn evaluate_tally_precondition_clause(
                         .map(RadonReport::into_inner)
                         .collect::<Vec<RadonTypes>>(),
                 ),
+                max_count: counter.max_val as u16,
             }),
             // Majority of errors, return errors mode.
             Some(most_frequent_type) if most_frequent_type == error_type_discriminant => {
@@ -1791,7 +1792,8 @@ mod tests {
                     v.into_iter()
                         .map(RadonReport::into_inner)
                         .collect::<Vec<RadonTypes>>()
-                )
+                ),
+                max_count: 2,
             }
         );
     }

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -346,7 +346,19 @@ pub fn validate_consensus(
     let results = serial_iter_decode(
         &mut reveals
             .iter()
-            .map(|reveal_tx| reveal_tx.body.reveal.as_slice()),
+            .map(|&reveal_tx| (reveal_tx.body.reveal.as_slice(), reveal_tx)),
+        |e: RadError, slice: &[u8], reveal_tx: &RevealTransaction| {
+            log::warn!(
+                "Could not decode reveal from {:?} (revealed bytes were `{:?}`): {:?}",
+                reveal_tx,
+                &slice,
+                e
+            );
+            Some(RadonReport::from_result(
+                Err(RadError::MalformedReveal),
+                &ReportContext::default(),
+            ))
+        },
     );
 
     let results_len = results.len();

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -346,16 +346,7 @@ pub fn validate_consensus(
     let results = serial_iter_decode(
         &mut reveals
             .iter()
-            .map(|&reveal_tx| (reveal_tx.body.reveal.as_slice(), reveal_tx)),
-        |e: RadError, slice: &[u8], reveal_tx: &RevealTransaction| {
-            log::warn!(
-                "Could not decode reveal from {:?} (revealed bytes were `{:?}`): {:?}",
-                reveal_tx,
-                &slice,
-                e
-            );
-            Some(RadonReport::from_result(Err(e), &ReportContext::default()))
-        },
+            .map(|reveal_tx| reveal_tx.body.reveal.as_slice()),
     );
 
     let results_len = results.len();

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -403,7 +403,10 @@ pub fn construct_report_from_clause_result(
             match run_tally_report(values, script, Some(liars)) {
                 Ok(x) => x,
                 Err(e) => RadonReport::from_result(
-                    Err(e),
+                    Err(RadError::TallyExecution {
+                        inner: Some(Box::new(e)),
+                        message: None,
+                    }),
                     &ReportContext::from_stage(Stage::Tally(metadata)),
                 ),
             }

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -18,7 +18,7 @@ use witnet_data_structures::{
     },
     data_request::DataRequestPool,
     error::{BlockError, DataRequestError, TransactionError},
-    radon_error::{RadonError, RadonErrors},
+    radon_error::RadonError,
     radon_report::{RadonReport, ReportContext, Stage, TallyMetaData},
     transaction::{
         CommitTransaction, DRTransaction, MintTransaction, RevealTransaction, TallyTransaction,
@@ -277,7 +277,8 @@ pub fn evaluate_tally_precondition_clause(
     // Otherwise, return `RadError::InsufficientConsensus`.
     if achieved_consensus >= minimum_consensus {
         let error_type_discriminant =
-            RadonTypes::RadonError(RadonError::from(RadonErrors::default())).discriminant();
+            RadonTypes::RadonError(RadonError::try_from(RadError::default()).unwrap())
+                .discriminant();
 
         // Decide based on the most frequent type.
         match counter.max_pos {
@@ -1469,7 +1470,7 @@ pub fn compare_blocks(
 
 #[cfg(test)]
 mod tests {
-    use witnet_data_structures::radon_error::{RadonError, RadonErrors};
+    use witnet_data_structures::radon_error::RadonError;
     use witnet_rad::types::{float::RadonFloat, integer::RadonInteger};
 
     use super::*;
@@ -1731,7 +1732,7 @@ mod tests {
     #[test]
     fn test_tally_precondition_clause_majority_of_errors() {
         let rad_int = RadonTypes::Integer(RadonInteger::from(1));
-        let rad_err = RadonError::from(RadonErrors::HTTPError);
+        let rad_err = RadonError::try_from(RadError::HttpStatus { status_code: 0 }).unwrap();
 
         let rad_rep_int = RadonReport::from_result(Ok(rad_int), &ReportContext::default()).unwrap();
         let rad_rep_err = RadonReport::from_result(
@@ -1792,7 +1793,7 @@ mod tests {
     fn test_tally_precondition_clause_3_errors_vs_2_ints_and_2_floats() {
         let rad_int = RadonTypes::Integer(RadonInteger::from(1));
         let rad_float = RadonTypes::Float(RadonFloat::from(1));
-        let rad_err = RadonError::from(RadonErrors::HTTPError);
+        let rad_err = RadonError::try_from(RadError::HttpStatus { status_code: 0 }).unwrap();
 
         let rad_rep_int = RadonReport::from_result(Ok(rad_int), &ReportContext::default()).unwrap();
         let rad_rep_float =
@@ -1835,7 +1836,7 @@ mod tests {
 
     #[test]
     fn test_tally_precondition_clause_all_errors() {
-        let rad_err = RadonError::from(RadonErrors::HTTPError);
+        let rad_err = RadonError::try_from(RadError::HttpStatus { status_code: 0 }).unwrap();
         let rad_rep_err = RadonReport::from_result(
             Ok(RadonTypes::RadonError(rad_err.clone())),
             &ReportContext::default(),

--- a/wallet/src/actors/app/handlers/run_rad_req.rs
+++ b/wallet/src/actors/app/handlers/run_rad_req.rs
@@ -1,5 +1,5 @@
 use actix::prelude::*;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::actors::app;
 use crate::types;
@@ -12,7 +12,17 @@ pub struct RunRadReqRequest {
 
 #[derive(Debug, Serialize)]
 pub struct RunRadReqResponse {
+    #[serde(serialize_with = "debug_serialize")]
     pub result: types::RadonTypes,
+}
+
+// Serialize a type as a string, using its debug representation
+fn debug_serialize<S, T>(x: &T, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: std::fmt::Debug,
+{
+    s.serialize_str(&format!("{:?}", x))
 }
 
 impl Message for RunRadReqRequest {


### PR DESCRIPTION
Close #939
Close #963 

This implements a bidirectional conversion between `RadonErrors` and `RadError`. This way we avoid duplicating the serialization logic. Basically, all `RadonErrors` must be convertible to `RadError`, and if that `RadError` has any extra arguments, these arguments are encoded into the CBOR array. Detailed explanation:

`RadonError` is the type reported by nodes when a data request has some error. Most `RadonTypes` are encoded as their CBOR equivalent: for example `RadonInteger` is encoded as `Value::Integer` and `RadonString` is `Value::Text`. But there is no `Value::Error`, so the encoding of `RadonError` is a bit different.

A `RadonError` is serialized as a tagged CBOR array with tag id 39:

```rust
CborValue::Tagged(Tag::of(39), Box::new(CborValue::Array(values)))
```

Where `values` is an array where the first element is the error code, and the other elements are extra arguments (depending on the error code, most of the errors do not have any extra arguments).

All the possible error codes are defined as `RadonErrors`.

The `values` array is created using the `ErrorLike` trait:

```rust
impl ErrorLike for RadError {
    fn encode_cbor_array(&self) -> Vec<SerdeCborValue> {
        self.try_into_cbor_array().unwrap()
    }
}
```

`try_into_cbor_array` performs the serialization. The error arguments are serialized using `serde_cbor`, so anything that implements `Serialize` works. One important exception is anything related to `RadonTypes`. Because of the special serialization of `RadonError`, `RadonTypes` cannot implement `Serialize`. But for example the `ModeTie` error has one argument `values: RadonArray`. The current workaround is to first convert the `RadonArray` to bytes, and then serialize that bytes. This results in CBOR inside CBOR, we must deserialize that twice, but it works. Some alternatives are replacing `RadonArray` with `Vec<Values>`, or making that argument optional, or not supporting `ModeTie` errors.

Deserialization is performed in `try_from_kind_and_cbor_args`. It's pretty straight-forward given the serialization. Everything is tested so errors like "forgetting to implement serialize when adding a new `RadonErrors`" or copy-paste errors can be easily avoided.