### PR TITLE
chore: do not strip release binaries

### DIFF
--- a/docker/cross-compilation/aarch64-unknown-linux-gnu/Dockerfile
+++ b/docker/cross-compilation/aarch64-unknown-linux-gnu/Dockerfile
@@ -43,5 +43,5 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
     PKG_CONFIG_ALLOW_CROSS=1 \
-    RUST_BACKTRACE=1 \
-    STRIP=aarch64-linux-gnu-strip
+    RUST_BACKTRACE=1
+    #STRIP=aarch64-linux-gnu-strip

--- a/docker/cross-compilation/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/cross-compilation/arm-unknown-linux-gnueabihf/Dockerfile
@@ -49,5 +49,5 @@ ENV CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
     PKG_CONFIG_ALLOW_CROSS=1 \
-    RUST_BACKTRACE=1 \
-    STRIP=arm-linux-gnueabihf-strip
+    RUST_BACKTRACE=1
+    #STRIP=arm-linux-gnueabihf-strip

--- a/docker/cross-compilation/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/docker/cross-compilation/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -43,5 +43,5 @@ ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
     PKG_CONFIG_ALLOW_CROSS=1 \
-    RUST_BACKTRACE=1 \
-    STRIP=arm-linux-gnueabihf-strip
+    RUST_BACKTRACE=1
+    #STRIP=arm-linux-gnueabihf-strip

--- a/docker/cross-compilation/x86_64-unknown-linux-gnu/Dockerfile
+++ b/docker/cross-compilation/x86_64-unknown-linux-gnu/Dockerfile
@@ -31,5 +31,5 @@ RUN apt-get clean && apt-get autoremove
 ENV OPENSSL_DIR=/openssl \
     OPENSSL_INCLUDE_DIR=/openssl/include \
     OPENSSL_LIB_DIR=/openssl/lib \
-    RUST_BACKTRACE=1 \
-    STRIP=strip
+    RUST_BACKTRACE=1
+    #STRIP=strip


### PR DESCRIPTION
This should add some information to backtraces, but I'm not sure how much of an impact does this make.
Binary size before strip: 31 MB
Binary size after strip: 24 MB