### PR TITLE
fix(node): race condition during ChainInfo loading

### DIFF
--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -501,7 +501,7 @@ impl ChainManager {
         self.chain_state
             .chain_info
             .as_ref()
-            .unwrap()
+            .expect("ChainInfo is None")
             .highest_block_checkpoint
     }
 


### PR DESCRIPTION
Sometimes, the node can panic when initializing because the `chain_info` is `None`. That's because one future was incorrectly spawned with `.spawn()` instead of `.wait()`.
Replace that `.spawn()` with a future chain so hopefully we prevent similar problems in the future.

Now the final `.wait(ctx)` blocks the actor until it is properly initialized.

Also, for some reason `cargo fmt` does not work on this file.