### PR TITLE
Epoch notification timestamp check

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -56,6 +56,13 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
 
     fn handle(&mut self, msg: EpochNotification<EveryEpochPayload>, ctx: &mut Context<Self>) {
         log::debug!("Periodic epoch notification received {:?}", msg.checkpoint);
+        let current_timestamp = get_timestamp();
+        log::debug!(
+            "Timestamp diff: {}, Epoch timestamp: {}. Current timestamp: {}",
+            current_timestamp as i64 - msg.timestamp as i64,
+            msg.timestamp,
+            current_timestamp
+        );
         let current_epoch = msg.checkpoint;
         self.current_epoch = Some(current_epoch);
         let block_number = self.chain_state.block_number();

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -405,6 +405,10 @@ pub struct EpochNotification<T: Send> {
     /// Epoch that has just started
     pub checkpoint: Epoch,
 
+    /// Timestamp of the start of the epoch.
+    /// This is used to verify that the messages arrive on time
+    pub timestamp: i64,
+
     /// Payload for the epoch notification
     pub payload: T,
 }

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -49,25 +49,25 @@ pub struct EpochPayload;
 #[derive(Clone, Debug)]
 pub struct EveryEpochPayload;
 
-/// Handler for EpochNotification<EpochPayload>
-impl Handler<EpochNotification<EpochPayload>> for ChainManager {
-    type Result = ();
-
-    fn handle(&mut self, msg: EpochNotification<EpochPayload>, _ctx: &mut Context<Self>) {
-        log::debug!("Epoch notification received {:?}", msg.checkpoint);
-    }
-}
-
 /// Handler for EpochNotification<EveryEpochPayload>
 impl Handler<EpochNotification<EveryEpochPayload>> for Session {
     type Result = ();
 
     fn handle(&mut self, msg: EpochNotification<EveryEpochPayload>, ctx: &mut Context<Self>) {
         log::debug!("Periodic epoch notification received {:?}", msg.checkpoint);
+        let current_timestamp = get_timestamp();
+        log::debug!(
+            "Timestamp diff: {}, Epoch timestamp: {}. Current timestamp: {}",
+            current_timestamp as i64 - msg.timestamp as i64,
+            msg.timestamp,
+            current_timestamp
+        );
+
         self.current_epoch = msg.checkpoint;
 
-        let now = get_timestamp();
-        if self.blocks_timestamp != 0 && now - self.blocks_timestamp > self.blocks_timeout {
+        if self.blocks_timestamp != 0
+            && current_timestamp - self.blocks_timestamp > self.blocks_timeout
+        {
             // Get ChainManager address
             let chain_manager_addr = ChainManager::from_registry();
 

--- a/node/src/actors/sessions_manager/handlers.rs
+++ b/node/src/actors/sessions_manager/handlers.rs
@@ -274,6 +274,15 @@ impl Handler<EpochNotification<()>> for SessionsManager {
     type Result = ();
 
     fn handle(&mut self, msg: EpochNotification<()>, ctx: &mut Context<Self>) {
+        log::debug!("Periodic epoch notification received {:?}", msg.checkpoint);
+        let current_timestamp = get_timestamp();
+        log::debug!(
+            "Timestamp diff: {}, Epoch timestamp: {}. Current timestamp: {}",
+            current_timestamp as i64 - msg.timestamp as i64,
+            msg.timestamp,
+            current_timestamp
+        );
+
         log::info!(
             "{} Inbound: {} | Outbound: {}",
             Cyan.bold().paint("[Sessions]"),


### PR DESCRIPTION
Add some logs to epoch manager, to detect problems with EpochNotifications.

Now when a node notices that it missed an epoch, it will move back to WaitingConsensus state and start synchronizing with its peers. This should prevent nodes from forking in some cases. 