### PR TITLE
dataRequestReport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3894,6 +3894,7 @@ dependencies = [
 name = "witnet"
 version = "0.7.3"
 dependencies = [
+ "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecount 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "directories 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ wallet = ["witnet_wallet"]
 travis-ci = { repository = "https://github.com/witnet/witnet-rust", branch = "master" }
 
 [dependencies]
+ansi_term = "0.12.1"
 bytecount = "0.6.0"
 ctrlc = "3.1.3"
 directories = "2.0.2"

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1782,7 +1782,7 @@ impl TryFrom<DataRequestInfo> for DataRequestReport {
 }
 
 /// List of outputs related to a data request
-#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DataRequestInfo {
     /// List of commitments to resolve the data request
     pub commits: HashMap<PublicKeyHash, CommitTransaction>,
@@ -1798,6 +1798,23 @@ pub struct DataRequestInfo {
     pub current_commit_round: u16,
     /// Current reveal round
     pub current_reveal_round: u16,
+    /// Current stage, or None if finished
+    pub current_stage: Option<DataRequestStage>,
+}
+
+impl Default for DataRequestInfo {
+    fn default() -> Self {
+        Self {
+            commits: Default::default(),
+            reveals: Default::default(),
+            tally: None,
+            block_hash_dr_tx: None,
+            block_hash_tally_tx: None,
+            current_commit_round: 0,
+            current_reveal_round: 0,
+            current_stage: Some(DataRequestStage::COMMIT),
+        }
+    }
 }
 
 impl From<DataRequestReport> for DataRequestInfo {
@@ -1814,6 +1831,7 @@ impl From<DataRequestReport> for DataRequestInfo {
             block_hash_tally_tx: Some(x.block_hash_tally_tx),
             current_commit_round: x.current_commit_round,
             current_reveal_round: x.current_reveal_round,
+            current_stage: None,
         }
     }
 }
@@ -1842,11 +1860,12 @@ impl DataRequestState {
         epoch: Epoch,
         block_hash_dr_tx: &Hash,
     ) -> Self {
+        let stage = DataRequestStage::COMMIT;
         let mut info = DataRequestInfo {
             ..DataRequestInfo::default()
         };
         info.block_hash_dr_tx = Some(*block_hash_dr_tx);
-        let stage = DataRequestStage::COMMIT;
+        info.current_stage = Some(stage);
 
         Self {
             data_request,
@@ -1942,6 +1961,7 @@ impl DataRequestState {
                 }
             }
         };
+        self.info.current_stage = Some(self.stage);
     }
 }
 

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1741,6 +1741,9 @@ pub enum InventoryItem {
 /// Data request report to be persisted into Storage and
 /// using as index the Data Request OutputPointer
 // FIXME (#792): Review if this struct is needed
+// It is not needed, we just need to store the transaction hash for all the commits, reveals, and
+// tally. All the information can then be retrieved from the database. The data request transaction
+// hash is used as the key.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DataRequestReport {
     /// List of commitment output pointers to resolve the data request

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -507,7 +507,7 @@ pub fn get_block(hash: Result<(Hash,), jsonrpc_core::Error>) -> JsonRpcResultAsy
 }
 
 /// Format of the output of getTransaction
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetTransactionOutput {
     /// Transaction

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -103,6 +103,17 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
                 write_to_path.as_deref(),
             )
         }
+        Command::DataRequestReport {
+            node,
+            dr_tx_hash,
+            json,
+            print_data_request,
+        } => rpc::data_request_report(
+            node.unwrap_or(config.jsonrpc.server_address),
+            dr_tx_hash,
+            json,
+            print_data_request,
+        ),
     }
 }
 
@@ -246,6 +257,21 @@ pub enum Command {
         /// Change the path where to write storage_path/private_key_pkh.txt". Implies --write
         #[structopt(long = "write-to")]
         write_to: Option<PathBuf>,
+    },
+    #[structopt(
+        name = "dataRequestReport",
+        about = "Show information about a data request"
+    )]
+    DataRequestReport {
+        /// Socket address of the Witnet node to query.
+        #[structopt(short = "n", long = "node")]
+        node: Option<SocketAddr>,
+        #[structopt(name = "dr-tx-hash", help = "Data request transaction hash")]
+        dr_tx_hash: String,
+        #[structopt(long = "json", help = "Show output in JSON format")]
+        json: bool,
+        #[structopt(long = "show-dr", help = "Print data request")]
+        print_data_request: bool,
     },
 }
 


### PR DESCRIPTION
Close #898

Implement a new `dataRequestReport` method.

```
witnet-node-dataRequestReport 0.7.3
Show information about a data request

USAGE:
    witnet node dataRequestReport [FLAGS] [OPTIONS] <dr-tx-hash>

FLAGS:
    -h, --help       Prints help information
        --json       Show output in JSON format
        --show-dr    Print data request
    -V, --version    Prints version information

OPTIONS:
    -n, --node <node>    Socket address of the Witnet node to query

ARGS:
    <dr-tx-hash>    Data request transaction hash
```

Sample output

```
$ witnet node dataRequestReport 8473a26fbf11656816d7c541928f2d6d3041ade1381c85b27a24808f83d14845
Report for data request 8473a26fbf11656816d7c541928f2d6d3041ade1381c85b27a24808f83d14845:
Deployed in block 0a71ea00a87b2ccfa7a5ca054ab33c228feaf4727fd0b51ca82e470869ecc431 by twit1v6u88hy2zzzla46k4pnqmf2a5tzr9dy5j2y49w
FINISHED with 3 commits and 3 reveals
Commit rounds: 1/2
Reveal rounds: 1/2
Reveals:
    [Rewarded ] twit1y04qrcglnfs7lww2qykfcyx6ezqgd68vdyq2wk: RadonTypes::RadonInteger(45)
    [Rewarded ] twit1v6u88hy2zzzla46k4pnqmf2a5tzr9dy5j2y49w: RadonTypes::RadonInteger(59)
    [Penalized] twit1jqzgx2wpzn2cjlp8nghvx0qg4nctps0te5fg9t: RadonTypes::RadonError(RetrieveTimeout)
Tally: RadonTypes::RadonInteger(52)
```