### PR TITLE
feat(wallet): implement epoch to timestamp conversion

### DIFF
--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -22,6 +22,7 @@ use jsonrpc_core as rpc;
 use jsonrpc_pubsub as pubsub;
 
 use witnet_config::config::Config;
+use witnet_data_structures::chain::EpochConstants;
 use witnet_net::{client::tcp::JsonRpcClient, server::ws::Server};
 
 mod account;
@@ -44,6 +45,10 @@ pub fn run(conf: Config) -> Result<(), Error> {
     let db_file_name = conf.wallet.db_file_name;
     let node_url = conf.wallet.node_url;
     let rocksdb_opts = conf.rocksdb.to_rocksdb_options();
+    let epoch_constants = EpochConstants {
+        checkpoint_zero_timestamp: conf.consensus_constants.checkpoint_zero_timestamp,
+        checkpoints_period: conf.consensus_constants.checkpoints_period,
+    };
 
     // Db-encryption params
     let db_hash_iterations = conf.wallet.db_encrypt_hash_iterations;
@@ -93,6 +98,7 @@ pub fn run(conf: Config) -> Result<(), Error> {
         db_hash_iterations,
         db_iv_length,
         db_salt_length,
+        epoch_constants,
     };
 
     let worker = actors::Worker::start(concurrency, db.clone(), params);

--- a/wallet/src/params.rs
+++ b/wallet/src/params.rs
@@ -1,4 +1,5 @@
 use crate::types;
+use witnet_data_structures::chain::EpochConstants;
 
 /// Cryptographic params that can be changed for each wallet.
 #[derive(Clone)]
@@ -11,6 +12,7 @@ pub struct Params {
     pub db_hash_iterations: u32,
     pub db_iv_length: usize,
     pub db_salt_length: usize,
+    pub epoch_constants: EpochConstants,
 }
 
 impl Default for Params {
@@ -24,6 +26,7 @@ impl Default for Params {
             db_hash_iterations: 10_000,
             db_iv_length: 16,
             db_salt_length: 32,
+            epoch_constants: EpochConstants::default(),
         }
     }
 }

--- a/wallet/src/repository/wallet/state.rs
+++ b/wallet/src/repository/wallet/state.rs
@@ -1,4 +1,5 @@
 use super::*;
+use witnet_data_structures::chain::EpochConstants;
 
 pub struct State {
     pub name: Option<String>,
@@ -11,4 +12,5 @@ pub struct State {
     pub balance: u64,
     pub transaction_next_id: u32,
     pub utxo_set: model::UtxoSet,
+    pub epoch_constants: EpochConstants,
 }


### PR DESCRIPTION
The wallet now reads the consensus constants from the config file (or uses the defaults if they are not present). These constants include the epoch zero timestamp and the checkpoints period, which are used to convert from epoch number to timestamp.