### PR TITLE
Limit the number of retrieved sources per epoch

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -304,6 +304,11 @@ pub struct JsonRPC {
 pub struct Mining {
     /// Binary flag telling whether to enable the MiningManager or not
     pub enabled: bool,
+    /// Limits the number of retrievals to perform during a single epoch.
+    /// This tries to prevent nodes from forking out or being left in a
+    /// bad condition if hitting bandwidth or CPU bottlenecks.
+    /// Set to 0 totally disable participation in resolving data requests.
+    pub data_request_max_retrievals_per_epoch: u16,
     /// Timeout for data request retrieval and aggregation execution.
     /// This should usually be slightly below half the checkpoints period.
     /// Set to 0 to disable timeouts.
@@ -563,6 +568,10 @@ impl Mining {
                 .data_request_timeout
                 .to_owned()
                 .unwrap_or_else(|| defaults.mining_data_request_timeout()),
+            data_request_max_retrievals_per_epoch: config
+                .data_request_max_retrievals_per_epoch
+                .to_owned()
+                .unwrap_or_else(|| defaults.mining_data_request_max_retrievals_per_epoch()),
             genesis_path: config
                 .genesis_path
                 .clone()

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -124,6 +124,12 @@ pub trait Defaults {
         Duration::from_secs(2)
     }
 
+    /// Set the limit of retrievals per epoch to 65_535.
+    /// This in practice equals no limit enforcement.
+    fn mining_data_request_max_retrievals_per_epoch(&self) -> u16 {
+        core::u16::MAX
+    }
+
     /// Genesis block path, "./genesis_block.json" by default
     fn mining_genesis_path(&self) -> String {
         "genesis_block.json".to_string()

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -68,6 +68,9 @@ impl ChainManager {
                     act.data_request_timeout = Some(config.mining.data_request_timeout);
                 }
 
+                // Set the retrievals limit per epoch, as read from the configuration
+                act.data_request_max_retrievals_per_epoch = config.mining.data_request_max_retrievals_per_epoch;
+
                 act.tx_pending_timeout = config.mempool.tx_pending_timeout;
 
                 let magic = consensus_constants.get_magic();

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -161,6 +161,8 @@ pub struct ChainManager {
     consensus_c: u32,
     /// Constants used to convert between epoch and timestamp
     epoch_constants: Option<EpochConstants>,
+    /// Maximum number of sources to retrieve in a single epoch
+    data_request_max_retrievals_per_epoch: u16,
     /// Timeout for data request retrieval and aggregation execution
     data_request_timeout: Option<Duration>,
     /// Pending transaction timeout

--- a/witnet.toml
+++ b/witnet.toml
@@ -26,6 +26,7 @@ update_period_seconds = 8000000
 
 [mining]
 enabled = true
+data_request_max_retrievals_per_epoch = 30
 data_request_timeout_milliseconds = 2000
 genesis_path = "genesis_block.json"
 


### PR DESCRIPTION
This PR introduces a configuration entry, `data_request_max_retrievals_per_epoch`, that enables setting a limit on the number of sources that can be retrieved in a single epoch.

The motivation for this change is reducing the likelihood for a node to be de-synced because of some retrievals draining way too much resources.

Solve #1098