### PR TITLE
misc bridge fixes

### DIFF
--- a/bridges/ethereum/src/actors/block_relay_and_poi.rs
+++ b/bridges/ethereum/src/actors/block_relay_and_poi.rs
@@ -34,7 +34,7 @@ pub fn block_relay_and_poi(
             let block_relay_contract = eth_state.block_relay_contract.clone();
             let config2 = config.clone();
 
-            let (block, _is_new_block) = match msg {
+            let (block, is_new_block) = match msg {
                 WitnetBlock::New(block) => (block, true),
                 WitnetBlock::Replay(block) => (block, false),
             };
@@ -51,7 +51,8 @@ pub fn block_relay_and_poi(
             };
 
             // Enable block relay?
-            if config.enable_block_relay {
+
+            if (is_new_block && config.enable_block_relay_new_blocks) || (!is_new_block && config.enable_block_relay_old_blocks) {
                 let block_epoch: U256 = block.block_header.beacon.checkpoint.into();
                 let dr_merkle_root: U256 =
                     match block.block_header.merkle_roots.dr_hash_merkle_root {

--- a/bridges/ethereum/src/actors/claim_and_post.rs
+++ b/bridges/ethereum/src/actors/claim_and_post.rs
@@ -365,7 +365,7 @@ fn claim_and_post_dr(
 
                         Either::B(witnet_client2
                             .execute("sendRequest", bdr_params)
-                            .map_err(|e| error!("{:?}", e))
+                            .map_err(|e| error!("sendRequest: {:?}", e))
                             .map(move |bdr_res| {
                                 debug!("sendRequest: {:?}", bdr_res);
                             }).then(|_| futures::failed(())))
@@ -426,7 +426,7 @@ fn claim_and_post_dr(
 
                     witnet_client
                         .execute("sendRequest", bdr_params)
-                        .map_err(|e| error!("{:?}", e))
+                        .map_err(|e| error!("sendRequest: {:?}", e))
                         .map(move |bdr_res| {
                             debug!("sendRequest: {:?}", bdr_res);
                         })

--- a/bridges/ethereum/src/actors/eth_event_stream.rs
+++ b/bridges/ethereum/src/actors/eth_event_stream.rs
@@ -133,7 +133,7 @@ pub fn eth_event_stream(
                                             contract::Options::default(),
                                             None,
                                         )
-                                        .map_err(|e| error!("{:?}", e))
+                                        .map_err(|e| error!("readDrHash: {:?}", e))
                                         .and_then(move |dr_tx_hash: U256| {
                                             let dr_tx_hash = Hash::SHA256(dr_tx_hash.into());
                                             info!(

--- a/bridges/ethereum/src/actors/witnet_block_stream.rs
+++ b/bridges/ethereum/src/actors/witnet_block_stream.rs
@@ -48,7 +48,7 @@ pub fn witnet_block_stream(
                     e.into_inner()
                 );
             } else {
-                error!("{:?}", e);
+                error!("Unhandled timeout error: {:?}", e);
             }
         })
         .then(|witnet_subscription_id_value| {

--- a/bridges/ethereum/src/config.rs
+++ b/bridges/ethereum/src/config.rs
@@ -47,6 +47,8 @@ pub struct Config {
     pub eth_event_polling_rate_ms: u64,
     /// Running in the witnet testnet?
     pub witnet_testnet: bool,
+    /// If readDrHash returns 0, try again later
+    pub read_dr_hash_interval_ms: u64,
     /// Gas limits for some methods. If missing, let the client estimate
     pub gas_limits: Gas,
 }

--- a/bridges/ethereum/src/config.rs
+++ b/bridges/ethereum/src/config.rs
@@ -43,6 +43,24 @@ pub struct Config {
     pub eth_event_polling_rate_ms: u64,
     /// Running in the witnet testnet?
     pub witnet_testnet: bool,
+    /// Gas limits for some methods. If missing, let the client estimate
+    pub gas_limits: Gas,
+}
+
+/// Gas limits for some methods. If missing, let the client estimate
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Gas {
+    /// claimDataRequests gas limit
+    pub claim_data_requests: Option<u64>,
+    /// postDataRequest gas limit
+    pub post_data_request: Option<u64>,
+    /// postNewBlock gas limit
+    pub post_new_block: Option<u64>,
+    /// reportDataRequestInclusion gas limit
+    pub report_data_request_inclusion: Option<u64>,
+    /// reportResult gas limit
+    pub report_result: Option<u64>,
 }
 
 /// Load configuration from a file written in Toml format.

--- a/bridges/ethereum/src/config.rs
+++ b/bridges/ethereum/src/config.rs
@@ -21,8 +21,12 @@ pub struct Config {
     pub block_relay_contract_addr: H160,
     /// Ethereum account used to create the transactions
     pub eth_account: H160,
-    /// Enable block relay from witnet to ethereum?
-    pub enable_block_relay: bool,
+    /// Enable block relay from witnet to ethereum, relay only new blocks
+    /// (blocks that were recently consolidated)
+    pub enable_block_relay_new_blocks: bool,
+    /// Enable block relay from witnet to ethereum, relay only old blocks
+    /// (old blocks that were never posted to the block relay)
+    pub enable_block_relay_old_blocks: bool,
     /// Enable data request claim + inclusion
     pub enable_claim_and_inclusion: bool,
     /// Enable data request result reporting

--- a/bridges/ethereum/src/main.rs
+++ b/bridges/ethereum/src/main.rs
@@ -75,7 +75,7 @@ fn post_example_dr(
                 opt.value = Some(U256::from_dec_str("2500000000000000").unwrap());
                 // The cost of posting a data request is mainly the storage, so
                 // big data requests may need bigger amounts of gas
-                opt.gas = Some(1_000_000.into());
+                opt.gas = config.gas_limits.post_data_request.map(Into::into);
             }),
         )
         .map(|tx| {

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -8,8 +8,12 @@ wbi_contract_addr = "0x49824bd89338C26Ea204F20AcbAd404CFeAB3301"
 block_relay_contract_addr = "0x1D774D4D7EC51B111EFE48EB5D53022C3e9CC4Af"
 # Ethereum account used to create the transactions
 eth_account = "0x20E56DAc7582782584c46061F382812D502Dd139"
-# Enable block relay from witnet to ethereum?
-enable_block_relay = true
+# Enable block relay from witnet to ethereum, relay only new blocks
+# (blocks that were recently consolidated)
+enable_block_relay_new_blocks = true
+# Enable block relay from witnet to ethereum, relay only old blocks
+# (old blocks that were never posted to the block relay, but contain a posted tally)
+enable_block_relay_old_blocks = true
 # Enable data request claim + inclusion
 enable_claim_and_inclusion = true
 # Enable data request result reporting

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -30,3 +30,12 @@ claim_dr_rate_ms = 30_000
 eth_event_polling_rate_ms = 1_000
 # Running in the witnet testnet?
 witnet_testnet = true
+
+# Gas limits for some methods.
+# To let the client estimate, comment out the methods
+[gas_limits]
+claim_data_requests = 500000
+post_data_request = 1000000
+post_new_block = 200000
+report_data_request_inclusion = 200000
+report_result = 200000


### PR DESCRIPTION
This makes a few breaking changes to the bridge configuration file.

`enable_block_relay` has been separated into two different flags:

```toml
# Enable block relay from witnet to ethereum, relay only new blocks
# (blocks that were recently consolidated)
enable_block_relay_new_blocks = true
# Enable block relay from witnet to ethereum, relay only old blocks
# (old blocks that were never posted to the block relay, but contain a posted tally)
enable_block_relay_old_blocks = true
```

And now the gas limits can be set in the config file:

```toml
# Gas limits for some methods.
# To let the client estimate, comment out the methods
[gas_limits]
claim_data_requests = 500000
post_data_request = 1000000
post_new_block = 200000
report_data_request_inclusion = 200000
report_result = 200000
```