### PR TITLE
Fix docker image so it correctly sets the public address unless disabled

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -84,11 +84,12 @@ docker-image-build-all:
 docker-image-build target:
     docker build --no-cache -t witnet-rust/{{target}} -f docker/cross-compilation/{{target}}/Dockerfile docker/cross-compilation
 
+# builds a multi architecture docker image for running a witnet-rust node from released binaries
 docker-image-buildx version="latest" +flags="":
     docker buildx build \
         -f docker/witnet-rust/Dockerfile \
         --build-arg WITNET_VERSION={{version}} \
-        --platform linux/amd64,linux/386,linux/arm64,linux/arm/v7 \
+        --platform linux/amd64,linux/arm64,linux/arm/v7 \
         --tag witnet/witnet-rust:{{version}} \
         docker/witnet-rust {{flags}}
 

--- a/docker/debug-run/Dockerfile
+++ b/docker/debug-run/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:disco
+FROM ubuntu:focal
 
 # Install basic environment dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/witnet-rust/Dockerfile
+++ b/docker/witnet-rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM ubuntu:disco
+FROM --platform=$TARGETPLATFORM ubuntu:focal
 
 # Install basic environment dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -22,11 +22,11 @@ EXPOSE 21338
 EXPOSE 11212
 
 # Run the install script
-RUN ["chmod", "+x", "./runner.sh"]
-RUN ["./runner.sh"]
+RUN ["chmod", "+x", "./downloader.sh", "./ip_detector.sh", "./runner.sh"]
+RUN ["./downloader.sh"]
 
 # Set compilation entry point (always gets executed)
-ENTRYPOINT ["./witnet"]
+ENTRYPOINT ["./runner.sh"]
 
 # Set default command (can be overriden)
 CMD ["node", "server"]

--- a/docker/witnet-rust/downloader.sh
+++ b/docker/witnet-rust/downloader.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+VERSION=${WITNET_VERSION:-"latest"}
+
+if [[ "$VERSION" == "latest" ]]; then
+    VERSION=`curl https://github.com/witnet/witnet-rust/releases/latest --cacert /etc/ssl/certs/ca-certificates.crt 2>/dev/null | egrep -o "[0-9|\.]{5}(-rc[0-9]+)?"`
+fi
+
+TRIPLET=`bash --version | head -1 | sed -En 's/^.*\ \((.+)-(.+)-(.+)\)$/\1-\2-\3/p'`
+
+if [[ "$TRIPLET" == *"linux"* ]]; then
+    TRIPLET=`echo $TRIPLET | sed 's/pc/unknown/g'`
+fi
+
+URL="https://github.com/witnet/witnet-rust/releases/download/$VERSION/witnet-$VERSION-$TRIPLET.tar.gz"
+
+FILENAME="$VERSION.tar.gz"
+FOLDERNAME="."
+
+echo "Downloading 'witnet-$VERSION-$TRIPLET.tar.gz'. It may take a few seconds..."
+curl -L $URL -o /tmp/${FILENAME} --cacert /etc/ssl/certs/ca-certificates.crt >/dev/null 2>&1 &&
+tar -zxf /tmp/${FILENAME} --directory ${FOLDERNAME} >/dev/null 2>&1 &&
+chmod +x $FOLDERNAME/witnet &&
+rm -f /tmp/${FILENAME} &&
+${FOLDERNAME}/witnet --version ||
+echo "Error downloading and installing witnet-rust on version $VERSION for $TRIPLET"

--- a/docker/witnet-rust/ip_detector.sh
+++ b/docker/witnet-rust/ip_detector.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+CONFIG_FILE_FROM_CMD=`echo "$@" | sed -E 's/(.*-c\s*)?(.*\.toml)?.*/\2/'`
+CONFIG_FILE=${CONFIG_FILE_FROM_CMD:-witnet.toml}
+DEFAULT_IP="0.0.0.0"
+DEFAULT_PORT="21337"
+DEFAULT_ADDR="$DEFAULT_IP:$DEFAULT_PORT"
+
+echo "Reading configuration from $CONFIG_FILE"
+
+function read_public_addr_from_config {
+    echo "Reading public_addr from config file";
+    PUBLIC_ADDR_FROM_CONFIG=`grep public_addr $CONFIG_FILE | cut -d "\"" -f2`;
+    LISTENING_PORT_FROM_CONFIG=`grep "server_addr" $CONFIG_FILE | head -1 | cut -d "\"" -f2 | cut -d ":" -f2`
+}
+
+function guess_public_addr {
+    echo "Trying to guess public_addr";
+    API_URL="http://bot.whatismyipaddress.com/";
+    PUBLIC_ADDR_FROM_API="`curl $API_URL 2>/dev/null || echo $DEFAULT_IP`:${LISTENING_PORT_FROM_CONFIG:-$DEFAULT_PORT}";
+}
+
+function replace_ip_in_config_if_not_set {
+    read_public_addr_from_config;
+    if [[ "$PUBLIC_ADDR_FROM_CONFIG" == "$DEFAULT_ADDR" ]]; then
+        guess_public_addr;
+        if [[ "$PUBLIC_ADDR_FROM_API" != "$DEFAULT_ADDR" ]]; then
+           echo "Trying to replace public_address ($PUBLIC_ADDR_FROM_API) into config file ($CONFIG_FILE)";
+           sed -i -E "s/public_addr\s*=\s*\"$DEFAULT_ADDR\"/public_addr = \"$PUBLIC_ADDR_FROM_API\"/" $CONFIG_FILE;
+        fi
+    else
+      if [[ "$PUBLIC_ADDR_FROM_CONFIG" == "" ]]; then
+        guess_public_addr;
+        echo "Trying to write public_address ($PUBLIC_ADDR_FROM_API) into config file ($CONFIG_FILE)";
+        sed -i -E "s/^\[connections\]$/[connections]\npublic_addr = \"$PUBLIC_ADDR_FROM_API\"/" $CONFIG_FILE;
+      fi
+    fi
+    return 0; # This is best effort, it's a pity if it didn't work out, but we need to keep running the node anyway.
+}
+
+replace_ip_in_config_if_not_set

