### PR TITLE
feat: ignore genesis block needed for local builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ Cargo.lock
 
 # Ignore generated documentation
 site
+
+# Ignore genesis block
+genesis_block.json


### PR DESCRIPTION
I've followed https://docs.witnet.io/developer/from-source/ and it downloads genesis_block.json but it's not ignored yet by git so it should be helpful to make it ignored to have a clean git status while a build can be done.
Or am I missing something ?