### PR TITLE
Move session errors to debug

### DIFF
--- a/node/src/actors/connections_manager/mod.rs
+++ b/node/src/actors/connections_manager/mod.rs
@@ -81,7 +81,7 @@ impl ConnectionsManager {
                 // Process the ResolverResult
                 match res {
                     Err(error) => {
-                        log::warn!("Failed to connect to a peer with error: {:?}", error);
+                        log::debug!("Failed to connect to a peer with error: {:?}", error);
                         actix::fut::err(())
                     }
                     Ok(stream) => {

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -18,18 +18,19 @@ use serde::{Deserialize, Serialize};
 use tokio::net::TcpStream;
 
 use witnet_data_structures::{
-    chain::UtxoSelectionStrategy,
     chain::{
         Block, CheckpointBeacon, DataRequestInfo, DataRequestOutput, Epoch, EpochConstants, Hash,
         InventoryEntry, InventoryItem, PointerToBlock, PublicKeyHash, RADRequest, RADTally,
-        Reputation, UtxoInfo, ValueTransferOutput,
+        Reputation, UtxoInfo, UtxoSelectionStrategy, ValueTransferOutput,
     },
     radon_report::RadonReport,
     transaction::{CommitTransaction, RevealTransaction, Transaction},
 };
-use witnet_p2p::sessions::{GetConsolidatedPeersResult, SessionStatus, SessionType};
-use witnet_rad::error::RadError;
-use witnet_rad::types::RadonTypes;
+use witnet_p2p::{
+    error::SessionsError,
+    sessions::{GetConsolidatedPeersResult, SessionStatus, SessionType},
+};
+use witnet_rad::{error::RadError, types::RadonTypes};
 
 use super::{
     chain_manager::{ChainManagerError, StateMachine, MAX_BLOCKS_SYNC},
@@ -674,7 +675,7 @@ pub struct CloseSession;
 ////////////////////////////////////////////////////////////////////////////////////////
 
 /// Message result of unit
-pub type SessionsUnitResult = Result<(), failure::Error>;
+pub type SessionsUnitResult = Result<(), SessionsError>;
 
 /// Message indicating a new session needs to be created
 pub struct Create {

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -394,7 +394,7 @@ fn update_consolidate(session: &Session, ctx: &mut Context<Session>) {
                         actix::fut::ok(())
                     }
                     _ => {
-                        log::warn!(
+                        log::debug!(
                             "Failed to consolidate session {:?} in SessionManager",
                             act.remote_addr
                         );

--- a/p2p/src/sessions/bounded_sessions.rs
+++ b/p2p/src/sessions/bounded_sessions.rs
@@ -39,18 +39,18 @@ impl<T> BoundedSessions<T> {
         &mut self,
         address: SocketAddr,
         reference: T,
-    ) -> Result<(), failure::Error> {
+    ) -> Result<(), SessionsError> {
         // Check num peers
         if self
             .limit
             .map(|limit| self.collection.len() >= limit as usize)
             .unwrap_or(false)
         {
-            return Err(SessionsError::MaxPeersReached.into());
+            return Err(SessionsError::MaxPeersReached);
         }
         // Check if address is already in sessions collection
         if self.collection.contains_key(&address) {
-            return Err(SessionsError::AddressAlreadyRegistered.into());
+            return Err(SessionsError::AddressAlreadyRegistered);
         }
         // Insert session into the right collection
         self.collection.insert(address, SessionInfo { reference });
@@ -62,11 +62,11 @@ impl<T> BoundedSessions<T> {
     pub fn unregister_session(
         &mut self,
         address: SocketAddr,
-    ) -> Result<SessionInfo<T>, failure::Error> {
+    ) -> Result<SessionInfo<T>, SessionsError> {
         // Insert session into the right map (if not present)
         match self.collection.remove(&address) {
             Some(info) => Ok(info),
-            None => Err(SessionsError::AddressNotFound.into()),
+            None => Err(SessionsError::AddressNotFound),
         }
     }
 }

--- a/p2p/src/sessions/mod.rs
+++ b/p2p/src/sessions/mod.rs
@@ -179,7 +179,7 @@ where
 
         self.outbound_consolidated
             .limit
-            .map(|limit| limit as usize - num_outbound_sessions)
+            .map(|limit| usize::from(limit).saturating_sub(num_outbound_sessions))
             .unwrap_or(1)
     }
     /// Method to get a random consolidated outbound session


### PR DESCRIPTION
Fix #1056 

It is possible that the node tries to connect twice to the same peer because of a race condition in the code. This can result in some errors when registering and unregistering peers.

This PR will:

* Remove backtraces from some logs
* Move the errors that can happen because of the race condition to debug level
* Fix overflow in `num_missing_outbound`