--- a/docker/witnet-rust/runner.sh
+++ b/docker/witnet-rust/runner.sh
@@ -1,64 +1,9 @@
 #!/bin/bash
 
-VERSION=${WITNET_VERSION:-"latest"}
+PUBLIC_ADDR_DISCOVERY=${PUBLIC_ADDR_DISCOVERY:-"true"}
 
-if [[ "$VERSION" == "latest" ]]; then
-    VERSION=`curl https://github.com/witnet/witnet-rust/releases/latest --cacert /etc/ssl/certs/ca-certificates.crt 2>/dev/null | egrep -o "[0-9|\.]{5}(-rc[0-9]+)?"`
+if [[ "$PUBLIC_ADDR_DISCOVERY" == "true" ]]; then
+    ./ip_detector.sh
 fi
 
-TRIPLET=`bash --version | head -1 | sed -En 's/^.*\ \((.+)-(.+)-(.+)\)$/\1-\2-\3/p'`
-
-if [[ "$TRIPLET" == *"linux"* ]]; then
-    TRIPLET=`echo $TRIPLET | sed 's/pc/unknown/g'`
-fi
-
-URL="https://github.com/witnet/witnet-rust/releases/download/$VERSION/witnet-$VERSION-$TRIPLET.tar.gz"
-
-FILENAME="$VERSION.tar.gz"
-FOLDERNAME="."
-CONFIG_FILE_FROM_CMD=`echo "$@" | sed -E 's/(.*-c\s*)?(.*\.toml)?.*/\2/'`
-CONFIG_FILE=${CONFIG_FILE_FROM_CMD:-witnet.toml}
-DEFAULT_IP="0.0.0.0"
-DEFAULT_PORT="21337"
-DEFAULT_ADDR="$DEFAULT_IP:$DEFAULT_PORT"
-
-echo "Reading configuration from $CONFIG_FILE"
-
-function read_public_addr_from_config {
-    echo "Reading public_addr from config file";
-    PUBLIC_ADDR_FROM_CONFIG=`grep public_addr $CONFIG_FILE | cut -d "\"" -f2`;
-    LISTENING_PORT_FROM_CONFIG=`grep "server_addr" $CONFIG_FILE | head -1 | cut -d "\"" -f2 | cut -d ":" -f2`
-}
-
-function guess_public_addr {
-    echo "Trying to guess public_addr";
-    API_URL="http://bot.whatismyipaddress.com/";
-    PUBLIC_ADDR_FROM_API="`curl $API_URL 2>/dev/null || echo $DEFAULT_IP`:${LISTENING_PORT_FROM_CONFIG:-$DEFAULT_PORT}";
-}
-
-function replace_ip_in_config_if_not_set {
-    read_public_addr_from_config;
-    if [[ "$PUBLIC_ADDR_FROM_CONFIG" == "$DEFAULT_ADDR" ]]; then
-        guess_public_addr;
-        if [[ "$PUBLIC_ADDR_FROM_API" != "$DEFAULT_ADDR" ]]; then
-           echo "Trying to replace public_address ($PUBLIC_ADDR_FROM_API) into config file ($CONFIG_FILE)";
-           sed -i -E "s/public_addr\s*=\s*\"$DEFAULT_ADDR\"/public_addr = \"$PUBLIC_ADDR_FROM_API\"/" $CONFIG_FILE;
-        fi
-    else
-      if [[ "$PUBLIC_ADDR_FROM_CONFIG" == "" ]]; then
-        guess_public_addr;
-        echo "Trying to write public_address ($PUBLIC_ADDR_FROM_API) into config file ($CONFIG_FILE)";
-        sed -i -E "s/^\[connections\]$/[connections]\npublic_addr = \"$PUBLIC_ADDR_FROM_API\"/" $CONFIG_FILE;
-      fi
-    fi
-    return 0; # This is best effort, it's a pity if it didn't work out, but we need to keep running the node anyway.
-}
-
-echo "Downloading 'witnet-$VERSION-$TRIPLET.tar.gz'. It may take a few seconds..."
-curl -L $URL -o /tmp/${FILENAME} --cacert /etc/ssl/certs/ca-certificates.crt >/dev/null 2>&1 &&
-tar -zxf /tmp/${FILENAME} --directory ${FOLDERNAME} >/dev/null 2>&1 &&
-replace_ip_in_config_if_not_set &&
-chmod +x $FOLDERNAME/witnet &&
-rm -f /tmp/${FILENAME} &&
-${FOLDERNAME}/witnet --version ||
-echo "Error downloading and installing witnet-rust on version $VERSION for $TRIPLET"
+./witnet "$@"


### PR DESCRIPTION
This fixes the `witnet/witnet-rust` docker image so it correctly sets the public address when starting unless explicitly disabled using the `PUBLIC_ADDR_DISCOVERY=false` environment flag:

```console
docker run -d \
    --volume ~/.witnet:/.witnet \
    --name witnet_node \
    --publish 21337:21337 \
    -e PUBLIC_ADDR_DISCOVERY=false \
    witnet/witnet-rust
```