### PR TITLE
Peers cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +819,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "either"
 version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2192,6 +2207,18 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "prettytable-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3021,6 +3048,16 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3905,6 +3942,7 @@ dependencies = [
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4293,9 +4331,11 @@ dependencies = [
 "checksum derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2159be042979966de68315bce7034bb000c775f22e3e834e1c52ff78f041cae8"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum directories 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
+"checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+"checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 "checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
 "checksum enum-as-inner 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3d58266c97445680766be408285e798d3401c6d4c378ec5552e78737e681e37d"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
@@ -4445,6 +4485,7 @@ dependencies = [
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+"checksum prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
 "checksum primitive-types 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
 "checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
 "checksum proc-macro-error 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "875077759af22fa20b610ad4471d8155b321c89c3f2785526c9839b099be4e0a"
@@ -4539,6 +4580,7 @@ dependencies = [
 "checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+"checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum terminal_size 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "e25a60e3024df9029a414be05f46318a77c22538861a22170077d0388c0e926e"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ hex = "0.4.1"
 itertools = "0.8.2"
 lazy_static = "1.4.0"
 log = "0.4.8"
+prettytable-rs = { version = "0.8.0", default-features = false }
 serde_json = "1.0.47"
 structopt = "0.3.9"
 terminal_size = "0.1.10"

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -946,7 +946,7 @@ pub fn master_key_export() -> JsonRpcResultAsync {
 }
 
 /// Named tuple of `(address, type)`
-#[derive(Serialize)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct AddrType {
     /// Socket address of the peer
     pub address: String,

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -519,11 +519,26 @@ impl Message for GetRandomPeers {
     type Result = PeersSocketAddrsResult;
 }
 
-/// Message to get all the peer addresses from the list
+/// Message to get all the peer addresses from the tried list
 pub struct RequestPeers;
 
 impl Message for RequestPeers {
     type Result = PeersSocketAddrsResult;
+}
+
+/// Message to get all the peer addresses from the new and tried lists
+pub struct GetKnownPeers;
+
+impl Message for GetKnownPeers {
+    type Result = Result<PeersNewTried, failure::Error>;
+}
+
+/// List of known peers sorted by bucket
+pub struct PeersNewTried {
+    /// Peers in new bucket
+    pub new: Vec<SocketAddr>,
+    /// Peers in tried bucket
+    pub tried: Vec<SocketAddr>,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -26,7 +26,7 @@ use witnet_data_structures::{
     },
     transaction::{CommitTransaction, RevealTransaction, Transaction},
 };
-use witnet_p2p::sessions::{SessionStatus, SessionType};
+use witnet_p2p::sessions::{GetConsolidatedPeersResult, SessionStatus, SessionType};
 use witnet_rad::error::RadError;
 use witnet_rad::types::RadonTypes;
 
@@ -761,6 +761,14 @@ pub struct NumSessionsResult {
     pub inbound: usize,
     /// Outbound
     pub outbound: usize,
+}
+
+/// Get list of inbound and outbound peers
+#[derive(Clone, Debug)]
+pub struct GetConsolidatedPeers;
+
+impl Message for GetConsolidatedPeers {
+    type Result = Result<GetConsolidatedPeersResult, ()>;
 }
 
 // JsonRpcServer messages (notifications)

--- a/node/src/actors/peers_manager/handlers.rs
+++ b/node/src/actors/peers_manager/handlers.rs
@@ -3,8 +3,8 @@ use log;
 
 use super::PeersManager;
 use crate::actors::messages::{
-    AddConsolidatedPeer, AddPeers, GetRandomPeers, PeersSocketAddrResult, PeersSocketAddrsResult,
-    RemovePeers, RequestPeers,
+    AddConsolidatedPeer, AddPeers, GetKnownPeers, GetRandomPeers, PeersNewTried,
+    PeersSocketAddrResult, PeersSocketAddrsResult, RemovePeers, RequestPeers,
 };
 use witnet_util::timestamp::get_timestamp;
 
@@ -80,5 +80,17 @@ impl Handler<RequestPeers> for PeersManager {
     fn handle(&mut self, _msg: RequestPeers, _: &mut Context<Self>) -> Self::Result {
         log::debug!("Get all peers");
         self.peers.get_all_from_tried()
+    }
+}
+
+/// Handler for RequestPeers message
+impl Handler<GetKnownPeers> for PeersManager {
+    type Result = Result<PeersNewTried, failure::Error>;
+
+    fn handle(&mut self, _msg: GetKnownPeers, _: &mut Context<Self>) -> Self::Result {
+        Ok(PeersNewTried {
+            new: self.peers.get_all_from_new()?,
+            tried: self.peers.get_all_from_tried()?,
+        })
     }
 }

--- a/node/src/actors/sessions_manager/handlers.rs
+++ b/node/src/actors/sessions_manager/handlers.rs
@@ -18,8 +18,8 @@ use crate::actors::{
     codec::P2PCodec,
     messages::{
         AddConsolidatedPeer, AddPeers, Anycast, Broadcast, Consolidate, Create, EpochNotification,
-        NumSessions, NumSessionsResult, PeerBeacon, Register, SessionsUnitResult, TryMineBlock,
-        Unregister,
+        GetConsolidatedPeers, NumSessions, NumSessionsResult, PeerBeacon, Register,
+        SessionsUnitResult, TryMineBlock, Unregister,
     },
     peers_manager::PeersManager,
     session::Session,
@@ -365,5 +365,13 @@ impl Handler<NumSessions> for SessionsManager {
             inbound: self.sessions.get_num_inbound_sessions(),
             outbound: self.sessions.get_num_outbound_sessions(),
         })
+    }
+}
+
+impl Handler<GetConsolidatedPeers> for SessionsManager {
+    type Result = <GetConsolidatedPeers as Message>::Result;
+
+    fn handle(&mut self, _msg: GetConsolidatedPeers, _ctx: &mut Context<Self>) -> Self::Result {
+        Ok(self.sessions.get_consolidated_sessions_addr())
     }
 }

--- a/p2p/src/sessions/mod.rs
+++ b/p2p/src/sessions/mod.rs
@@ -301,6 +301,24 @@ where
         cons_sessions.unregister_session(address).map(|_| ())
     }
 
