### PR TITLE
Import master key

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -261,6 +261,10 @@ pub struct Storage {
     /// Path to the directory that will contain the database. Used
     /// only if backend is RocksDB.
     pub db_path: PathBuf,
+    /// Path to the master key to import when initializing the node
+    #[partial_struct(skip)]
+    #[partial_struct(serde(default))]
+    pub master_key_import_path: Option<PathBuf>,
 }
 
 fn as_protected_string<'de, D>(deserializer: D) -> Result<Option<Protected>, D::Error>
@@ -518,6 +522,7 @@ impl Storage {
                 .db_path
                 .to_owned()
                 .unwrap_or_else(|| defaults.storage_db_path()),
+            master_key_import_path: config.master_key_import_path.clone(),
         }
     }
 }
@@ -755,6 +760,7 @@ mod tests {
             backend: StorageBackend::RocksDB,
             password: None,
             db_path: Some(PathBuf::from("other")),
+            master_key_import_path: None,
         };
         let config = Storage::from_partial(&partial_config, &Testnet1);
 

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -71,6 +71,10 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
                 config.storage.db_path = db;
             }
 
+            if let Some(master_key_import_path) = params.master_key_import {
+                config.storage.master_key_import_path = Some(master_key_import_path);
+            }
+
             config.connections.known_peers.extend(params.known_peers);
 
             node::actors::node::run(config, || {
@@ -258,6 +262,9 @@ pub struct ConfigParams {
     bootstrap_peers_period_seconds: Option<u64>,
     #[structopt(long = "db", help = NODE_DB_HELP)]
     db: Option<PathBuf>,
+    /// Path to file that contains the master key to import
+    #[structopt(long = "master-key-import")]
+    master_key_import: Option<PathBuf>,
 }
 
 static NODE_DB_HELP: &str = r#"Path to the node database. If not specified will use '.witnet-rust-mainnet' for mainnet, or '.witnet-rust-testnet-N' for testnet number N."#;


### PR DESCRIPTION
Close #1034 

The idea is to be able to import the master key when starting the node for the first time:

```
$ cargo run -- node run --master-key-import private_key_twit1wpmdccr3rn5zw8wuppu4wsg34ul9yvl6awt2q5.txt 
```

The current implementation requires users to delete the storage in order to import a different master key. This avoids any problems that could arise from people accidentally overwriting their private key and losing their mined wits. Also, it's significantly simpler to implement, as the current code assumes that the node master key never changes in many places.

This is the error that appears in the logs when trying to import a master key without deleting the storage:
```
[2020-03-04T11:47:04Z ERROR witnet_node::signature_mngr] Failed to configure master key: Tried to overwrite node master key with a different one.
    Node pkh:     twit19ddjj2w8vv98mzdujkzgw36kqtpnt3l22r9dj9
    Imported pkh: twit1wpmdccr3rn5zw8wuppu4wsg34ul9yvl6awt2q5
    
    In order to import a different master key, you need to export the current master key and delete the storage
Error: Non-zero exit code: 1
```

In order to be able to import a different master key without deleting the storage, we would need to re-index the list `own_utxos` with the new pkh. Otherwise only the imported reputation would be correct, the balance would be 0. That would still require stopping the node, though.