### PR TITLE
Add debug information to release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,5 @@ version = "1.0.101"
 opt-level = 0
 
 [profile.release]
+debug = 1
 opt-level = 3


### PR DESCRIPTION
This should make backtraces of docker nodes less useless.

Impact on binary size:
debug = 0: 31 MB
debug = 1: 329 MB (wtf)

Note that this is only line tables, for full debug information the setting is "debug = 2"

https://doc.rust-lang.org/cargo/reference/profiles.html#debug