### PR TITLE
Change getBlockChain API to limit based on number of blocks

### DIFF
--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -99,8 +99,10 @@ impl Message for GetBlock {
 pub struct GetBlocksEpochRange {
     /// Range of Epochs (prefer using the new method to create a range)
     pub range: (Bound<Epoch>, Bound<Epoch>),
-    /// Maximum blocks limit
+    /// Maximum blocks limit. 0 means unlimited
     pub limit: usize,
+    /// Whether to apply the limit from the end: return the last n blocks
+    pub limit_from_end: bool,
 }
 
 impl GetBlocksEpochRange {
@@ -133,7 +135,15 @@ impl GetBlocksEpochRange {
         Self {
             range: (cloned(r.start_bound()), cloned(r.end_bound())),
             limit,
+            limit_from_end: false,
         }
+    }
+    /// new method with a specified limit, returning the last `limit` items
+    pub fn new_with_limit_from_end<R: RangeBounds<Epoch>>(r: R, limit: usize) -> Self {
+        let mut rb = Self::new_with_limit(r, limit);
+        rb.limit_from_end = true;
+
+        rb
     }
 }
 

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -42,7 +42,7 @@ pub fn raw(addr: SocketAddr) -> Result<(), failure::Error> {
     }
 }
 
-pub fn get_blockchain(addr: SocketAddr, epoch: i64, limit: u32) -> Result<(), failure::Error> {
+pub fn get_blockchain(addr: SocketAddr, epoch: i64, limit: i64) -> Result<(), failure::Error> {
     let mut stream = start_client(addr)?;
     let params = GetBlockChainParams { epoch, limit };
     let response = send_request(

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -124,12 +124,15 @@ pub enum Command {
         /// Socket address of the Witnet node to query.
         #[structopt(short = "n", long = "node")]
         node: Option<SocketAddr>,
-        /// First epoch for which to show block hashes. If negative, show blocks from the last n epochs.
-        #[structopt(long = "epoch", default_value = "-50")]
+        /// First epoch for which to return block hashes.
+        /// If negative, return block hashes from the last n epochs.
+        #[structopt(long = "epoch", allow_hyphen_values = true, default_value = "0")]
         epoch: i64,
-        /// Number of epochs for which to show block hashes. If zero, unlimited.
-        #[structopt(long = "limit", default_value = "0")]
-        limit: u32,
+        /// Number of block hashes to return.
+        /// If negative, return the last n block hashes from this epoch range.
+        /// If zero, unlimited.
+        #[structopt(long = "limit", allow_hyphen_values = true, default_value = "-50")]
+        limit: i64,
     },
     #[structopt(
         name = "getBlock",


### PR DESCRIPTION
Close #1058 

Now by default the `blockchain` CLI method will return the last 50 blocks.