### PR TITLE
fix(node): send PeersBeacons even if peers < outbound limit

### DIFF
--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -156,6 +156,8 @@ impl Message for GetBlocksEpochRange {
 pub struct PeersBeacons {
     /// A list of peers and their respective last beacon
     pub pb: Vec<(SocketAddr, Option<CheckpointBeacon>)>,
+    /// Outbound limit: how many beacons did we expect in total
+    pub outbound_limit: Option<u16>,
 }
 
 impl Message for PeersBeacons {

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -1,8 +1,9 @@
 use std::io::Error;
 
+use actix::io::WriteHandler;
 use actix::{
-    io::WriteHandler, ActorContext, ActorFuture, AsyncContext, Context, ContextFutureSpawner,
-    Handler, StreamHandler, SystemService, WrapFuture,
+    ActorContext, ActorFuture, Context, ContextFutureSpawner, Handler, StreamHandler,
+    SystemService, WrapFuture,
 };
 use futures::future;
 
@@ -353,10 +354,8 @@ fn update_consolidate(session: &Session, ctx: &mut Context<Session>) {
             session.remote_addr
         });
 
-    let session_type = session.session_type;
-
     // First evaluate Feeler case
-    if session_type == SessionType::Feeler {
+    if session.session_type == SessionType::Feeler {
         // Get peer manager address
         let peers_manager_addr = PeersManager::from_registry();
 
@@ -382,7 +381,7 @@ fn update_consolidate(session: &Session, ctx: &mut Context<Session>) {
                 session_type: session.session_type,
             })
             .into_actor(session)
-            .then(move |res, act, ctx| {
+            .then(|res, act, ctx| {
                 match res {
                     Ok(Ok(_)) => {
                         log::debug!(
@@ -391,32 +390,6 @@ fn update_consolidate(session: &Session, ctx: &mut Context<Session>) {
                         );
                         // Set status to consolidate
                         act.status = SessionStatus::Consolidated;
-
-                        // Send LastBeacon to inbound peers
-                        if session_type == SessionType::Inbound {
-                            let chain_manager_addr = ChainManager::from_registry();
-                            chain_manager_addr
-                                .send(GetHighestCheckpointBeacon)
-                                .into_actor(act)
-                                .then(|res, _act, ctx| {
-                                    match res {
-                                        Ok(Ok(beacon)) => ctx.notify(SendLastBeacon { beacon }),
-                                        // This error can happen when the ChainManager is being initialized and the CheckpointBeacon has not been loaded from storage yet
-                                        Ok(Err(e)) => log::error!(
-                                            "Cannot send beacon to new inbound peer: {}",
-                                            e
-                                        ),
-                                        // This error can happen when the ChainManager actor is not running
-                                        Err(e) => log::error!(
-                                            "Cannot send beacon to new inbound peer: {}",
-                                            e
-                                        ),
-                                    }
-
-                                    actix::fut::ok(())
-                                })
-                                .wait(ctx);
-                        }
 
                         actix::fut::ok(())
                     }

--- a/node/src/actors/sessions_manager/mod.rs
+++ b/node/src/actors/sessions_manager/mod.rs
@@ -242,9 +242,10 @@ impl SessionsManager {
             .chain(pnb.iter().map(|k| (*k, None)))
             .collect();
         let mut peers_to_keep: HashSet<_> = pb.iter().map(|(k, _v)| *k).collect();
+        let outbound_limit = self.sessions.outbound_consolidated.limit;
 
         ChainManager::from_registry()
-            .send(PeersBeacons { pb })
+            .send(PeersBeacons { pb, outbound_limit })
             .into_actor(self)
             .then(|res, act, _ctx| {
                 match res {

--- a/node/src/actors/sessions_manager/mod.rs
+++ b/node/src/actors/sessions_manager/mod.rs
@@ -256,6 +256,12 @@ impl SessionsManager {
                         // Nothing to do, carry on
                     }
                     Ok(Ok(peers_to_unregister)) => {
+                        if !peers_to_unregister.is_empty() {
+                            log::debug!(
+                                "Dropping {} peers that were out of consensus",
+                                peers_to_unregister.len()
+                            );
+                        }
                         // Unregister peers out of consensus
                         for peer in peers_to_unregister {
                             if let Some(a) =


### PR DESCRIPTION
This fixes a bug where the node would move to WaitingConsensus as soon
as one of its peers closed the connection.

Now the SessionsManager will always send the list of beacons to the
ChainManager. If there is consensus after counting the missing peers as
"NO BEACON", the node will start synchronizing even if it's still
missing some peers.

For example, if a node has `outbound_limit = 5` and `consensus_c = 70`, it means that it's waiting for 5 peers, and at least 70% of them must agree (in this case 4 peers out of 5). So before this PR the node would wait for 5 peers, and then calculate the consensus. After this PR, the node calculates the consensus once every epoch, and if at least 4 peers reported the same beacon, it will start synchronizing even if it is still missing some peers.

---------------

If the node has less peers than "consensus_c %", so in the previous example 3 peers out of 5, it will not drop any peers.

This PR also reverts one change introduced in commit 15e9313c06e933adfc438c7fa29b642aa98f8369 (PR  https://github.com/witnet/witnet-rust/pull/1126). We found a case where the node wrongly assumes that it got all the beacons for this epoch, when in reality it just got the beacons from last epoch when connecting to the peer:

![image](https://user-images.githubusercontent.com/44392885/80208708-13af5a80-8631-11ea-8d30-aa3b493954aa.png)

So now we do not send the beacon when establishing a new connection. That makes synchronization up to one epoch slower, and now the nodes cannot sync before epoch 0, unless we add a hack to send beacons periodically before epoch 0.