### PR TITLE
feat(config): set consensus constants for T7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "witnet"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "bytecount 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 publish = false
 repository = "witnet/witnet-rust"

--- a/witnet.toml
+++ b/witnet.toml
@@ -14,12 +14,11 @@ enabled = true
 server_address = "127.0.0.1:21338"
 
 [consensus_constants]
-checkpoints_period = 30
-checkpoint_zero_timestamp = 1584111600
-bootstrap_hash = "00000000000000000000000000000000000000007769746e65742d302e372e30"
-genesis_hash = "7a7a438b857e8a50fb3281df32b34f8acd930da8f0d51f308903c8a55e6ff7a9"
+checkpoints_period = 45
+checkpoint_zero_timestamp = 1584748800
+bootstrap_hash = "00000000000000000000000000000000000000007769746e65742d302e372e31"
+genesis_hash = "53cf1a851e686292438ebec48e8c502f58d4cca9013e4fed3db114be0cb40d23"
 mining_replication_factor = 1
-activity_period = 240
 
 [ntp]
 update_period_seconds = 8000000


### PR DESCRIPTION
This PR needs to be rebased to #1099, #1101 and #1105 upon their merge.

The used genesis block is https://github.com/witnet/genesis_block/blob/master/testnet_0.7.1_genesis_block.json

Checkpoint zero is intentionally in the future (2020-03-21 00:00:00 UTC).