### PR TITLE
Memohash sync

### DIFF
--- a/data_structures/src/transaction.rs
+++ b/data_structures/src/transaction.rs
@@ -59,6 +59,42 @@ pub enum Transaction {
     Mint(MintTransaction),
 }
 
+impl From<VTTransaction> for Transaction {
+    fn from(transaction: VTTransaction) -> Self {
+        Self::ValueTransfer(transaction)
+    }
+}
+
+impl From<DRTransaction> for Transaction {
+    fn from(transaction: DRTransaction) -> Self {
+        Self::DataRequest(transaction)
+    }
+}
+
+impl From<CommitTransaction> for Transaction {
+    fn from(transaction: CommitTransaction) -> Self {
+        Self::Commit(transaction)
+    }
+}
+
+impl From<RevealTransaction> for Transaction {
+    fn from(transaction: RevealTransaction) -> Self {
+        Self::Reveal(transaction)
+    }
+}
+
+impl From<TallyTransaction> for Transaction {
+    fn from(transaction: TallyTransaction) -> Self {
+        Self::Tally(transaction)
+    }
+}
+
+impl From<MintTransaction> for Transaction {
+    fn from(transaction: MintTransaction) -> Self {
+        Self::Mint(transaction)
+    }
+}
+
 impl AsRef<Transaction> for Transaction {
     fn as_ref(&self) -> &Self {
         self

--- a/data_structures/src/transaction.rs
+++ b/data_structures/src/transaction.rs
@@ -29,6 +29,19 @@ impl PartialEq for MemoHash {
     }
 }
 
+/// Forced implementation of `Sync` for `MemoHash`.
+///
+/// This is needed because `MemoHash::hash` is of type `Cell`, which in turn has constraint `!Sync`.
+///
+/// Putting `Cell` here gave us memoization through interior mutability. However, it prevented us
+/// from sharing any structure containing a MemoHash from being shared across threads.
+///
+/// This implementation restores the possibility of sharing this structure across threads with
+/// limited impact to thread safety, as the `Cell` itself is only set through calling
+/// `<T: MemoizedHashable>::hash`, which is a pure method. Therefore the maximum impact is a race
+/// condition in the case that `MemoHash::get` is called concurrently.
+unsafe impl Sync for MemoHash {}
+
 impl MemoHash {
     fn new() -> Self {
         Self {

--- a/wallet/src/actors/app/methods.rs
+++ b/wallet/src/actors/app/methods.rs
@@ -468,7 +468,7 @@ impl App {
             .value_transfer_txns
             .into_iter()
             .map(types::Transaction::from);
-        let block_txns = dr_txns.chain(vtt_txns).collect::<Vec<types::Transaction>>();
+        let block_txns = Arc::new(dr_txns.chain(vtt_txns).collect::<Vec<types::Transaction>>());
 
         // Index block transactions on each wallet
         for (id, wallet) in self.state.wallets() {

--- a/wallet/src/actors/worker/handlers/index_txns.rs
+++ b/wallet/src/actors/worker/handlers/index_txns.rs
@@ -7,7 +7,7 @@ pub struct IndexTxns(
     /// Wallet id
     pub String,
     pub types::SessionWallet,
-    pub Vec<types::VTTransactionBody>,
+    pub Vec<types::Transaction>,
     pub model::BlockInfo,
 );
 

--- a/wallet/src/actors/worker/handlers/index_txns.rs
+++ b/wallet/src/actors/worker/handlers/index_txns.rs
@@ -2,12 +2,13 @@ use actix::prelude::*;
 
 use crate::actors::worker;
 use crate::{model, types};
+use std::sync::Arc;
 
 pub struct IndexTxns(
     /// Wallet id
     pub String,
     pub types::SessionWallet,
-    pub Vec<types::Transaction>,
+    pub Arc<Vec<types::Transaction>>,
     pub model::BlockInfo,
 );
 

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -221,7 +221,7 @@ impl Worker {
         &self,
         wallet: &types::Wallet,
         block: &model::BlockInfo,
-        txns: &[types::VTTransactionBody],
+        txns: &[types::Transaction],
     ) -> Result<()> {
         wallet.index_transactions(block, txns)?;
 

--- a/wallet/src/model.rs
+++ b/wallet/src/model.rs
@@ -1,5 +1,6 @@
 //! Types that are serializable and can be returned as a response.
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -83,6 +84,22 @@ pub struct Transaction {
 pub enum TransactionType {
     ValueTransfer,
     DataRequest,
+}
+
+pub struct UnsupportedTransactionType(pub String);
+
+impl TryFrom<&types::Transaction> for TransactionType {
+    type Error = UnsupportedTransactionType;
+
+    fn try_from(value: &types::Transaction) -> Result<Self, Self::Error> {
+        use types::Transaction::*;
+
+        match value {
+            ValueTransfer(_) => Ok(TransactionType::ValueTransfer),
+            DataRequest(_) => Ok(TransactionType::DataRequest),
+            _ => Err(UnsupportedTransactionType(format!("{:?}", value))),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/wallet/src/repository/error.rs
+++ b/wallet/src/repository/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
     Failure(#[cause] failure::Error),
     #[fail(display = "key derivation failed: {}", _0)]
     KeyDerivation(#[cause] types::KeyDerivationError),
+    #[fail(display = "transaction type not supported: {}", _0)]
+    UnsupportedTransactionType(String),
 }
 
 impl From<failure::Error> for Error {

--- a/wallet/src/repository/wallet/tests/factories.rs
+++ b/wallet/src/repository/wallet/tests/factories.rs
@@ -58,6 +58,13 @@ pub fn transaction_id() -> types::TransactionId {
     types::TransactionId::SHA256(bytes)
 }
 
+pub fn vtt_from_body(body: types::VTTransactionBody) -> types::Transaction {
+    types::Transaction::ValueTransfer(VTTransaction {
+        body,
+        signatures: vec![],
+    })
+}
+
 #[derive(Default)]
 pub struct Input {
     transaction_id: Option<types::TransactionId>,


### PR DESCRIPTION
Forced implementation of `Sync` for `MemoHash`.

This is needed because `MemoHash::hash` is of type `Cell`, which in turn has constraint `!Sync`.

Putting `Cell` here gave us memoization through interior mutability. However, it prevented us
from sharing any structure containing a MemoHash from being shared across threads.

This implementation restores the possibility of sharing this structure across threads with
limited impact to thread safety, as the `Cell` itself is only set through calling
`<T: MemoizedHashable>::hash`, which is a pure method. Therefore the maximum impact is a race
condition in the case that `MemoHash::get` is called concurrently.
