### PR TITLE
Make retrieval timeout be expressed in milliseconds

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -219,6 +219,16 @@ pub struct Connections {
     pub bucketing_update_period: i64,
 }
 
+fn from_millis<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(match u64::deserialize(deserializer) {
+        Ok(secs) => Some(Duration::from_millis(secs)),
+        Err(_) => None,
+    })
+}
+
 fn from_secs<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
 where
     D: Deserializer<'de>,
@@ -299,8 +309,8 @@ pub struct Mining {
     /// Set to 0 to disable timeouts.
     #[partial_struct(serde(
         default,
-        deserialize_with = "from_secs",
-        rename = "data_request_timeout_seconds"
+        deserialize_with = "from_millis",
+        rename = "data_request_timeout_millis"
     ))]
     pub data_request_timeout: Duration,
     /// Genesis block path

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -310,7 +310,7 @@ pub struct Mining {
     #[partial_struct(serde(
         default,
         deserialize_with = "from_millis",
-        rename = "data_request_timeout_millis"
+        rename = "data_request_timeout_milliseconds"
     ))]
     pub data_request_timeout: Duration,
     /// Genesis block path

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -121,10 +121,7 @@ pub trait Defaults {
 
     /// Timeout for data request retrieval and aggregation execution
     fn mining_data_request_timeout(&self) -> Duration {
-        // Default to 1/10 of the checkpoints period
-        Duration::from_secs(u64::from(
-            self.consensus_constants_checkpoints_period() / 10,
-        ))
+        Duration::from_secs(2)
     }
 
     /// Genesis block path, "./genesis_block.json" by default

--- a/witnet.toml
+++ b/witnet.toml
@@ -26,7 +26,7 @@ update_period_seconds = 8000000
 
 [mining]
 enabled = true
-data_request_timeout_seconds = 5
+data_request_timeout_millis = 2000
 genesis_path = "genesis_block.json"
 
 [log]

--- a/witnet.toml
+++ b/witnet.toml
@@ -26,7 +26,7 @@ update_period_seconds = 8000000
 
 [mining]
 enabled = true
-data_request_timeout_millis = 2000
+data_request_timeout_milliseconds = 2000
 genesis_path = "genesis_block.json"
 
 [log]


### PR DESCRIPTION
Using milliseconds gives finer granularity and adapts better to reality, as most APIs should normally return a result or an error under 1 second.

The default is changed to 1/30th of the epoch length, in line with #1099.

The `witnet.toml` config file is also changed so it uses `1000` milliseconds.