### PR TITLE
fix(data_structures): remove from data_requests_by_epoch only once

### DIFF
--- a/data_structures/src/data_request.rs
+++ b/data_structures/src/data_request.rs
@@ -209,18 +209,20 @@ impl DataRequestPool {
                         // When a data request changes from commit stage to reveal stage, it should
                         // be removed from the "data_requests_by_epoch" map, which stores the data
                         // requests potentially available for commitment
-                        if let Some(hs) = data_requests_by_epoch.get_mut(&dr_state.epoch) {
-                            let present = hs.remove(dr_pointer);
-                            if hs.is_empty() {
-                                data_requests_by_epoch.remove(&dr_state.epoch);
-                            }
-                            if !present {
-                                log::error!(
-                                    "Data request {:?} was not present in the \
-                                     data_requests_by_epoch map (epoch #{})",
-                                    dr_pointer,
-                                    dr_state.epoch
-                                );
+                        if dr_state.info.current_reveal_round == 0 {
+                            if let Some(hs) = data_requests_by_epoch.get_mut(&dr_state.epoch) {
+                                let present = hs.remove(dr_pointer);
+                                if hs.is_empty() {
+                                    data_requests_by_epoch.remove(&dr_state.epoch);
+                                }
+                                if !present {
+                                    log::error!(
+                                        "Data request {:?} was not present in the \
+                                         data_requests_by_epoch map (epoch #{})",
+                                        dr_pointer,
+                                        dr_state.epoch
+                                    );
+                                }
                             }
                         }
 


### PR DESCRIPTION
We can see a strange error while synchronizing the testnet in commit 8af0f30ce061478a68f8c4d1acfa578033da9d37:

> [2020-01-30T15:02:35Z INFO  witnet_node::actors::chain_manager] Synchronization progress: 17.60% (  4373/ 24843). Latest synced block is 7days 2h 35m old.
[2020-01-30T15:02:35Z INFO  witnet_node::actors::chain_manager] Synchronization progress: 17.61% (  4374/ 24843). Latest synced block is 7days 2h 34m 30s old.
[2020-01-30T15:02:35Z ERROR witnet_data_structures::data_request] Data request b0f36f514e8f9aa1667485d10a6883c6c8781e2b12eb3cfb4243c2c999d830d3 was not present in the data_requests_by_epoch map (epoch #4373)
[2020-01-30T15:02:35Z INFO  witnet_node::actors::chain_manager] Synchronization progress: 17.61% (  4375/ 24843). Latest synced block is 7days 2h 34m old.
[2020-01-30T15:02:35Z INFO  witnet_node::actors::chain_manager] Synchronization progress: 17.61% (  4376/ 24843). Latest synced block is 7days 2h 33m 30s old.

A bisection points to 8cef4c816a9249eddd9a3ccfc54a342d15d6c3a7 as the first bad commit

This PR fixes that