### PR TITLE
feat(node): use all beacons in consensus, not only expected ones

### DIFF
--- a/node/src/actors/session/actor.rs
+++ b/node/src/actors/session/actor.rs
@@ -62,24 +62,20 @@ impl Actor for Session {
                     session_type: self.session_type,
                 })
                 .into_actor(self)
-                .then(|res, act, ctx| {
-                    match res {
-                        Ok(Ok(_)) => {
-                            debug!(
-                                "Successfully registered session {:?} into SessionManager",
-                                act.remote_addr
-                            );
+                .then(|res, act, ctx| match res {
+                    Ok(Ok(_)) => {
+                        debug!(
+                            "Successfully registered session {:?} into SessionManager",
+                            act.remote_addr
+                        );
 
-                            actix::fut::ok(())
-                        }
-                        _ => {
-                            error!("Session register into Session Manager failed");
-                            // FIXME(#72): a full stop of the session is not correct (unregister should
-                            // be skipped)
-                            ctx.stop();
+                        actix::fut::ok(())
+                    }
+                    _ => {
+                        error!("Session register into Session Manager failed");
+                        ctx.stop();
 
-                            actix::fut::err(())
-                        }
+                        actix::fut::err(())
                     }
                 })
                 .and_then(|_, act, _ctx| {

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -399,8 +399,7 @@ fn update_consolidate(session: &Session, ctx: &mut Context<Session>) {
                             "Failed to consolidate session {:?} in SessionManager",
                             act.remote_addr
                         );
-                        // FIXME(#72): a full stop of the session is not correct (unregister should
-                        // be skipped)
+
                         ctx.stop();
 
                         actix::fut::err(())
@@ -437,8 +436,6 @@ fn peer_discovery_get_peers(session: &mut Session, ctx: &mut Context<Session>) {
                 }
                 _ => {
                     log::warn!("Failed to receive peer addresses from PeersManager");
-                    // FIXME(#72): a full stop of the session is not correct (unregister should
-                    // be skipped)
                     ctx.stop();
                 }
             }
@@ -689,8 +686,6 @@ fn session_last_beacon_inbound(
                 }
                 _ => {
                     log::warn!("Failed to get highest checkpoint beacon from ChainManager");
-                    // FIXME(#72): a full stop of the session is not correct (unregister should
-                    // be skipped)
                     ctx.stop();
 
                     actix::fut::err(())

--- a/node/src/actors/sessions_manager/beacons.rs
+++ b/node/src/actors/sessions_manager/beacons.rs
@@ -23,15 +23,9 @@ impl Beacons {
         self.beacons_already_sent
     }
 
-    /// Have all the peers sent us a beacon since the last call to clear()?
-    pub fn all(&self) -> bool {
-        self.peers_not_beacon.is_empty()
-    }
-
-    /// Return number of peers which have sent us a beacon, or are expected to
-    /// send it to us
+    /// Return number of peers which have sent us a beacon
     pub fn total_count(&self) -> usize {
-        self.peers_with_beacon.len() + self.peers_not_beacon.len()
+        self.peers_with_beacon.len()
     }
 
     /// Clear the existing lists of peers and start waiting for the new ones

--- a/node/src/actors/sessions_manager/beacons.rs
+++ b/node/src/actors/sessions_manager/beacons.rs
@@ -63,6 +63,14 @@ impl Beacons {
         self.peers_with_beacon.remove(k);
     }
 
+    /// When a new peer connects, we add it to the peers_not_beacon map, in order to
+    /// close the connection if the peer is not in consensus
+    pub fn also_wait_for(&mut self, k: SocketAddr) {
+        if !self.peers_with_beacon.contains_key(&k) {
+            self.peers_not_beacon.insert(k);
+        }
+    }
+
     /// Get all the beacons in order to send a PeersBeacons message.
     /// Returns a tuple of (peers which have sent us beacons, peers which have not)
     /// or None if a PeersBeacons message was already sent during this epoch

--- a/node/src/actors/sessions_manager/beacons.rs
+++ b/node/src/actors/sessions_manager/beacons.rs
@@ -56,6 +56,13 @@ impl Beacons {
         self.peers_with_beacon.insert(k, v);
     }
 
+    /// Remove beacon. Used when a peer disconnects before we reach consensus:
+    /// we do not want to count that beacon
+    pub fn remove(&mut self, k: &SocketAddr) {
+        self.peers_not_beacon.remove(k);
+        self.peers_with_beacon.remove(k);
+    }
+
     /// Get all the beacons in order to send a PeersBeacons message.
     /// Returns a tuple of (peers which have sent us beacons, peers which have not)
     /// or None if a PeersBeacons message was already sent during this epoch

--- a/node/src/actors/sessions_manager/handlers.rs
+++ b/node/src/actors/sessions_manager/handlers.rs
@@ -334,9 +334,7 @@ impl Handler<PeerBeacon> for SessionsManager {
     type Result = ();
 
     fn handle(&mut self, msg: PeerBeacon, ctx: &mut Context<Self>) {
-        if !self.beacons.insert(msg.address, msg.beacon) {
-            log::debug!("Unexpected beacon from {}", msg.address);
-        }
+        self.beacons.insert(msg.address, msg.beacon);
 
         // Check if we have all the beacons, and sent PeersBeacons message to ChainManager
         match self.try_send_peers_beacons(ctx) {

--- a/node/src/actors/sessions_manager/handlers.rs
+++ b/node/src/actors/sessions_manager/handlers.rs
@@ -176,11 +176,17 @@ impl Handler<Consolidate> for SessionsManager {
         }
 
         match &result {
-            Ok(_) => log::debug!(
-                "Established a consolidated {:?} session with the peer at {}",
-                msg.session_type,
-                msg.address
-            ),
+            Ok(_) => {
+                log::debug!(
+                    "Established a consolidated {:?} session with the peer at {}",
+                    msg.session_type,
+                    msg.address
+                );
+                if msg.session_type == SessionType::Outbound {
+                    // Add outbound peer to the list of peers that should send us a beacon
+                    self.beacons.also_wait_for(msg.address);
+                }
+            }
             Err(error) => log::error!(
                 "Error while consolidating {:?} session with the peer at {}: {:?}",
                 msg.session_type,

--- a/node/src/actors/sessions_manager/handlers.rs
+++ b/node/src/actors/sessions_manager/handlers.rs
@@ -124,11 +124,16 @@ impl Handler<Unregister> for SessionsManager {
                     .unregister_session(msg.session_type, msg.status, msg.address);
 
             match &result {
-                Ok(_) => log::debug!(
-                    "Session (type {:?}) unregistered for peer {}",
-                    msg.session_type,
-                    msg.address
-                ),
+                Ok(_) => {
+                    log::debug!(
+                        "Session (type {:?}) unregistered for peer {}",
+                        msg.session_type,
+                        msg.address
+                    );
+                    if msg.session_type == SessionType::Outbound {
+                        self.beacons.remove(&msg.address);
+                    }
+                }
                 Err(error) => log::error!(
                     "Error while unregistering peer {} (session type {:?}): {}",
                     msg.address,

--- a/node/src/actors/sessions_manager/mod.rs
+++ b/node/src/actors/sessions_manager/mod.rs
@@ -217,10 +217,6 @@ impl SessionsManager {
             .limit
             .map(|x| x as usize);
         if Some(self.beacons.total_count()) < expected_peers {
-            return Err(NotSendingPeersBeaconsBecause::BootstrapNeeded);
-        }
-
-        if !self.beacons.all() {
             return Err(NotSendingPeersBeaconsBecause::NotEnoughBeacons);
         }
 

--- a/node/src/actors/sessions_manager/mod.rs
+++ b/node/src/actors/sessions_manager/mod.rs
@@ -216,7 +216,7 @@ impl SessionsManager {
             .outbound_consolidated
             .limit
             .map(|x| x as usize);
-        if Some(self.beacons.total_count()) != expected_peers {
+        if Some(self.beacons.total_count()) < expected_peers {
             return Err(NotSendingPeersBeaconsBecause::BootstrapNeeded);
         }
 


### PR DESCRIPTION
Additionally, now a `LastBeacon` message is sent to all inbound peers as soon as they consolidate their connection, which greatly reduces the synchronization delay.