### PR TITLE
Export private key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3919,9 +3919,11 @@ dependencies = [
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "webbrowser 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_config 0.3.2",
+ "witnet_crypto 0.3.2",
  "witnet_data_structures 0.3.2",
  "witnet_node 0.4.0",
  "witnet_rad 0.3.2",
+ "witnet_util 0.3.2",
  "witnet_validations 0.3.2",
  "witnet_wallet 0.3.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,11 @@ toml = "0.5.6"
 webbrowser = "0.5.2"
 
 witnet_config = { path = "./config" }
+witnet_crypto = { path = "./crypto" }
 witnet_data_structures = { path = "./data_structures" }
 witnet_node = { path = "./node", optional = true }
 witnet_rad = { path = "./rad" }
+witnet_util = { path = "./util" }
 witnet_validations = { path = "./validations" }
 witnet_wallet = { path = "./wallet", optional = true }
 

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -182,7 +182,7 @@ pub type CryptoEngine = Secp256k1<secp256k1::All>;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ExtendedSK {
     /// Secret key
-    secret_key: SK,
+    pub secret_key: SK,
     /// Chain code
     chain_code: Protected,
 }

--- a/util/src/credentials.rs
+++ b/util/src/credentials.rs
@@ -1,0 +1,25 @@
+use std::{fs::File, path::Path};
+
+/// Create a file to store credentials securely: it will only be readable by
+/// the user that created it
+#[cfg(unix)]
+pub fn create_credentials_file<P: AsRef<Path>>(path: P) -> Result<File, std::io::Error> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let file = File::create(path)?;
+    let mut perms = file.metadata()?.permissions();
+    // -rw-------
+    perms.set_mode(0o600);
+    file.set_permissions(perms)?;
+
+    Ok(file)
+}
+
+/// Create a file to store credentials securely (not supported in this architecture, will just
+/// create a normal file)
+#[cfg(not(unix))]
+pub fn create_credentials_file<P: AsRef<Path>>(path: P) -> Result<File, std::io::Error> {
+    let file = File::create(path)?;
+
+    Ok(file)
+}

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -8,6 +8,9 @@
 #![deny(unused_mut)]
 #![deny(missing_docs)]
 
+/// Utilities to securely store secrets in files
+pub mod credentials;
+
 /// Parse utilities
 pub mod parser;
 


### PR DESCRIPTION
Close #1033 

This PR adds the ability to export the private key associated to the identity used by the node. A new `exportPrivateKey` command can be used to print that private key:

```
$ cargo run -- node masterKeyExport
Private key for pkh twit1cpnnz00l0lg84mn6t8wsq855f88nx5rw6tkfkn:
xprv1qru3g4rsugt5edkkhpycn5xnxctdwd3zr6m0re294u6urwvzjcexzqya0njnwklpgs8t8ffu5cx3evlc72n5e7tyfyxmg4aaxjt30ls49c4mrp5y
```

Or write the private key to a file inside the storage dir specified in the config:
```
$ cargo run -- node masterKeyExport --write
Private key written to /home/t/witnet-rust/.witnet-rust-testnet-6/private_key_twit1cqhaxkxatx5uf7kr2qe9772qa2hqdp5705jwx4.txt
```

In the future, the `masterKeyImport` command will be used to restore the identity.