### PR TITLE
feat: add option for disabling sensitive JSON-RPC methods

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -284,6 +284,8 @@ pub struct JsonRPC {
     /// JSON-RPC server address, that is, the socket address (interface ip and
     /// port) for the JSON-RPC server
     pub server_address: SocketAddr,
+    /// Enable methods not suitable for shared nodes
+    pub enable_sensitive_methods: bool,
 }
 
 /// Mining-related configuration
@@ -532,6 +534,10 @@ impl JsonRPC {
                 .server_address
                 .to_owned()
                 .unwrap_or_else(|| defaults.jsonrpc_server_address()),
+            enable_sensitive_methods: config
+                .enable_sensitive_methods
+                .to_owned()
+                .unwrap_or_else(|| defaults.jsonrpc_enable_sensitive_methods()),
         }
     }
 }
@@ -834,6 +840,7 @@ mod tests {
         let partial_config = PartialJsonRPC {
             enabled: None,
             server_address: Some(addr),
+            enable_sensitive_methods: None,
         };
         let config = JsonRPC::from_partial(&partial_config, &Testnet);
 

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -109,6 +109,11 @@ pub trait Defaults {
     /// Default JSON-RPC server addr
     fn jsonrpc_server_address(&self) -> SocketAddr;
 
+    /// JSON-RPC sensitive methods enabled by default
+    fn jsonrpc_enable_sensitive_methods(&self) -> bool {
+        true
+    }
+
     /// MiningManager, enabled by default
     fn mining_enabled(&self) -> bool {
         true

--- a/node/src/actors/json_rpc/server.rs
+++ b/node/src/actors/json_rpc/server.rs
@@ -60,7 +60,10 @@ impl JsonRpcServer {
                 let server_addr = config.jsonrpc.server_address;
                 act.server_addr = Some(server_addr);
                 // Create and store the JSON-RPC method handler
-                let jsonrpc_io = jsonrpc_io_handler(act.subscriptions.clone());
+                let jsonrpc_io = jsonrpc_io_handler(
+                    act.subscriptions.clone(),
+                    config.jsonrpc.enable_sensitive_methods,
+                );
                 act.jsonrpc_io = Some(Rc::new(jsonrpc_io));
 
                 // Bind TCP listener to this address


### PR DESCRIPTION
Close #1050 

Now, users can set `enable_sensitive_methods = false` to disable the following JSON-RPC methods:

```
"createVRF",
"getPkh",
"getPublicKey",
"masterKeyExport",
"sendRequest",
"sendValue",
"sign",
```

Trying to use one of these methods when it has been disabled will result in a custom "unauthorized" error:

```
 $ cargo run -- -c witnet_01.toml node getPkh
    Finished dev [unoptimized + debuginfo] target(s) in 0.20s
     Running `target/debug/witnet -c witnet_01.toml node getPkh`
Loading config from: witnet_01.toml
Setting log level to: ERROR, source: Config
Error: ServerError { code: -32603, message: "Method getPkh not allowed while node setting json_rpc.enable_sensitive_methods is set to false" }
```

The default behavior is the same as before (all methods enabled), this is not a breaking change.

Unresolved issues:

* Print warning when starting the JSON-RPC server with `enable_sensitive_methods = true` and listening to a non-local address?
* Alternative names: `expose_private_methods`, `enable_personal_methods`, `public_mode`, `allow_insecure_methods`