### PR TITLE
fix(wallet): index genesis block in initial sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ Cargo.lock
 *.log
 
 # Ignore rocksdb default storage path
-.wit/
+.wit*/
 
 # Ignore generated documentation
 site

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -439,8 +439,8 @@ impl Worker {
         let retrieve_responses = async { futures03::future::try_join_all(txn_futures).await };
         let transactions: Vec<types::Transaction> =
             futures03::executor::block_on(retrieve_responses)?;
-        log::info!(
-            "Received {} wallet transactions from node",
+        log::debug!(
+            "Retrieved value transfer output information from node (queried {} wallet transactions)",
             transactions.len()
         );
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -52,7 +52,7 @@ pub fn run(conf: Config) -> Result<(), Error> {
         checkpoint_zero_timestamp: conf.consensus_constants.checkpoint_zero_timestamp,
         checkpoints_period: conf.consensus_constants.checkpoints_period,
     };
-    let genesis_hash = conf.consensus_constants.genesis_hash;
+    let genesis_prev_hash = conf.consensus_constants.bootstrap_hash;
 
     // Db-encryption params
     let db_hash_iterations = conf.wallet.db_encrypt_hash_iterations;
@@ -111,12 +111,12 @@ pub fn run(conf: Config) -> Result<(), Error> {
         db_salt_length,
         epoch_constants,
         node_sync_batch_size,
-        genesis_hash,
+        genesis_prev_hash,
     };
 
     let last_beacon = Arc::new(RwLock::new(CheckpointBeacon {
         checkpoint: 0,
-        hash_prev_block: genesis_hash,
+        hash_prev_block: genesis_prev_hash,
     }));
     let network = String::from(if testnet { "Testnet" } else { "Mainnet" });
     let node_params = params::NodeParams {

--- a/wallet/src/model.rs
+++ b/wallet/src/model.rs
@@ -30,7 +30,7 @@ pub struct Address {
     pub keychain: u32,
     pub account: u32,
     pub path: String,
-    pub label: Option<String>,
+    pub info: AddressInfo,
     pub pkh: types::PublicKeyHash,
 }
 
@@ -38,6 +38,15 @@ pub struct Address {
 pub struct Addresses {
     pub addresses: Vec<Address>,
     pub total: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct AddressInfo {
+    pub label: Option<String>,
+    pub received_payments: Vec<String>,
+    pub received_amount: u64,
+    pub first_payment_date: Option<i64>,
+    pub last_payment_date: Option<i64>,
 }
 
 #[derive(Debug, Serialize)]

--- a/wallet/src/model.rs
+++ b/wallet/src/model.rs
@@ -219,6 +219,16 @@ impl From<&types::OutputPointer> for OutPtr {
     }
 }
 
+impl fmt::Display for OutPtr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&format!(
+            "{}:{}",
+            &self.transaction_id(),
+            &self.output_index
+        ))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct KeyBalance {
     /// PKH receiving this balance

--- a/wallet/src/params.rs
+++ b/wallet/src/params.rs
@@ -21,7 +21,7 @@ pub struct Params {
     pub db_salt_length: usize,
     pub epoch_constants: EpochConstants,
     pub node_sync_batch_size: u32,
-    pub genesis_hash: Hash,
+    pub genesis_prev_hash: Hash,
 }
 
 impl Default for Params {
@@ -37,7 +37,7 @@ impl Default for Params {
             db_salt_length: 32,
             epoch_constants: EpochConstants::default(),
             node_sync_batch_size: 100,
-            genesis_hash: Hash::default(),
+            genesis_prev_hash: Hash::default(),
         }
     }
 }

--- a/wallet/src/repository/keys.rs
+++ b/wallet/src/repository/keys.rs
@@ -120,7 +120,7 @@ pub fn address_info(account_index: u32, keychain: u32, key_index: u32) -> String
     )
 }
 
-/// Info associated to a pkh.
+/// Path information associated to a pkh (account, keychain and index).
 #[inline]
 pub fn pkh(pkh: &PublicKeyHash) -> Vec<u8> {
     [b"pkh-", pkh.as_ref()].concat().to_vec()

--- a/wallet/src/repository/keys.rs
+++ b/wallet/src/repository/keys.rs
@@ -113,9 +113,9 @@ pub fn address_pkh(account_index: u32, keychain: u32, key_index: u32) -> String 
 
 /// An address's label.
 #[inline]
-pub fn address_label(account_index: u32, keychain: u32, key_index: u32) -> String {
+pub fn address_info(account_index: u32, keychain: u32, key_index: u32) -> String {
     format!(
-        "account-{}-key-{}-{}-address-label",
+        "account-{}-key-{}-{}-address-info",
         account_index, keychain, key_index
     )
 }

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -78,7 +78,7 @@ where
             .get(&keys::wallet_last_sync())
             .unwrap_or_else(|_| CheckpointBeacon {
                 checkpoint: 0,
-                hash_prev_block: params.genesis_hash,
+                hash_prev_block: params.genesis_prev_hash,
             });
         let external_key = db.get(&keys::account_key(account, constants::EXTERNAL_KEYCHAIN))?;
         let next_external_index = db.get_or_default(&keys::account_next_index(

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -167,6 +167,13 @@ where
             keychain,
             index
         );
+        let info = model::AddressInfo {
+            label,
+            received_payments: vec![],
+            received_amount: 0,
+            first_payment_date: None,
+            last_payment_date: None,
+        };
 
         // Persist changes and new address in database
         let mut batch = self.db.batch();
@@ -174,9 +181,7 @@ where
         batch.put(keys::address(account, keychain, index), &address)?;
         batch.put(keys::address_path(account, keychain, index), &path)?;
         batch.put(keys::address_pkh(account, keychain, index), &pkh)?;
-        if let Some(label) = &label {
-            batch.put(keys::address_label(account, keychain, index), label)?;
-        }
+        batch.put(keys::address_info(account, keychain, index), &info)?;
         batch.put(
             keys::pkh(&pkh),
             model::Path {
@@ -192,7 +197,7 @@ where
         let address = model::Address {
             address,
             path,
-            label,
+            info,
             index,
             account,
             keychain,
@@ -270,9 +275,7 @@ where
         let address = self.db.get(&keys::address(account, keychain, index))?;
         let path = self.db.get(&keys::address_path(account, keychain, index))?;
         let pkh = self.db.get(&keys::address_pkh(account, keychain, index))?;
-        let label = self
-            .db
-            .get_opt(&keys::address_label(account, keychain, index))?;
+        let info = self.db.get(&keys::address_info(account, keychain, index))?;
 
         Ok(model::Address {
             address,
@@ -281,7 +284,7 @@ where
             index,
             account,
             keychain,
-            label,
+            info,
         })
     }
 

--- a/wallet/src/repository/wallet/tests/mod.rs
+++ b/wallet/src/repository/wallet/tests/mod.rs
@@ -98,7 +98,7 @@ fn test_gen_external_address_saves_details_in_db() {
     );
     assert_eq!(
         label,
-        db.get::<_, String>(&keys::address_label(account, keychain, index))
+        db.get::<_, String>(&keys::address_info(account, keychain, index))
             .unwrap()
     );
 }
@@ -248,7 +248,7 @@ fn test_gen_internal_address_saves_details_in_db() {
     );
     assert_eq!(
         label,
-        db.get::<_, String>(&keys::address_label(account, keychain, index))
+        db.get::<_, String>(&keys::address_info(account, keychain, index))
             .unwrap()
     );
 }


### PR DESCRIPTION
The wallet was not indexing the genesis block at the initial wallet synchronization, because of the `since_beacon` is pointing to epoch 0 and the sync logic start at `checkpoint + 1`.

The solution was to handle this specific case before the `loop` that iterates synchronization batches.