### PR TITLE
fix: rename testnet3 environment to testnet

### DIFF
--- a/bridges/ethereum/src/config.rs
+++ b/bridges/ethereum/src/config.rs
@@ -84,7 +84,7 @@ pub fn from_file<S: AsRef<Path>>(file: S) -> Result<Config, Box<dyn std::error::
     let c: Config = toml::from_str(&contents)?;
     // Set environment: must be the same as the witnet node
     witnet_data_structures::set_environment(if c.witnet_testnet {
-        Environment::Testnet1
+        Environment::Testnet
     } else {
         Environment::Mainnet
     });

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -18,7 +18,7 @@
 //!
 //! * By creating the instance manually:
 //! ```text
-//! Config { environment: Environment::Testnet1, ... }
+//! Config { environment: Environment::Testnet, ... }
 //! ```
 //! * By using the [Default](std::default::Default) instance
 //! ```
@@ -46,7 +46,7 @@ use std::time::Duration;
 use log::warn;
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::defaults::{Defaults, Testnet1, Testnet3};
+use crate::defaults::{Defaults, Testnet};
 use crate::dirs;
 use partial_struct::PartialStruct;
 use witnet_crypto::hash::HashFunction;
@@ -340,8 +340,7 @@ impl Config {
             Environment::Mainnet => {
                 panic!("Config with mainnet environment is currently not allowed");
             }
-            Environment::Testnet1 => &Testnet1,
-            Environment::Testnet3 => &Testnet3,
+            Environment::Testnet => &Testnet,
         };
 
         let consensus_constants = match config.environment {
@@ -357,10 +356,7 @@ impl Config {
                 consensus_constants_from_partial(&consensus_constants_no_changes, defaults)
             }
             // In testnet, allow to override the consensus constants
-            Environment::Testnet1 => {
-                consensus_constants_from_partial(&config.consensus_constants, defaults)
-            }
-            Environment::Testnet3 => {
+            Environment::Testnet => {
                 consensus_constants_from_partial(&config.consensus_constants, defaults)
             }
         };
@@ -749,9 +745,9 @@ mod tests {
     #[test]
     fn test_storage_default_from_partial() {
         let partial_config = PartialStorage::default();
-        let config = Storage::from_partial(&partial_config, &Testnet1);
+        let config = Storage::from_partial(&partial_config, &Testnet);
 
-        assert_eq!(config.db_path.to_str(), Testnet1.storage_db_path().to_str());
+        assert_eq!(config.db_path.to_str(), Testnet.storage_db_path().to_str());
     }
 
     #[test]
@@ -762,7 +758,7 @@ mod tests {
             db_path: Some(PathBuf::from("other")),
             master_key_import_path: None,
         };
-        let config = Storage::from_partial(&partial_config, &Testnet1);
+        let config = Storage::from_partial(&partial_config, &Testnet);
 
         assert_eq!(config.db_path.to_str(), Some("other"));
     }
@@ -770,29 +766,29 @@ mod tests {
     #[test]
     fn test_connections_default_from_partial() {
         let partial_config = PartialConnections::default();
-        let config = Connections::from_partial(&partial_config, &Testnet1);
+        let config = Connections::from_partial(&partial_config, &Testnet);
 
-        assert_eq!(config.server_addr, Testnet1.connections_server_addr());
-        assert_eq!(config.inbound_limit, Testnet1.connections_inbound_limit());
-        assert_eq!(config.outbound_limit, Testnet1.connections_outbound_limit());
-        assert_eq!(config.known_peers, Testnet1.connections_known_peers());
+        assert_eq!(config.server_addr, Testnet.connections_server_addr());
+        assert_eq!(config.inbound_limit, Testnet.connections_inbound_limit());
+        assert_eq!(config.outbound_limit, Testnet.connections_outbound_limit());
+        assert_eq!(config.known_peers, Testnet.connections_known_peers());
         assert_eq!(
             config.bootstrap_peers_period,
-            Testnet1.connections_bootstrap_peers_period()
+            Testnet.connections_bootstrap_peers_period()
         );
         assert_eq!(
             config.storage_peers_period,
-            Testnet1.connections_storage_peers_period()
+            Testnet.connections_storage_peers_period()
         );
         assert_eq!(
             config.discovery_peers_period,
-            Testnet1.connections_discovery_peers_period()
+            Testnet.connections_discovery_peers_period()
         );
         assert_eq!(
             config.handshake_timeout,
-            Testnet1.connections_handshake_timeout()
+            Testnet.connections_handshake_timeout()
         );
-        assert_eq!(config.blocks_timeout, Testnet1.connections_blocks_timeout());
+        assert_eq!(config.blocks_timeout, Testnet.connections_blocks_timeout());
     }
 
     #[test]
@@ -813,7 +809,7 @@ mod tests {
             consensus_c: Some(51),
             bucketing_update_period: Some(200),
         };
-        let config = Connections::from_partial(&partial_config, &Testnet1);
+        let config = Connections::from_partial(&partial_config, &Testnet);
 
         assert_eq!(config.server_addr, addr);
         assert_eq!(config.inbound_limit, 3);
@@ -833,9 +829,9 @@ mod tests {
     #[test]
     fn test_jsonrpc_default_from_partial() {
         let partial_config = PartialJsonRPC::default();
-        let config = JsonRPC::from_partial(&partial_config, &Testnet1);
+        let config = JsonRPC::from_partial(&partial_config, &Testnet);
 
-        assert_eq!(config.server_address, Testnet1.jsonrpc_server_address());
+        assert_eq!(config.server_address, Testnet.jsonrpc_server_address());
     }
 
     #[test]
@@ -845,7 +841,7 @@ mod tests {
             enabled: None,
             server_address: Some(addr),
         };
-        let config = JsonRPC::from_partial(&partial_config, &Testnet1);
+        let config = JsonRPC::from_partial(&partial_config, &Testnet);
 
         assert_eq!(config.server_address, addr);
     }
@@ -855,59 +851,59 @@ mod tests {
         let partial_config = PartialConfig::default();
         let config = Config::from_partial(&partial_config);
 
-        assert_eq!(config.environment, Environment::Testnet3);
+        assert_eq!(config.environment, Environment::Testnet);
         assert_eq!(
             config.connections.server_addr,
-            Testnet3.connections_server_addr()
+            Testnet.connections_server_addr()
         );
         assert_eq!(
             config.connections.inbound_limit,
-            Testnet3.connections_inbound_limit()
+            Testnet.connections_inbound_limit()
         );
         assert_eq!(
             config.connections.outbound_limit,
-            Testnet3.connections_outbound_limit()
+            Testnet.connections_outbound_limit()
         );
         assert_eq!(
             config.connections.known_peers,
-            Testnet3.connections_known_peers()
+            Testnet.connections_known_peers()
         );
         assert_eq!(
             config.connections.bootstrap_peers_period,
-            Testnet3.connections_bootstrap_peers_period()
+            Testnet.connections_bootstrap_peers_period()
         );
         assert_eq!(
             config.connections.storage_peers_period,
-            Testnet3.connections_storage_peers_period()
+            Testnet.connections_storage_peers_period()
         );
         assert_eq!(
             config.connections.discovery_peers_period,
-            Testnet3.connections_discovery_peers_period()
+            Testnet.connections_discovery_peers_period()
         );
         assert_eq!(
             config.connections.feeler_peers_period,
-            Testnet3.connections_feeler_peers_period()
+            Testnet.connections_feeler_peers_period()
         );
         assert_eq!(
             config.connections.handshake_timeout,
-            Testnet3.connections_handshake_timeout()
+            Testnet.connections_handshake_timeout()
         );
-        assert_eq!(config.storage.db_path, Testnet3.storage_db_path());
+        assert_eq!(config.storage.db_path, Testnet.storage_db_path());
         assert_eq!(
             config.jsonrpc.server_address,
-            Testnet3.jsonrpc_server_address()
+            Testnet.jsonrpc_server_address()
         );
         assert_eq!(
             config.connections.blocks_timeout,
-            Testnet3.connections_blocks_timeout()
+            Testnet.connections_blocks_timeout()
         );
         assert_eq!(
             config.connections.consensus_c,
-            Testnet3.connections_consensus_c()
+            Testnet.connections_consensus_c()
         );
         assert_eq!(
             config.connections.bucketing_update_period,
-            Testnet3.connections_bucketing_update_period()
+            Testnet.connections_bucketing_update_period()
         );
     }
 }

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -269,11 +269,8 @@ pub trait Defaults {
 /// Struct that will implement all the mainnet defaults
 pub struct Mainnet;
 
-/// Struct that will implement all the testnet-1 defaults
-pub struct Testnet1;
-
-/// Struct that will implement all the testnet-3 defaults
-pub struct Testnet3;
+/// Struct that will implement all the testnet defaults
+pub struct Testnet;
 
 impl Defaults for Mainnet {
     fn connections_server_addr(&self) -> SocketAddr {
@@ -285,7 +282,7 @@ impl Defaults for Mainnet {
     }
 
     fn storage_db_path(&self) -> PathBuf {
-        PathBuf::from(".witnet-rust-mainnet")
+        PathBuf::from(".witnet")
     }
 
     fn consensus_constants_checkpoint_zero_timestamp(&self) -> i64 {
@@ -295,7 +292,7 @@ impl Defaults for Mainnet {
     }
 }
 
-impl Defaults for Testnet1 {
+impl Defaults for Testnet {
     fn connections_server_addr(&self) -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 21337)
     }
@@ -305,29 +302,7 @@ impl Defaults for Testnet1 {
     }
 
     fn storage_db_path(&self) -> PathBuf {
-        PathBuf::from(".witnet-rust-testnet-1")
-    }
-
-    fn connections_bootstrap_peers_period(&self) -> Duration {
-        Duration::from_secs(15)
-    }
-
-    fn consensus_constants_checkpoint_zero_timestamp(&self) -> i64 {
-        1_548_855_420
-    }
-}
-
-impl Defaults for Testnet3 {
-    fn connections_server_addr(&self) -> SocketAddr {
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 21337)
-    }
-
-    fn jsonrpc_server_address(&self) -> SocketAddr {
-        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 21338)
-    }
-
-    fn storage_db_path(&self) -> PathBuf {
-        PathBuf::from(".witnet-rust-testnet-3")
+        PathBuf::from(".witnet")
     }
 
     fn connections_bootstrap_peers_period(&self) -> Duration {

--- a/config/src/loaders/toml.rs
+++ b/config/src/loaders/toml.rs
@@ -87,7 +87,7 @@ mod tests {
         super::FILE_CONTENTS.with(|cell| {
             cell.set(
                 r"
-environment = 'testnet-1'
+environment = 'testnet'
 [connections]
 inbound_limit = 999
     ",
@@ -96,7 +96,7 @@ inbound_limit = 999
         let filename = Path::new("config.toml");
         let config = super::from_file(&filename).unwrap();
 
-        assert_eq!(config.environment, Environment::Testnet1);
+        assert_eq!(config.environment, Environment::Testnet);
         assert_eq!(config.connections.inbound_limit, Some(999));
     }
 

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -63,16 +63,13 @@ pub enum Environment {
     #[serde(rename = "mainnet")]
     Mainnet,
     /// "testnet" environment
-    #[serde(rename = "testnet-1")]
-    Testnet1,
-    /// "testnet" environment
-    #[serde(rename = "testnet-3")]
-    Testnet3,
+    #[serde(rename = "testnet")]
+    Testnet,
 }
 
 impl Default for Environment {
     fn default() -> Environment {
-        Environment::Testnet3
+        Environment::Testnet
     }
 }
 
@@ -80,8 +77,7 @@ impl fmt::Display for Environment {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let s = match self {
             Environment::Mainnet => "mainnet",
-            Environment::Testnet1 => "testnet1",
-            Environment::Testnet3 => "testnet3",
+            Environment::Testnet => "testnet",
         };
 
         f.write_str(s)
@@ -2596,10 +2592,10 @@ mod tests {
 
         // If we change the environment, the prefix and the checksum change
         let addr_testnet = "twit1gdm8mqlz8lxtj05w05mw63jvecyenvuasgmfk9";
-        assert_eq!(pkh.bech32(Environment::Testnet1), addr_testnet);
+        assert_eq!(pkh.bech32(Environment::Testnet), addr_testnet);
         // But the PKH is the same as mainnet
         assert_eq!(
-            PublicKeyHash::from_bech32(Environment::Testnet1, addr_testnet).unwrap(),
+            PublicKeyHash::from_bech32(Environment::Testnet, addr_testnet).unwrap(),
             pkh
         );
         // Although if we try to deserialize this as a mainnet address, it will fail

--- a/node/tests/config_test.rs
+++ b/node/tests/config_test.rs
@@ -12,7 +12,7 @@ fn test_get_config() {
 
         let fut = config_mngr::get()
             .and_then(|config| {
-                assert_eq!(Environment::Testnet3, config.environment);
+                assert_eq!(Environment::Testnet, config.environment);
 
                 Ok(())
             })

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -99,7 +99,7 @@ pub fn get_pkh(addr: SocketAddr) -> Result<(), failure::Error> {
     let pkh = parse_response::<PublicKeyHash>(&response)?;
 
     println!("{}", pkh);
-    println!("Testnet address: {}", pkh.bech32(Environment::Testnet1));
+    println!("Testnet address: {}", pkh.bech32(Environment::Testnet));
     println!("Mainnet address: {}", pkh.bech32(Environment::Mainnet));
 
     Ok(())

--- a/wallet/src/actors/app/handlers/create_vtt.rs
+++ b/wallet/src/actors/app/handlers/create_vtt.rs
@@ -95,7 +95,7 @@ fn validate_address(
 ) -> Result<types::PublicKeyHash, app::ValidationErrors> {
     types::PublicKeyHash::from_bech32(
         if testnet {
-            Environment::Testnet1
+            Environment::Testnet
         } else {
             Environment::Mainnet
         },

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -129,7 +129,7 @@ where
 
         let pkh = witnet_data_structures::chain::PublicKey::from(key).pkh();
         let address = pkh.bech32(if self.params.testnet {
-            Environment::Testnet1
+            Environment::Testnet
         } else {
             Environment::Mainnet
         });
@@ -663,7 +663,7 @@ where
                     .ok_or_else(|| Error::TransactionBalanceOverflow)?;
 
                 let address = output.pkh.bech32(if self.params.testnet {
-                    Environment::Testnet1
+                    Environment::Testnet
                 } else {
                     Environment::Mainnet
                 });


### PR DESCRIPTION
Close #1073 

This can break some users configuration files: if they had explicitly set `environment = "testnet-3"`, they will see this error:

```
Error: Error parsing config file: unknown variant `testnet-3`, expected `mainnet` or `testnet` for key `environment` at line 40 column 1
```

But the default configuration file does not have that field, so hopefully this doesn't cause many problems.

This also changes the default storage path from `.witnet-rust-testnet-3` to `.witnet`. So users that have not set any `db_path` in the configuration file will have to manually rename that folder. But since the default configuration file now explicitly sets `db_path = ".witnet"`, this shouldn't be a common problem.