### PR TITLE
Store coin age in UTXO set 

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1942,7 +1942,12 @@ pub enum DataRequestStage {
 /// Unspent Outputs Pool
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct UnspentOutputsPool {
+    /// Map of output pointer to value transfer output
     map: HashMap<OutputPointer, ValueTransferOutput>,
+    /// Map of transaction hash to a tuple of:
+    /// * The epoch of the block that included the transaction
+    /// * A reference count, used to keep this map clear after removing transactions
+    transaction_epoch: HashMap<Hash, (Epoch, u32)>,
 }
 
 impl UnspentOutputsPool {
@@ -1966,16 +1971,40 @@ impl UnspentOutputsPool {
         &mut self,
         k: OutputPointer,
         v: ValueTransferOutput,
+        block_epoch: Epoch,
     ) -> Option<ValueTransferOutput> {
-        self.map.insert(k, v)
+        let transaction_id = k.transaction_id;
+        let old_vto = self.map.insert(k.clone(), v);
+        if old_vto.is_none() {
+            let (transaction_epoch, refcount) = self
+                .transaction_epoch
+                .entry(transaction_id)
+                .or_insert((block_epoch, 0));
+            *refcount += 1;
+            // A transaction can only live inside one block, so the epoch must be equal
+            assert_eq!(block_epoch, *transaction_epoch);
+        } else {
+            // Tried to insert an existing transaction again
+            // TODO: This shouldn't really happen, panic?
+            panic!("{} inserted twice to UTXO set", k);
+        }
+
+        old_vto
     }
 
-    pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<ValueTransferOutput>
-    where
-        OutputPointer: std::borrow::Borrow<Q>,
-        Q: std::hash::Hash + Eq,
-    {
-        self.map.remove(k)
+    pub fn remove(&mut self, k: &OutputPointer) -> Option<ValueTransferOutput> {
+        let vto = self.map.remove(k);
+
+        if vto.is_some() {
+            // Decrease refcount
+            let (_epoch, refcount) = self.transaction_epoch.get_mut(&k.transaction_id).unwrap();
+            *refcount -= 1;
+            if *refcount == 0 {
+                self.transaction_epoch.remove(&k.transaction_id);
+            }
+        }
+
+        vto
     }
 
     pub fn drain(
@@ -1986,6 +2015,19 @@ impl UnspentOutputsPool {
 
     pub fn iter(&self) -> std::collections::hash_map::Iter<OutputPointer, ValueTransferOutput> {
         self.map.iter()
+    }
+
+    /// Returns the epoch of the block that included the transaction referenced
+    /// by this OutputPointer. The difference between that epoch and the
+    /// current epoch is the "coin age".
+    pub fn utxo_epoch(&self, k: &OutputPointer) -> Option<Epoch> {
+        if !self.map.contains_key(k) {
+            None
+        } else {
+            self.transaction_epoch
+                .get(&k.transaction_id)
+                .map(|(epoch, _refcount)| *epoch)
+        }
     }
 }
 
@@ -2284,6 +2326,7 @@ fn update_utxo_outputs(
     utxo: &mut UnspentOutputsPool,
     outputs: &[ValueTransferOutput],
     txn_hash: Hash,
+    block_epoch: Epoch,
 ) {
     for (index, output) in outputs.iter().enumerate() {
         // Add the new outputs to the utxo_set
@@ -2292,7 +2335,7 @@ fn update_utxo_outputs(
             output_index: u32::try_from(index).unwrap(),
         };
 
-        utxo.insert(output_pointer, output.clone());
+        utxo.insert(output_pointer, output.clone(), block_epoch);
     }
 }
 
@@ -2300,6 +2343,7 @@ fn update_utxo_outputs(
 pub fn generate_unspent_outputs_pool(
     unspent_outputs_pool: &UnspentOutputsPool,
     transactions: &[Transaction],
+    block_epoch: Epoch,
 ) -> UnspentOutputsPool {
     // Create a copy of the state "unspent_outputs_pool"
     let mut unspent_outputs = unspent_outputs_pool.clone();
@@ -2309,20 +2353,36 @@ pub fn generate_unspent_outputs_pool(
         match transaction {
             Transaction::ValueTransfer(vt_transaction) => {
                 update_utxo_inputs(&mut unspent_outputs, &vt_transaction.body.inputs);
-                update_utxo_outputs(&mut unspent_outputs, &vt_transaction.body.outputs, txn_hash);
+                update_utxo_outputs(
+                    &mut unspent_outputs,
+                    &vt_transaction.body.outputs,
+                    txn_hash,
+                    block_epoch,
+                );
             }
             Transaction::DataRequest(dr_transaction) => {
                 update_utxo_inputs(&mut unspent_outputs, &dr_transaction.body.inputs);
-                update_utxo_outputs(&mut unspent_outputs, &dr_transaction.body.outputs, txn_hash);
+                update_utxo_outputs(
+                    &mut unspent_outputs,
+                    &dr_transaction.body.outputs,
+                    txn_hash,
+                    block_epoch,
+                );
             }
             Transaction::Tally(tally_transaction) => {
-                update_utxo_outputs(&mut unspent_outputs, &tally_transaction.outputs, txn_hash);
+                update_utxo_outputs(
+                    &mut unspent_outputs,
+                    &tally_transaction.outputs,
+                    txn_hash,
+                    block_epoch,
+                );
             }
             Transaction::Mint(mint_transaction) => {
                 update_utxo_outputs(
                     &mut unspent_outputs,
                     &[mint_transaction.output.clone()],
                     txn_hash,
+                    block_epoch,
                 );
             }
             _ => {}
@@ -3126,5 +3186,84 @@ mod tests {
         assert_eq!(rep_engine.threshold_factor(7), 50);
         assert_eq!(rep_engine.threshold_factor(8), 100);
         assert_eq!(rep_engine.threshold_factor(9), u32::max_value());
+    }
+
+    #[test]
+    fn utxo_set_coin_age() {
+        let mut p = UnspentOutputsPool::default();
+        let v = || ValueTransferOutput::default();
+
+        let k0: OutputPointer =
+            "0222222222222222222222222222222222222222222222222222222222222222:0"
+                .parse()
+                .unwrap();
+        p.insert(k0.clone(), v(), 0);
+        assert_eq!(p.utxo_epoch(&k0), Some(0));
+
+        let k1: OutputPointer =
+            "1222222222222222222222222222222222222222222222222222222222222222:0"
+                .parse()
+                .unwrap();
+        p.insert(k1.clone(), v(), 1);
+        assert_eq!(p.utxo_epoch(&k1), Some(1));
+
+        // k2 points to the same transaction as k1, so they must have the same coin age
+        let k2: OutputPointer =
+            "1222222222222222222222222222222222222222222222222222222222222222:1"
+                .parse()
+                .unwrap();
+        p.insert(k2.clone(), v(), 1);
+        assert_eq!(p.utxo_epoch(&k2), Some(1));
+
+        // Removing k2 should not affect k1
+        p.remove(&k2);
+        assert_eq!(p.utxo_epoch(&k2), None);
+        assert_eq!(p.utxo_epoch(&k1), Some(1));
+        assert_eq!(p.utxo_epoch(&k0), Some(0));
+
+        p.remove(&k1);
+        assert_eq!(p.utxo_epoch(&k2), None);
+        assert_eq!(p.utxo_epoch(&k1), None);
+        assert_eq!(p.utxo_epoch(&k0), Some(0));
+
+        p.remove(&k0);
+        assert_eq!(p.utxo_epoch(&k0), None);
+
+        assert_eq!(p, UnspentOutputsPool::default());
+    }
+
+    #[test]
+    #[should_panic]
+    fn utxo_set_insert_twice() {
+        // Inserting the same input twice into the UTXO set panics
+        let mut p = UnspentOutputsPool::default();
+        let v = || ValueTransferOutput::default();
+
+        let k0: OutputPointer =
+            "0222222222222222222222222222222222222222222222222222222222222222:0"
+                .parse()
+                .unwrap();
+        p.insert(k0.clone(), v(), 0);
+        p.insert(k0, v(), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn utxo_set_insert_same_transaction_different_epoch() {
+        // Inserting the same transaction twice with different block epoch number panics
+        let mut p = UnspentOutputsPool::default();
+        let v = || ValueTransferOutput::default();
+
+        let k0: OutputPointer =
+            "0222222222222222222222222222222222222222222222222222222222222222:0"
+                .parse()
+                .unwrap();
+        p.insert(k0, v(), 0);
+        let k1: OutputPointer =
+            "0222222222222222222222222222222222222222222222222222222222222222:1"
+                .parse()
+                .unwrap();
+
+        p.insert(k1, v(), 1);
     }
 }

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1939,7 +1939,55 @@ pub enum DataRequestStage {
     TALLY,
 }
 
-pub type UnspentOutputsPool = HashMap<OutputPointer, ValueTransferOutput>;
+/// Unspent Outputs Pool
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct UnspentOutputsPool {
+    map: HashMap<OutputPointer, ValueTransferOutput>,
+}
+
+impl UnspentOutputsPool {
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&ValueTransferOutput>
+    where
+        OutputPointer: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq,
+    {
+        self.map.get(k)
+    }
+
+    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    where
+        OutputPointer: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq,
+    {
+        self.map.contains_key(k)
+    }
+
+    pub fn insert(
+        &mut self,
+        k: OutputPointer,
+        v: ValueTransferOutput,
+    ) -> Option<ValueTransferOutput> {
+        self.map.insert(k, v)
+    }
+
+    pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<ValueTransferOutput>
+    where
+        OutputPointer: std::borrow::Borrow<Q>,
+        Q: std::hash::Hash + Eq,
+    {
+        self.map.remove(k)
+    }
+
+    pub fn drain(
+        &mut self,
+    ) -> std::collections::hash_map::Drain<OutputPointer, ValueTransferOutput> {
+        self.map.drain()
+    }
+
+    pub fn iter(&self) -> std::collections::hash_map::Iter<OutputPointer, ValueTransferOutput> {
+        self.map.iter()
+    }
+}
 
 pub type Blockchain = BTreeMap<Epoch, Hash>;
 

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1946,8 +1946,10 @@ pub struct UnspentOutputsPool {
     map: HashMap<OutputPointer, ValueTransferOutput>,
     /// Map of transaction hash to a tuple of:
     /// * The number of the block that included the transaction
-    ///   (how many blocks were consolidated before this one)
-    /// * A reference count, used to keep this map clear after removing transactions
+    ///   (how many blocks were consolidated before this one).
+    /// * A reference count, used to keep this map clear after removing transactions.
+    ///   This reference count is the number of output pointers that point to this
+    ///   transaction hash, when it reaches 0 the entry should be removed.
     transaction_block_number: HashMap<Hash, (u32, u32)>,
 }
 
@@ -1975,20 +1977,17 @@ impl UnspentOutputsPool {
         block_number: u32,
     ) -> Option<ValueTransferOutput> {
         let transaction_id = k.transaction_id;
-        let old_vto = self.map.insert(k.clone(), v);
+        let old_vto = self.map.insert(k, v);
         if old_vto.is_none() {
-            let (transaction_epoch, refcount) = self
+            // Store block number for this transaction hash
+            // If the transaction hash already exists, do not update the block number
+            let (_block_number, refcount) = self
                 .transaction_block_number
                 .entry(transaction_id)
                 .or_insert((block_number, 0));
+            // Increase the refcount if this is a new output pointer
+            // Entries should be removed from the map when the refcount reaches 0 again
             *refcount += 1;
-            // A transaction can only live inside one block, so the epoch must be equal
-            // TODO: panic or skip check?
-            assert_eq!(block_number, *transaction_epoch);
-        } else {
-            // Tried to insert an existing transaction again
-            // TODO: This shouldn't really happen, panic?
-            panic!("{} inserted twice to UTXO set", k);
         }
 
         old_vto
@@ -1998,12 +1997,13 @@ impl UnspentOutputsPool {
         let vto = self.map.remove(k);
 
         if vto.is_some() {
-            // Decrease refcount
+            // Decrease refcount if this is a new output pointer
             let (_epoch, refcount) = self
                 .transaction_block_number
                 .get_mut(&k.transaction_id)
                 .unwrap();
             *refcount -= 1;
+            // Entries should be removed from the map when the refcount reaches 0
             if *refcount == 0 {
                 self.transaction_block_number.remove(&k.transaction_id);
             }
@@ -2026,12 +2026,12 @@ impl UnspentOutputsPool {
     /// by this OutputPointer. The difference between that number and the
     /// current number of consolidated blocks is the "coin age".
     pub fn included_in_block_number(&self, k: &OutputPointer) -> Option<Epoch> {
-        if !self.map.contains_key(k) {
-            None
-        } else {
+        if self.map.contains_key(k) {
             self.transaction_block_number
                 .get(&k.transaction_id)
                 .map(|(epoch, _refcount)| *epoch)
+        } else {
+            None
         }
     }
 }
@@ -3243,9 +3243,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn utxo_set_insert_twice() {
-        // Inserting the same input twice into the UTXO set panics
+        // Inserting the same input twice into the UTXO set overwrites the transaction
         let mut p = UnspentOutputsPool::default();
         let v = || ValueTransferOutput::default();
 
@@ -3254,13 +3253,17 @@ mod tests {
                 .parse()
                 .unwrap();
         p.insert(k0.clone(), v(), 0);
-        p.insert(k0, v(), 0);
+        p.insert(k0.clone(), v(), 0);
+        assert_eq!(p.included_in_block_number(&k0), Some(0));
+        // Removing once is enough
+        p.remove(&k0);
+        assert_eq!(p.included_in_block_number(&k0), None);
     }
 
     #[test]
-    #[should_panic]
     fn utxo_set_insert_same_transaction_different_epoch() {
-        // Inserting the same transaction twice with different block number panics
+        // Inserting the same transaction twice with different block number keeps
+        // the old block number but the new transaction
         let mut p = UnspentOutputsPool::default();
         let v = || ValueTransferOutput::default();
 
@@ -3268,12 +3271,14 @@ mod tests {
             "0222222222222222222222222222222222222222222222222222222222222222:0"
                 .parse()
                 .unwrap();
-        p.insert(k0, v(), 0);
+        p.insert(k0.clone(), v(), 0);
+        assert_eq!(p.included_in_block_number(&k0), Some(0));
         let k1: OutputPointer =
             "0222222222222222222222222222222222222222222222222222222222222222:1"
                 .parse()
                 .unwrap();
 
-        p.insert(k1, v(), 1);
+        p.insert(k1.clone(), v(), 1);
+        assert_eq!(p.included_in_block_number(&k1), Some(0));
     }
 }

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -89,6 +89,7 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
         log::debug!("Periodic epoch notification received {:?}", msg.checkpoint);
         let current_epoch = msg.checkpoint;
         self.current_epoch = Some(current_epoch);
+        let block_number = self.chain_state.block_number();
 
         log::debug!(
             "EpochNotification received while StateMachine is in state {:?}",
@@ -187,6 +188,7 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                             chain_info.consensus_constants.mining_backup_factor,
                             self.bootstrap_hash,
                             self.genesis_block_hash,
+                            block_number,
                         ) {
                             Ok(utxo_diff) => {
                                 let block_pkh = &block_candidate.block_sig.public_key.pkh();

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -187,6 +187,7 @@ impl ChainManager {
                     &tally_transactions,
                     own_pkh,
                     epoch_constants,
+                    act.chain_state.block_number(),
                 );
 
                 // Sign the block hash
@@ -570,6 +571,7 @@ impl ChainManager {
 /// Build a new Block using the supplied leadership proof and by filling transactions from the
 /// `transaction_pool`
 /// Returns an unsigned block!
+#[allow(clippy::too_many_arguments)]
 fn build_block(
     pools_ref: (&mut TransactionsPool, &UnspentOutputsPool, &DataRequestPool),
     max_block_weight: u32,
@@ -578,10 +580,11 @@ fn build_block(
     tally_transactions: &[TallyTransaction],
     own_pkh: PublicKeyHash,
     epoch_constants: EpochConstants,
+    block_number: u32,
 ) -> (BlockHeader, BlockTransactions) {
     let (transactions_pool, unspent_outputs_pool, dr_pool) = pools_ref;
     let epoch = beacon.checkpoint;
-    let mut utxo_diff = UtxoDiff::new(unspent_outputs_pool, epoch);
+    let mut utxo_diff = UtxoDiff::new(unspent_outputs_pool, block_number);
 
     // Get all the unspent transactions and calculate the sum of their fees
     let mut transaction_fees = 0;
@@ -831,6 +834,7 @@ mod tests {
         // Fields required to mine a block
         let block_beacon = CheckpointBeacon::default();
         let block_proof = BlockEligibilityClaim::default();
+        let block_number = 1;
 
         // Build empty block (because max weight is zero)
         let (block_header, txns) = build_block(
@@ -841,6 +845,7 @@ mod tests {
             &[],
             PublicKeyHash::default(),
             EpochConstants::default(),
+            block_number,
         );
         let block = Block {
             block_header,
@@ -881,6 +886,7 @@ mod tests {
             bytes: Protected::from(vec![0xcd; 32]),
         };
         let block_proof = BlockEligibilityClaim::create(vrf, &secret_key, block_beacon).unwrap();
+        let block_number = 1;
 
         // Build empty block (because max weight is zero)
 
@@ -892,6 +898,7 @@ mod tests {
             &[],
             PublicKeyHash::default(),
             EpochConstants::default(),
+            block_number,
         );
 
         // Create a KeyedSignature
@@ -1024,6 +1031,7 @@ mod tests {
         // Fields required to mine a block
         let block_beacon = CheckpointBeacon::default();
         let block_proof = BlockEligibilityClaim::default();
+        let block_number = 1;
 
         // Build block with
 
@@ -1035,6 +1043,7 @@ mod tests {
             &[],
             PublicKeyHash::default(),
             EpochConstants::default(),
+            block_number,
         );
         let block = Block {
             block_header,

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -580,9 +580,8 @@ fn build_block(
     epoch_constants: EpochConstants,
 ) -> (BlockHeader, BlockTransactions) {
     let (transactions_pool, unspent_outputs_pool, dr_pool) = pools_ref;
-    let mut utxo_diff = UtxoDiff::new(unspent_outputs_pool);
-
     let epoch = beacon.checkpoint;
+    let mut utxo_diff = UtxoDiff::new(unspent_outputs_pool, epoch);
 
     // Get all the unspent transactions and calculate the sum of their fees
     let mut transaction_fees = 0;

--- a/node/src/actors/chain_manager/transaction_factory.rs
+++ b/node/src/actors/chain_manager/transaction_factory.rs
@@ -321,10 +321,10 @@ mod tests {
             VTTransactionBody::new(vec![fake_input], outputs),
             vec![],
         )));
-        let block_epoch = 0;
+        let block_number = 0;
 
         let (mut own_utxos, all_utxos) = own_utxos_all_utxos.into().unwrap_or_default();
-        let all_utxos = generate_unspent_outputs_pool(&all_utxos, &txns, block_epoch);
+        let all_utxos = generate_unspent_outputs_pool(&all_utxos, &txns, block_number);
         update_own_utxos(&mut own_utxos, own_pkh, &txns);
 
         (own_utxos, all_utxos)

--- a/node/src/actors/chain_manager/transaction_factory.rs
+++ b/node/src/actors/chain_manager/transaction_factory.rs
@@ -33,9 +33,9 @@ pub fn take_enough_utxos<S: std::hash::BuildHasher>(
     let mut list = vec![];
 
     for (op, ts) in own_utxos.iter_mut() {
-        let value = all_utxos[op].value;
+        let value = all_utxos.get(op).unwrap().value;
         total += value;
-        if all_utxos[op].time_lock > timestamp {
+        if all_utxos.get(op).unwrap().time_lock > timestamp {
             continue;
         }
 
@@ -713,7 +713,10 @@ mod tests {
         let (mut own_utxos, all_utxos) = build_utxo_set(vec![], (own_utxos1, all_utxos1), vec![t1]);
         assert_eq!(own_utxos.len(), 1);
         assert_eq!(
-            all_utxos[own_utxos.iter().next().unwrap().0].value,
+            all_utxos
+                .get(own_utxos.iter().next().unwrap().0)
+                .unwrap()
+                .value,
             1_000_000 - 1_000
         );
         assert_eq!(
@@ -845,7 +848,13 @@ mod tests {
         let (mut own_utxos, all_utxos) = build_utxo_set(vec![], (own_utxos, all_utxos), vec![t5]);
         // Since we are spending everything, the result is merging all the unspent outputs into one
         assert_eq!(own_utxos.len(), 1);
-        assert_eq!(all_utxos[own_utxos.iter().next().unwrap().0].value, 480);
+        assert_eq!(
+            all_utxos
+                .get(own_utxos.iter().next().unwrap().0)
+                .unwrap()
+                .value,
+            480
+        );
         assert_eq!(
             build_vtt_tx(vec![], 480 + 1, &mut own_utxos, own_pkh, &all_utxos)
                 .unwrap_err()
@@ -953,7 +962,10 @@ mod tests {
         // This will create a change output with value 1_000_000 - 3_900
         assert_eq!(own_utxos.len(), 1);
         assert_eq!(
-            all_utxos[own_utxos.iter().next().unwrap().0].value,
+            all_utxos
+                .get(own_utxos.iter().next().unwrap().0)
+                .unwrap()
+                .value,
             1_000_000 - 3_900
         );
         assert_eq!(

--- a/node/src/actors/chain_manager/transaction_factory.rs
+++ b/node/src/actors/chain_manager/transaction_factory.rs
@@ -321,9 +321,10 @@ mod tests {
             VTTransactionBody::new(vec![fake_input], outputs),
             vec![],
         )));
+        let block_epoch = 0;
 
         let (mut own_utxos, all_utxos) = own_utxos_all_utxos.into().unwrap_or_default();
-        let all_utxos = generate_unspent_outputs_pool(&all_utxos, &txns);
+        let all_utxos = generate_unspent_outputs_pool(&all_utxos, &txns, block_epoch);
         update_own_utxos(&mut own_utxos, own_pkh, &txns);
 
         (own_utxos, all_utxos)

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -112,8 +112,9 @@ fn build_utxo_set_with_mint<T: Into<Option<UnspentOutputsPool>>>(
     }));
 
     let all_utxos = all_utxos.into().unwrap_or_default();
+    let block_epoch = 0;
 
-    generate_unspent_outputs_pool(&all_utxos, &txns)
+    generate_unspent_outputs_pool(&all_utxos, &txns, block_epoch)
 }
 
 // Validate transactions in block
@@ -183,7 +184,8 @@ fn mint_valid() {
 fn vtt_no_inputs_no_outputs() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
 
     let vt_body = VTTransactionBody::new(vec![], vec![]);
     let vt_tx = VTTransaction::new(vt_body, vec![]);
@@ -206,7 +208,8 @@ fn vtt_no_inputs_no_outputs() {
 fn vtt_no_inputs_zero_output() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
 
     // Try to create a data request with no inputs
     let pkh = PublicKeyHash::default();
@@ -237,7 +240,8 @@ fn vtt_no_inputs_zero_output() {
 fn vtt_no_inputs() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
 
     // Try to create a data request with no inputs
     let pkh = PublicKeyHash::default();
@@ -268,7 +272,8 @@ fn vtt_no_inputs() {
 fn vtt_no_inputs_but_one_signature() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
 
     // No inputs but 1 signature
     let pkh = PublicKeyHash::default();
@@ -301,7 +306,8 @@ fn vtt_no_inputs_but_one_signature() {
 fn vtt_one_input_but_no_signature() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(
         "2222222222222222222222222222222222222222222222222222222222222222:0"
             .parse()
@@ -429,7 +435,8 @@ fn vtt_one_input_signatures() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let pkh = PublicKeyHash::default();
@@ -462,7 +469,8 @@ fn vtt_one_input_signatures() {
 fn vtt_input_not_in_utxo() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(
         "2222222222222222222222222222222222222222222222222222222222222222:0"
             .parse()
@@ -505,7 +513,8 @@ fn vtt_input_not_enough_value() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let pkh = PublicKeyHash::default();
@@ -540,7 +549,8 @@ fn vtt_one_input_zero_value_output() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let zero_output = ValueTransferOutput {
@@ -577,7 +587,8 @@ fn vtt_one_input_two_outputs_negative_fee() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let vto0 = ValueTransferOutput {
@@ -616,7 +627,8 @@ fn vtt_one_input_two_outputs() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let vto0 = ValueTransferOutput {
@@ -658,7 +670,8 @@ fn vtt_two_inputs_one_signature() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -701,7 +714,8 @@ fn vtt_two_inputs_one_signature_wrong_pkh() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -749,7 +763,8 @@ fn vtt_two_inputs_three_signatures() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -792,7 +807,8 @@ fn vtt_two_inputs_two_outputs() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -835,7 +851,8 @@ fn vtt_input_value_overflow() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -882,7 +899,8 @@ fn vtt_output_value_overflow() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -930,7 +948,8 @@ fn vtt_timelock() {
             time_lock,
         };
         let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-        let utxo_diff = UtxoDiff::new(&utxo_pool);
+        let block_epoch = 0;
+        let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
         let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
         let pkh = PublicKeyHash::default();
@@ -983,7 +1002,8 @@ fn vtt_valid() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let pkh = PublicKeyHash::default();
@@ -1143,7 +1163,8 @@ fn genesis_vtt_valid() {
 fn data_request_no_inputs() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
 
     // Try to create a data request with no inputs
     let dr_output = DataRequestOutput {
@@ -1173,7 +1194,8 @@ fn data_request_no_inputs() {
 fn data_request_no_inputs_but_one_signature() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
 
     // No inputs but 1 signature
     let dr_output = DataRequestOutput {
@@ -1212,7 +1234,8 @@ fn data_request_one_input_but_no_signature() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let dr_output = DataRequestOutput {
@@ -1251,7 +1274,8 @@ fn data_request_one_input_signatures() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let dr_output = DataRequestOutput {
@@ -1285,7 +1309,8 @@ fn data_request_one_input_signatures() {
 fn data_request_input_not_in_utxo() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(
         "2222222222222222222222222222222222222222222222222222222222222222:0"
             .parse()
@@ -1328,7 +1353,8 @@ fn data_request_input_not_enough_value() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let dr_output = DataRequestOutput {
@@ -1368,7 +1394,8 @@ fn data_request_output_value_overflow() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -1423,7 +1450,8 @@ fn test_drtx(dr_output: DataRequestOutput) -> Result<(), failure::Error> {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let dr_tx_body = DRTransactionBody::new(vec![vti], vec![], dr_output);
     let drs = sign_t(&dr_tx_body);
@@ -1678,7 +1706,8 @@ fn data_request_miner_fee() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let dr_tx_body = DRTransactionBody::new(vec![vti], vec![], dr_output);
     let drs = sign_t(&dr_tx_body);
@@ -1720,7 +1749,8 @@ fn data_request_miner_fee_with_change() {
         value: 200,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let dr_tx_body = DRTransactionBody::new(vec![vti], vec![change_output], dr_output);
     let drs = sign_t(&dr_tx_body);
@@ -1762,7 +1792,8 @@ fn data_request_miner_fee_with_too_much_change() {
         value: 300,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let dr_tx_body = DRTransactionBody::new(vec![vti], vec![change_output], dr_output);
     let drs = sign_t(&dr_tx_body);
@@ -1805,7 +1836,8 @@ fn data_request_zero_value_output() {
         value: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let utxo_diff = UtxoDiff::new(&utxo_pool);
+    let block_epoch = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let dr_tx_body = DRTransactionBody::new(vec![vti], vec![change_output], dr_output);
     let drs = sign_t(&dr_tx_body);
@@ -3985,6 +4017,7 @@ fn test_block_with_drpool<F: FnMut(&mut Block) -> bool>(
     let vrf = &mut VrfCtx::secp256k1().unwrap();
     let rep_eng = ReputationEngine::new(100);
     let mut utxo_set = UnspentOutputsPool::default();
+    let block_epoch = 0;
     // Insert output to utxo
     let output1 = ValueTransferOutput {
         time_lock: 0,
@@ -3994,7 +4027,7 @@ fn test_block_with_drpool<F: FnMut(&mut Block) -> bool>(
     //let tx_output1 = VTTransactionBody::new(vec![], vec![output1.clone()]);
     //let output1_pointer = OutputPointer { transaction_id: tx_output1.hash(), output_index: 0 };
     let output1_pointer = MILLION_TX_OUTPUT.parse().unwrap();
-    utxo_set.insert(output1_pointer, output1);
+    utxo_set.insert(output1_pointer, output1, block_epoch);
 
     let secret_key = SecretKey {
         bytes: Protected::from(vec![0xcd; 32]),
@@ -4224,6 +4257,7 @@ fn block_difficult_proof() {
         .ars_mut()
         .push_activity((0..512).map(|x| PublicKeyHash::from_hex(&format!("{:040}", x)).unwrap()));
     let mut utxo_set = UnspentOutputsPool::default();
+    let block_epoch = 0;
     // Insert output to utxo
     let output1 = ValueTransferOutput {
         time_lock: 0,
@@ -4233,7 +4267,7 @@ fn block_difficult_proof() {
     //let tx_output1 = VTTransactionBody::new(vec![], vec![output1.clone()]);
     //let output1_pointer = OutputPointer { transaction_id: tx_output1.hash(), output_index: 0 };
     let output1_pointer = MILLION_TX_OUTPUT.parse().unwrap();
-    utxo_set.insert(output1_pointer, output1);
+    utxo_set.insert(output1_pointer, output1, block_epoch);
 
     let secret_key = SecretKey {
         bytes: Protected::from(vec![0xcd; 32]),
@@ -4742,6 +4776,7 @@ fn test_blocks(txns: Vec<(BlockTransactions, u64)>) -> Result<(), failure::Error
     let vrf = &mut VrfCtx::secp256k1().unwrap();
     let rep_eng = ReputationEngine::new(100);
     let mut utxo_set = UnspentOutputsPool::default();
+    let block_epoch = 0;
     // Insert output to utxo
     let output1 = ValueTransferOutput {
         time_lock: 0,
@@ -4751,7 +4786,7 @@ fn test_blocks(txns: Vec<(BlockTransactions, u64)>) -> Result<(), failure::Error
     //let tx_output1 = VTTransactionBody::new(vec![], vec![output1.clone()]);
     //let output1_pointer = OutputPointer { transaction_id: tx_output1.hash(), output_index: 0 };
     let output1_pointer = MILLION_TX_OUTPUT.parse().unwrap();
-    utxo_set.insert(output1_pointer, output1);
+    utxo_set.insert(output1_pointer, output1, block_epoch);
 
     let secret_key = SecretKey {
         bytes: Protected::from(vec![0xcd; 32]),
@@ -5390,4 +5425,75 @@ fn genesis_block_full_validate() {
     )
     .unwrap();
     assert_eq!(signatures_to_verify, vec![]);
+}
+
+#[test]
+fn validate_block_transactions_uses_block_number_in_utxo_diff() {
+    // Check that the UTXO diff returned by validate_block_transactions respects the epoch number
+    let epoch_number = 1234;
+
+    let utxo_diff = {
+        let dr_pool = DataRequestPool::default();
+        let vrf = &mut VrfCtx::secp256k1().unwrap();
+        let rep_eng = ReputationEngine::new(100);
+        let utxo_set = UnspentOutputsPool::default();
+
+        let secret_key = SecretKey {
+            bytes: Protected::from(vec![0xcd; 32]),
+        };
+        let current_epoch = epoch_number;
+        let last_block_hash = LAST_BLOCK_HASH.parse().unwrap();
+        let block_beacon = CheckpointBeacon {
+            checkpoint: current_epoch,
+            hash_prev_block: last_block_hash,
+        };
+        let my_pkh = PublicKeyHash::default();
+        let genesis_block_hash = GENESIS_BLOCK_HASH.parse().unwrap();
+
+        let mut txns = BlockTransactions::default();
+        txns.mint = MintTransaction::new(
+            current_epoch,
+            ValueTransferOutput {
+                time_lock: 0,
+                pkh: my_pkh,
+                value: block_reward(current_epoch),
+            },
+        );
+
+        let mut block_header = BlockHeader::default();
+        build_merkle_tree(&mut block_header, &txns);
+        block_header.beacon = block_beacon;
+        block_header.proof = BlockEligibilityClaim::create(vrf, &secret_key, block_beacon).unwrap();
+
+        let block_sig = sign_t(&block_header);
+        let b = Block {
+            block_header,
+            block_sig,
+            txns,
+        };
+        let mut signatures_to_verify = vec![];
+
+        validate_block_transactions(
+            &utxo_set,
+            &dr_pool,
+            &b,
+            &mut signatures_to_verify,
+            &rep_eng,
+            genesis_block_hash,
+            EpochConstants::default(),
+        )
+        .unwrap()
+    };
+
+    // Apply the UTXO diff to an empty UTXO set
+    let mut utxo_set = UnspentOutputsPool::default();
+    utxo_diff.apply(&mut utxo_set);
+
+    // This will only check one transaction: the mint transaction
+    // But in the UTXO set there are no transactions, only outputs, so all the
+    // other transactions should follow the same behaviour
+    assert_eq!(utxo_set.iter().count(), 1);
+    for (output_pointer, _vto) in utxo_set.iter() {
+        assert_eq!(utxo_set.utxo_epoch(output_pointer), Some(epoch_number));
+    }
 }

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -112,9 +112,9 @@ fn build_utxo_set_with_mint<T: Into<Option<UnspentOutputsPool>>>(
     }));
 
     let all_utxos = all_utxos.into().unwrap_or_default();
-    let block_epoch = 0;
+    let block_number = 0;
 
-    generate_unspent_outputs_pool(&all_utxos, &txns, block_epoch)
+    generate_unspent_outputs_pool(&all_utxos, &txns, block_number)
 }
 
 // Validate transactions in block
@@ -184,8 +184,8 @@ fn mint_valid() {
 fn vtt_no_inputs_no_outputs() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
 
     let vt_body = VTTransactionBody::new(vec![], vec![]);
     let vt_tx = VTTransaction::new(vt_body, vec![]);
@@ -208,8 +208,8 @@ fn vtt_no_inputs_no_outputs() {
 fn vtt_no_inputs_zero_output() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
 
     // Try to create a data request with no inputs
     let pkh = PublicKeyHash::default();
@@ -240,8 +240,8 @@ fn vtt_no_inputs_zero_output() {
 fn vtt_no_inputs() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
 
     // Try to create a data request with no inputs
     let pkh = PublicKeyHash::default();
@@ -272,8 +272,8 @@ fn vtt_no_inputs() {
 fn vtt_no_inputs_but_one_signature() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
 
     // No inputs but 1 signature
     let pkh = PublicKeyHash::default();
@@ -306,8 +306,8 @@ fn vtt_no_inputs_but_one_signature() {
 fn vtt_one_input_but_no_signature() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(
         "2222222222222222222222222222222222222222222222222222222222222222:0"
             .parse()
@@ -435,8 +435,8 @@ fn vtt_one_input_signatures() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let pkh = PublicKeyHash::default();
@@ -469,8 +469,8 @@ fn vtt_one_input_signatures() {
 fn vtt_input_not_in_utxo() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(
         "2222222222222222222222222222222222222222222222222222222222222222:0"
             .parse()
@@ -513,8 +513,8 @@ fn vtt_input_not_enough_value() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let pkh = PublicKeyHash::default();
@@ -549,8 +549,8 @@ fn vtt_one_input_zero_value_output() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let zero_output = ValueTransferOutput {
@@ -587,8 +587,8 @@ fn vtt_one_input_two_outputs_negative_fee() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let vto0 = ValueTransferOutput {
@@ -627,8 +627,8 @@ fn vtt_one_input_two_outputs() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let vto0 = ValueTransferOutput {
@@ -670,8 +670,8 @@ fn vtt_two_inputs_one_signature() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -714,8 +714,8 @@ fn vtt_two_inputs_one_signature_wrong_pkh() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -763,8 +763,8 @@ fn vtt_two_inputs_three_signatures() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -807,8 +807,8 @@ fn vtt_two_inputs_two_outputs() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -851,8 +851,8 @@ fn vtt_input_value_overflow() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -899,8 +899,8 @@ fn vtt_output_value_overflow() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -948,8 +948,8 @@ fn vtt_timelock() {
             time_lock,
         };
         let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-        let block_epoch = 0;
-        let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+        let block_number = 0;
+        let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
         let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
         let pkh = PublicKeyHash::default();
@@ -1002,8 +1002,8 @@ fn vtt_valid() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let pkh = PublicKeyHash::default();
@@ -1163,8 +1163,8 @@ fn genesis_vtt_valid() {
 fn data_request_no_inputs() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
 
     // Try to create a data request with no inputs
     let dr_output = DataRequestOutput {
@@ -1194,8 +1194,8 @@ fn data_request_no_inputs() {
 fn data_request_no_inputs_but_one_signature() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
 
     // No inputs but 1 signature
     let dr_output = DataRequestOutput {
@@ -1234,8 +1234,8 @@ fn data_request_one_input_but_no_signature() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let dr_output = DataRequestOutput {
@@ -1274,8 +1274,8 @@ fn data_request_one_input_signatures() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let dr_output = DataRequestOutput {
@@ -1309,8 +1309,8 @@ fn data_request_one_input_signatures() {
 fn data_request_input_not_in_utxo() {
     let mut signatures_to_verify = vec![];
     let utxo_pool = UnspentOutputsPool::default();
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(
         "2222222222222222222222222222222222222222222222222222222222222222:0"
             .parse()
@@ -1353,8 +1353,8 @@ fn data_request_input_not_enough_value() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
 
     let dr_output = DataRequestOutput {
@@ -1394,8 +1394,8 @@ fn data_request_output_value_overflow() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto_21, vto_13], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti0 = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let vti1 = Input::new(utxo_pool.iter().nth(1).unwrap().0.clone());
 
@@ -1450,8 +1450,8 @@ fn test_drtx(dr_output: DataRequestOutput) -> Result<(), failure::Error> {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let dr_tx_body = DRTransactionBody::new(vec![vti], vec![], dr_output);
     let drs = sign_t(&dr_tx_body);
@@ -1706,8 +1706,8 @@ fn data_request_miner_fee() {
         time_lock: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let dr_tx_body = DRTransactionBody::new(vec![vti], vec![], dr_output);
     let drs = sign_t(&dr_tx_body);
@@ -1749,8 +1749,8 @@ fn data_request_miner_fee_with_change() {
         value: 200,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let dr_tx_body = DRTransactionBody::new(vec![vti], vec![change_output], dr_output);
     let drs = sign_t(&dr_tx_body);
@@ -1792,8 +1792,8 @@ fn data_request_miner_fee_with_too_much_change() {
         value: 300,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let dr_tx_body = DRTransactionBody::new(vec![vti], vec![change_output], dr_output);
     let drs = sign_t(&dr_tx_body);
@@ -1836,8 +1836,8 @@ fn data_request_zero_value_output() {
         value: 0,
     };
     let utxo_pool = build_utxo_set_with_mint(vec![vto], None, vec![]);
-    let block_epoch = 0;
-    let utxo_diff = UtxoDiff::new(&utxo_pool, block_epoch);
+    let block_number = 0;
+    let utxo_diff = UtxoDiff::new(&utxo_pool, block_number);
     let vti = Input::new(utxo_pool.iter().next().unwrap().0.clone());
     let dr_tx_body = DRTransactionBody::new(vec![vti], vec![change_output], dr_output);
     let drs = sign_t(&dr_tx_body);
@@ -4017,7 +4017,7 @@ fn test_block_with_drpool<F: FnMut(&mut Block) -> bool>(
     let vrf = &mut VrfCtx::secp256k1().unwrap();
     let rep_eng = ReputationEngine::new(100);
     let mut utxo_set = UnspentOutputsPool::default();
-    let block_epoch = 0;
+    let block_number = 0;
     // Insert output to utxo
     let output1 = ValueTransferOutput {
         time_lock: 0,
@@ -4027,7 +4027,7 @@ fn test_block_with_drpool<F: FnMut(&mut Block) -> bool>(
     //let tx_output1 = VTTransactionBody::new(vec![], vec![output1.clone()]);
     //let output1_pointer = OutputPointer { transaction_id: tx_output1.hash(), output_index: 0 };
     let output1_pointer = MILLION_TX_OUTPUT.parse().unwrap();
-    utxo_set.insert(output1_pointer, output1, block_epoch);
+    utxo_set.insert(output1_pointer, output1, block_number);
 
     let secret_key = SecretKey {
         bytes: Protected::from(vec![0xcd; 32]),
@@ -4107,6 +4107,7 @@ fn test_block_with_drpool<F: FnMut(&mut Block) -> bool>(
         &rep_eng,
         genesis_block_hash,
         EpochConstants::default(),
+        block_number,
     )?;
     verify_signatures_test(signatures_to_verify)?;
 
@@ -4257,7 +4258,7 @@ fn block_difficult_proof() {
         .ars_mut()
         .push_activity((0..512).map(|x| PublicKeyHash::from_hex(&format!("{:040}", x)).unwrap()));
     let mut utxo_set = UnspentOutputsPool::default();
-    let block_epoch = 0;
+    let block_number = 0;
     // Insert output to utxo
     let output1 = ValueTransferOutput {
         time_lock: 0,
@@ -4267,7 +4268,7 @@ fn block_difficult_proof() {
     //let tx_output1 = VTTransactionBody::new(vec![], vec![output1.clone()]);
     //let output1_pointer = OutputPointer { transaction_id: tx_output1.hash(), output_index: 0 };
     let output1_pointer = MILLION_TX_OUTPUT.parse().unwrap();
-    utxo_set.insert(output1_pointer, output1, block_epoch);
+    utxo_set.insert(output1_pointer, output1, block_number);
 
     let secret_key = SecretKey {
         bytes: Protected::from(vec![0xcd; 32]),
@@ -4342,6 +4343,7 @@ fn block_difficult_proof() {
                 &rep_eng,
                 genesis_block_hash,
                 EpochConstants::default(),
+                block_number,
             )?;
             verify_signatures_test(signatures_to_verify)?;
 
@@ -4776,7 +4778,7 @@ fn test_blocks(txns: Vec<(BlockTransactions, u64)>) -> Result<(), failure::Error
     let vrf = &mut VrfCtx::secp256k1().unwrap();
     let rep_eng = ReputationEngine::new(100);
     let mut utxo_set = UnspentOutputsPool::default();
-    let block_epoch = 0;
+    let block_number = 0;
     // Insert output to utxo
     let output1 = ValueTransferOutput {
         time_lock: 0,
@@ -4786,7 +4788,7 @@ fn test_blocks(txns: Vec<(BlockTransactions, u64)>) -> Result<(), failure::Error
     //let tx_output1 = VTTransactionBody::new(vec![], vec![output1.clone()]);
     //let output1_pointer = OutputPointer { transaction_id: tx_output1.hash(), output_index: 0 };
     let output1_pointer = MILLION_TX_OUTPUT.parse().unwrap();
-    utxo_set.insert(output1_pointer, output1, block_epoch);
+    utxo_set.insert(output1_pointer, output1, block_number);
 
     let secret_key = SecretKey {
         bytes: Protected::from(vec![0xcd; 32]),
@@ -4866,6 +4868,7 @@ fn test_blocks(txns: Vec<(BlockTransactions, u64)>) -> Result<(), failure::Error
             &rep_eng,
             genesis_block_hash,
             EpochConstants::default(),
+            block_number,
         )?;
         verify_signatures_test(signatures_to_verify)?;
 
@@ -5332,6 +5335,7 @@ fn genesis_block_value_overflow() {
     let utxo_set = UnspentOutputsPool::default();
 
     let current_epoch = 0;
+    let block_number = 0;
     let last_block_hash = bootstrap_hash;
     let chain_beacon = CheckpointBeacon {
         checkpoint: current_epoch,
@@ -5367,6 +5371,7 @@ fn genesis_block_value_overflow() {
         &rep_eng,
         genesis_block_hash,
         EpochConstants::default(),
+        block_number,
     );
     assert_eq!(signatures_to_verify, vec![]);
     assert_eq!(
@@ -5387,6 +5392,7 @@ fn genesis_block_full_validate() {
     let utxo_set = UnspentOutputsPool::default();
 
     let current_epoch = 0;
+    let block_number = 0;
     let last_block_hash = bootstrap_hash;
     let chain_beacon = CheckpointBeacon {
         checkpoint: current_epoch,
@@ -5422,6 +5428,7 @@ fn genesis_block_full_validate() {
         &rep_eng,
         genesis_block_hash,
         EpochConstants::default(),
+        block_number,
     )
     .unwrap();
     assert_eq!(signatures_to_verify, vec![]);
@@ -5429,8 +5436,8 @@ fn genesis_block_full_validate() {
 
 #[test]
 fn validate_block_transactions_uses_block_number_in_utxo_diff() {
-    // Check that the UTXO diff returned by validate_block_transactions respects the epoch number
-    let epoch_number = 1234;
+    // Check that the UTXO diff returned by validate_block_transactions respects the block number
+    let block_number = 1234;
 
     let utxo_diff = {
         let dr_pool = DataRequestPool::default();
@@ -5441,7 +5448,7 @@ fn validate_block_transactions_uses_block_number_in_utxo_diff() {
         let secret_key = SecretKey {
             bytes: Protected::from(vec![0xcd; 32]),
         };
-        let current_epoch = epoch_number;
+        let current_epoch = 1000;
         let last_block_hash = LAST_BLOCK_HASH.parse().unwrap();
         let block_beacon = CheckpointBeacon {
             checkpoint: current_epoch,
@@ -5481,6 +5488,7 @@ fn validate_block_transactions_uses_block_number_in_utxo_diff() {
             &rep_eng,
             genesis_block_hash,
             EpochConstants::default(),
+            block_number,
         )
         .unwrap()
     };
@@ -5494,6 +5502,9 @@ fn validate_block_transactions_uses_block_number_in_utxo_diff() {
     // other transactions should follow the same behaviour
     assert_eq!(utxo_set.iter().count(), 1);
     for (output_pointer, _vto) in utxo_set.iter() {
-        assert_eq!(utxo_set.utxo_epoch(output_pointer), Some(epoch_number));
+        assert_eq!(
+            utxo_set.included_in_block_number(output_pointer),
+            Some(block_number)
+        );
     }
 }


### PR DESCRIPTION
Close #1110

The coin age can be calculated using the `included_in_block_number` method of `UnspentOutputsPool`. As the name implies, the coin age is measured in the number of blocks, not the number of epochs.

This changes the chain state serialization, so old nodes must delete the storage.