### PR TITLE
Add option to easily send value to a new wallet

### DIFF
--- a/wallet/src/actors/app/handlers/close_session.rs
+++ b/wallet/src/actors/app/handlers/close_session.rs
@@ -5,7 +5,6 @@ use crate::actors::app;
 use crate::types;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct CloseSessionRequest {
     pub(crate) session_id: types::SessionId,
 }

--- a/wallet/src/actors/app/handlers/create_data_req.rs
+++ b/wallet/src/actors/app/handlers/create_data_req.rs
@@ -6,7 +6,6 @@ use crate::types;
 use crate::types::{Hashable as _, ProtobufConvert as _};
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct CreateDataReqRequest {
     session_id: types::SessionId,
     wallet_id: String,
@@ -15,7 +14,6 @@ pub struct CreateDataReqRequest {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
 struct DataRequestOutput {
     data_request: RADRequest,
     witness_reward: u64,
@@ -30,7 +28,6 @@ struct DataRequestOutput {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
 struct RADRequest {
     time_lock: u64,
     retrieve: Vec<types::RADRetrieve>,
@@ -39,7 +36,6 @@ struct RADRequest {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct CreateDataReqResponse {
     pub transaction_id: String,
     pub transaction: types::Transaction,

--- a/wallet/src/actors/app/handlers/create_vtt.rs
+++ b/wallet/src/actors/app/handlers/create_vtt.rs
@@ -9,7 +9,6 @@ use crate::types::{Hashable as _, ProtobufConvert as _};
 use witnet_data_structures::chain::Environment;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct CreateVttRequest {
     session_id: types::SessionId,
     wallet_id: String,
@@ -21,7 +20,6 @@ pub struct CreateVttRequest {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
 /// Part of CreateVttResponse struct, containing additional data to be displayed in clients
 /// (e.g. in a confirmation screen)
 pub struct VttMetadata {
@@ -31,7 +29,6 @@ pub struct VttMetadata {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct CreateVttResponse {
     pub transaction_id: String,
     pub transaction: types::Transaction,

--- a/wallet/src/actors/app/handlers/create_wallet.rs
+++ b/wallet/src/actors/app/handlers/create_wallet.rs
@@ -7,7 +7,6 @@ use crate::actors::app;
 use crate::types;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct CreateWalletRequest {
     name: Option<String>,
     caption: Option<String>,
@@ -17,7 +16,6 @@ pub struct CreateWalletRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct CreateWalletResponse {
     pub wallet_id: String,
 }

--- a/wallet/src/actors/app/handlers/generate_address.rs
+++ b/wallet/src/actors/app/handlers/generate_address.rs
@@ -5,7 +5,6 @@ use crate::actors::app;
 use crate::{model, types};
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GenerateAddressRequest {
     session_id: types::SessionId,
     wallet_id: String,

--- a/wallet/src/actors/app/handlers/get.rs
+++ b/wallet/src/actors/app/handlers/get.rs
@@ -5,7 +5,6 @@ use crate::actors::app;
 use crate::types;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GetRequest {
     session_id: types::SessionId,
     wallet_id: String,

--- a/wallet/src/actors/app/handlers/get_addresses.rs
+++ b/wallet/src/actors/app/handlers/get_addresses.rs
@@ -7,7 +7,6 @@ use crate::actors::app;
 use crate::{constants, model, types};
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GetAddressesRequest {
     session_id: types::SessionId,
     wallet_id: String,

--- a/wallet/src/actors/app/handlers/get_balance.rs
+++ b/wallet/src/actors/app/handlers/get_balance.rs
@@ -5,7 +5,6 @@ use crate::actors::app;
 use crate::{model, types};
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GetBalanceRequest {
     session_id: types::SessionId,
     wallet_id: String,

--- a/wallet/src/actors/app/handlers/get_transactions.rs
+++ b/wallet/src/actors/app/handlers/get_transactions.rs
@@ -7,7 +7,6 @@ use crate::actors::app;
 use crate::{constants, model, types};
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct GetTransactionsRequest {
     session_id: types::SessionId,
     wallet_id: String,

--- a/wallet/src/actors/app/handlers/lock_wallet.rs
+++ b/wallet/src/actors/app/handlers/lock_wallet.rs
@@ -5,7 +5,6 @@ use crate::actors::app;
 use crate::types;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct LockWalletRequest {
     wallet_id: String,
     session_id: types::SessionId,

--- a/wallet/src/actors/app/handlers/send_transaction.rs
+++ b/wallet/src/actors/app/handlers/send_transaction.rs
@@ -5,7 +5,6 @@ use crate::actors::app;
 use crate::types;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct SendTransactionRequest {
     session_id: types::SessionId,
     wallet_id: String,

--- a/wallet/src/actors/app/handlers/set.rs
+++ b/wallet/src/actors/app/handlers/set.rs
@@ -5,7 +5,6 @@ use crate::actors::app;
 use crate::types;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct SetRequest {
     session_id: types::SessionId,
     wallet_id: String,

--- a/wallet/src/actors/app/handlers/subscribe.rs
+++ b/wallet/src/actors/app/handlers/subscribe.rs
@@ -5,7 +5,6 @@ use crate::actors::app;
 use crate::types;
 
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct SubscribeRequest {
     pub session_id: types::SessionId,
 }

--- a/wallet/src/actors/app/handlers/unlock_wallet.rs
+++ b/wallet/src/actors/app/handlers/unlock_wallet.rs
@@ -5,14 +5,12 @@ use crate::actors::app;
 use crate::types;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct UnlockWalletRequest {
     pub wallet_id: String,
     pub password: types::Password,
 }
 
 #[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct UnlockWalletResponse {
     session_id: types::SessionId,
     name: Option<String>,

--- a/wallet/src/actors/app/handlers/update_wallet.rs
+++ b/wallet/src/actors/app/handlers/update_wallet.rs
@@ -5,7 +5,6 @@ use crate::actors::app;
 use crate::types;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct UpdateWalletRequest {
     session_id: types::SessionId,
     wallet_id: String,

--- a/wallet/src/actors/app/routes.rs
+++ b/wallet/src/actors/app/routes.rs
@@ -44,13 +44,13 @@ macro_rules! routes {
 /// Macro to add multiple JSON-RPC methods that forward the request to the Node at once
 macro_rules! forwarded_routes {
     ($io:expr, $api:expr $(,)?) => {};
-    ($io:expr, $api:expr, $method:expr, $($args:tt)*) => {
+    ($io:expr, $api:expr, ($method_wallet:expr, $method_node:expr), $($args:tt)*) => {
         {
             let api_addr = $api.clone();
-            $io.add_method($method, move |params: Params| {
-                log::debug!("Forwarding request for method: {}", $method);
+            $io.add_method($method_wallet, move |params: Params| {
+                log::debug!("Forwarding request for method: {}", $method_wallet);
                 let msg = ForwardRequest {
-                    method: $method.to_string(),
+                    method: $method_node.to_string(),
                     params
                 };
                 api_addr.send(msg)
@@ -75,7 +75,7 @@ pub fn connect_routes<T, S>(
 {
     handler.add_subscription(
         "notifications",
-        ("subscribeNotifications", {
+        ("subscribe_notifications", {
             let addr = api.clone();
             move |params: Params, _meta, subscriber: Subscriber| {
                 let addr_subscription_id = addr.clone();
@@ -124,7 +124,7 @@ pub fn connect_routes<T, S>(
                 system_arbiter.send(f);
             }
         }),
-        ("unsubscribeNotifications", {
+        ("unsubscribe_notifications", {
             let addr = api.clone();
             move |subscription_id, _meta| {
                 addr.send(UnsubscribeRequest(subscription_id))
@@ -138,53 +138,53 @@ pub fn connect_routes<T, S>(
     forwarded_routes!(
         handler,
         api,
-        "getBlock",
-        "getBlockChain",
-        "getOutput",
-        "inventory",
+        ("get_block", "getBlock"),
+        ("get_block_chain", "getBlockChain"),
+        ("get_output", "getOutput"),
+        ("inventory", "inventory"),
     );
 
     routes!(
         handler,
         api,
-        ("Get-Wallet-Infos", "getWalletInfos", WalletInfosRequest),
+        ("Get-Wallet-Infos", "get_wallet_infos", WalletInfosRequest),
         (
             "Create-Mnemonics",
-            "createMnemonics",
+            "create_mnemonics",
             CreateMnemonicsRequest
         ),
-        ("Import-Seed", "importSeed", ImportSeedRequest),
-        ("Create-Wallet", "createWallet", CreateWalletRequest),
-        ("Update-Wallet", "updateWallet", UpdateWalletRequest),
-        ("Lock-Wallet", "lockWallet", LockWalletRequest),
-        ("Unlock-Wallet", "unlockWallet", UnlockWalletRequest),
-        ("Lock-Wallet", "lockWallet", LockWalletRequest),
-        ("Close-Session", "closeSession", CloseSessionRequest),
+        ("Import-Seed", "import_seed", ImportSeedRequest),
+        ("Create-Wallet", "create_wallet", CreateWalletRequest),
+        ("Update-Wallet", "update_wallet", UpdateWalletRequest),
+        ("Lock-Wallet", "lock_wallet", LockWalletRequest),
+        ("Unlock-Wallet", "unlock_wallet", UnlockWalletRequest),
+        ("Lock-Wallet", "lock_wallet", LockWalletRequest),
+        ("Close-Session", "close_session", CloseSessionRequest),
         (
             "Get-Transactions",
-            "getTransactions",
+            "get_transactions",
             GetTransactionsRequest
         ),
         (
             "Send-Transaction",
-            "sendTransaction",
+            "send_transaction",
             SendTransactionRequest
         ),
         (
             "Generate-Address",
-            "generateAddress",
+            "generate_address",
             GenerateAddressRequest
         ),
-        ("Get-Addresses", "getAddresses", GetAddressesRequest),
+        ("Get-Addresses", "get_addresses", GetAddressesRequest),
         (
             "Create-Data-Request",
-            "createDataRequest",
+            "create_data_request",
             CreateDataReqRequest
         ),
-        ("Create-Vtt", "createVtt", CreateVttRequest),
-        ("Run-Rad-Request", "runRadRequest", RunRadReqRequest),
+        ("Create-Vtt", "create_vtt", CreateVttRequest),
+        ("Run-Rad-Request", "run_rad_request", RunRadReqRequest),
         ("Set", "set", SetRequest),
         ("Get", "get", GetRequest),
-        ("Get-Balance", "getBalance", GetBalanceRequest),
+        ("Get-Balance", "get_balance", GetBalanceRequest),
     );
 }

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -136,3 +136,12 @@ pub struct TransactionComponents {
     pub sign_keys: Vec<SK>,
     pub used_utxos: Vec<model::OutPtr>,
 }
+
+/// Builds a `ValueTransferTransaction` from a list of `ValueTransferOutput`s
+#[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BuildVtt {
+    /// List of `ValueTransferOutput`s
+    pub vto: Vec<VttOutput>,
+    /// Fee
+    pub fee: u64,
+}


### PR DESCRIPTION
Close #1029 

Add optional field `prefill` to `unlock_wallet`

```
{
  "wallet_id": "...",
  "password": "...",
  "prefill": [1000, 2000, 3000]
}
```

This will generate 3 new addresses and send 1000 nanowits to the first address, 2000 to the second and 3000 to the third.

In case of error (if the node is not synced or it does not have any balance), the addresses are generated but will not receive any wits.