### PR TITLE
chore: remove "mining enabled" log

### DIFF
--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -166,12 +166,6 @@ impl ChainManager {
             // Get consensus parameter from config
             act.consensus_c = config.connections.consensus_c;
 
-            if act.mining_enabled {
-                debug!("Mining enabled!");
-            } else {
-                debug!("Mining explicitly disabled by configuration.");
-            }
-
             fut::ok(())
         }).map_err(|err,_,_| {
             log::error!("Couldn't initialize from storage: {}", err);

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -41,7 +41,7 @@ impl ChainManager {
     /// Try to mine a block
     pub fn try_mine_block(&mut self, ctx: &mut Context<Self>) {
         if !self.mining_enabled {
-            debug!("Mining not enabled");
+            debug!("Mining disabled in configuration");
             return;
         }
 


### PR DESCRIPTION
This log is misleading since it is printed on every call to `initialize_from_storage`, and we use that method to roll back one block if something goes wrong.