### PR TITLE
feat(actors): run signature manager on its own thread

### DIFF
--- a/node/src/actors/node.rs
+++ b/node/src/actors/node.rs
@@ -27,6 +27,7 @@ pub fn run(config: Config, callback: fn()) -> Result<(), failure::Error> {
     config_mngr::start();
     actix::Arbiter::spawn(config_mngr::set(config).map_err(|_| System::current().stop()));
 
+    // Start StorageManager actor & SignatureManager
     storage_mngr::start();
     signature_mngr::start();
 


### PR DESCRIPTION
This PR follows the same approach in the `StorageManager` in order to run the `SignatureManager` on a separate thread.

The known limitation is that the number of threads that the pool can be configured has to be 1, because the way the `SignatureManager` is configured with the `SetKey` message (which requires to request  information to the storage).