### PR TITLE
chore: prepare release 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "witnet"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytecount 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 publish = false
 repository = "witnet/witnet-rust"

--- a/witnet.toml
+++ b/witnet.toml
@@ -2,8 +2,8 @@
 # https://docs.witnet.io/configuration/toml-file/
 [connections]
 server_addr = "0.0.0.0:21337"
-known_peers = ["52.166.178.145:22337", "52.166.178.145:23337", "52.166.178.145:25337"]
-outbound_limit = 3
+known_peers = ["52.166.178.145:22337", "52.166.178.145:23337", "52.166.178.145:24337", "52.166.178.145:25337"]
+outbound_limit = 4
 bootstrap_peers_period_seconds = 1
 
 [storage]
@@ -11,8 +11,8 @@ db_path = ".witnet-rust-testnet-6"
 
 [consensus_constants]
 checkpoints_period = 30
-checkpoint_zero_timestamp = 1577145600
-genesis_hash = "00000000000000000000000000000000000000007769746e65742d302e362e30"
+checkpoint_zero_timestamp = 1579651200
+genesis_hash = "00000000000000000000000000000000000000007769746e65742d302e362e31"
 
 [log]
 level = "debug"


### PR DESCRIPTION
This is the release candidate for Testnet 0.6.1