+    /// Get all the consolidated sessions addresses
+    pub fn get_consolidated_sessions_addr(&self) -> GetConsolidatedPeersResult {
+        GetConsolidatedPeersResult {
+            inbound: self
+                .inbound_consolidated
+                .collection
+                .iter()
+                .map(|(k, _v)| *k)
+                .collect(),
+            outbound: self
+                .outbound_consolidated
+                .collection
+                .iter()
+                .map(|(k, _v)| *k)
+                .collect(),
+        }
+    }
+
     /// Show the addresses of all the sessions
     pub fn show_ips(&self) -> Vec<String> {
         ["Inbound Unconsolidated".to_string()]
@@ -344,4 +362,15 @@ where
             )
             .collect()
     }
+}
+
+/// List of inbound and outbound peers
+#[derive(Clone, Debug)]
+pub struct GetConsolidatedPeersResult {
+    /// List of inbound peers: these opened a connection to us.
+    /// The address shown here is the inbound address, we cannot use it to connect to this peer.
+    pub inbound: Vec<SocketAddr>,
+    /// List of outbound peers: we opened the connection to these ones.
+    /// The address shown here can be used to connect to this peers in the future.
+    pub outbound: Vec<SocketAddr>,
 }

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -676,6 +676,28 @@ pub fn get_peers(addr: SocketAddr) -> Result<(), failure::Error> {
     Ok(())
 }
 
+pub fn get_known_peers(addr: SocketAddr) -> Result<(), failure::Error> {
+    let mut stream = start_client(addr)?;
+    let request = r#"{"jsonrpc": "2.0","method": "knownPeers", "id": "1"}"#;
+    let response = send_request(&mut stream, &request)?;
+    let peers: PeersResult = parse_response(&response)?;
+
+    if peers.is_empty() {
+        println!("No known peers");
+        return Ok(());
+    }
+
+    let mut table = Table::new();
+    table.set_format(*prettytable::format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
+    table.set_titles(row!["Address", "Type"]);
+    for AddrType { address, type_ } in peers {
+        table.add_row(row![address, type_]);
+    }
+    table.printstd();
+
+    Ok(())
+}
+
 // Response of the getBlockChain JSON-RPC method
 type ResponseBlockChain<'a> = Vec<(u32, &'a str)>;
 

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -114,6 +114,7 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
             json,
             print_data_request,
         ),
+        Command::GetPeers { node } => rpc::get_peers(node.unwrap_or(config.jsonrpc.server_address)),
     }
 }
 
@@ -272,6 +273,16 @@ pub enum Command {
         json: bool,
         #[structopt(long = "show-dr", help = "Print data request")]
         print_data_request: bool,
+    },
+    #[structopt(
+        name = "peers",
+        alias = "getPeers",
+        about = "Get the list of peers connected to the node"
+    )]
+    GetPeers {
+        /// Socket address of the Witnet node to query.
+        #[structopt(short = "n", long = "node")]
+        node: Option<SocketAddr>,
     },
 }
 

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -115,6 +115,9 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
             print_data_request,
         ),
         Command::GetPeers { node } => rpc::get_peers(node.unwrap_or(config.jsonrpc.server_address)),
+        Command::GetKnownPeers { node } => {
+            rpc::get_known_peers(node.unwrap_or(config.jsonrpc.server_address))
+        }
     }
 }
 
@@ -280,6 +283,16 @@ pub enum Command {
         about = "Get the list of peers connected to the node"
     )]
     GetPeers {
+        /// Socket address of the Witnet node to query.
+        #[structopt(short = "n", long = "node")]
+        node: Option<SocketAddr>,
+    },
+    #[structopt(
+        name = "knownPeers",
+        alias = "getKnownPeers",
+        about = "Get the list of peers known by the node"
+    )]
+    GetKnownPeers {
         /// Socket address of the Witnet node to query.
         #[structopt(short = "n", long = "node")]
         node: Option<SocketAddr>,


### PR DESCRIPTION
Close #312 
Close #313 

```
$ cargo run -- node peers
Loading config from: witnet.toml
Setting log level to: DEBUG, source: Config
[2020-04-15T10:08:20Z DEBUG witnet_data_structures] Set environment to testnet
[2020-04-15T10:08:20Z INFO  witnet::cli::node::json_rpc_client] Connecting to JSON-RPC server at 127.0.0.1:21338
 Address               | Type 
-----------------------+----------
 18.140.218.49:21337   | inbound 
 41.212.58.87:21337    | outbound 
 45.32.127.187:21337   | outbound 
 51.15.121.63:21337    | outbound 
 51.83.93.209:21337    | outbound 
 51.161.13.168:31040   | outbound 
 51.161.13.168:31084   | outbound 
 76.170.96.97:21337    | outbound 
 94.130.108.133:21337  | outbound 
 144.202.100.245:21337 | outbound 
 164.68.100.118:21337  | outbound 
 164.68.102.223:21337  | outbound 
 167.86.76.5:21337     | outbound 
 167.86.116.89:21337   | outbound 
 173.212.214.124:21337 | outbound 
```

Also, added a `knownPeers` command to get the list of known peers, with similar format:
```
 Address               | Type 
-----------------------+----------
 18.140.218.49:21337   | new 
 41.212.58.87:21337    | tried 
```