### PR TITLE
Avoid show redundant block and transaction messages in debug log level

### DIFF
--- a/bridges/ethereum/src/actors/mod.rs
+++ b/bridges/ethereum/src/actors/mod.rs
@@ -1,5 +1,4 @@
 use futures::Future;
-use log::*;
 use web3::types::{TransactionReceipt, U256};
 use witnet_data_structures::chain::Block;
 
@@ -47,7 +46,7 @@ pub fn handle_receipt(receipt: TransactionReceipt) -> impl Future<Item = (), Err
             futures::failed(())
         }
         x => {
-            error!("Unknown return code, should be 0 or 1, is: {:?}", x);
+            log::error!("Unknown return code, should be 0 or 1, is: {:?}", x);
             futures::failed(())
         }
     }

--- a/bridges/ethereum/src/config.rs
+++ b/bridges/ethereum/src/config.rs
@@ -1,6 +1,5 @@
 //! Configuration
 
-use log::*;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::path::Path;
@@ -79,7 +78,7 @@ pub fn from_file<S: AsRef<Path>>(file: S) -> Result<Config, Box<dyn std::error::
     let f = file.as_ref();
     let mut contents = String::new();
 
-    debug!("Loading config from `{}`", f.to_string_lossy());
+    log::debug!("Loading config from `{}`", f.to_string_lossy());
 
     let mut file = File::open(file)?;
     file.read_to_string(&mut contents)?;

--- a/bridges/ethereum/src/main.rs
+++ b/bridges/ethereum/src/main.rs
@@ -1,6 +1,5 @@
 //! Witnet <> Ethereum bridge
 use futures::stream::Stream;
-use log::*;
 use std::time::{Duration, Instant};
 use std::{
     path::PathBuf,
@@ -81,9 +80,9 @@ fn post_example_dr(
             }),
         )
         .map(|tx| {
-            info!("posted dr to wrb: {:?}", tx);
+            log::info!("posted dr to wrb: {:?}", tx);
         })
-        .map_err(|e| error!("Error posting dr to wrb: {}", e))
+        .map_err(|e| log::error!("Error posting dr to wrb: {}", e))
 }
 
 /// Command line usage and flags
@@ -104,7 +103,7 @@ fn main() {
     init_logger();
 
     if let Err(err) = run() {
-        error!("{}", err);
+        log::error!("{}", err);
         std::process::exit(1);
     }
 }
@@ -166,7 +165,7 @@ fn run() -> Result<(), String> {
                 let witnet_event_fut = match witnet_block_fut.wait() {
                     Ok(x) => x,
                     Err(e) => {
-                        error!("{}", e);
+                        log::error!("{}", e);
                         return;
                     }
                 };
@@ -175,7 +174,7 @@ fn run() -> Result<(), String> {
                 let eth_state2 = eth_state.clone();
                 tokio::spawn(
                     Interval::new(Instant::now(), Duration::from_millis(10_000))
-                        .map_err(|e| error!("Error creating interval: {:?}", e))
+                        .map_err(|e| log::error!("Error creating interval: {:?}", e))
                         .and_then(move |_| {
                             get_new_requests(
                                 Arc::clone(&config2),
@@ -193,7 +192,7 @@ fn run() -> Result<(), String> {
                 let eth_state2 = eth_state.clone();
                 tokio::spawn(
                     Interval::new(Instant::now(), Duration::from_millis(10_000))
-                        .map_err(|e| error!("Error creating interval: {:?}", e))
+                        .map_err(|e| log::error!("Error creating interval: {:?}", e))
                         .and_then(move |_| {
                             wrb_requests_periodic_sync(
                                 Arc::clone(&config2),

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -43,7 +43,6 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use log::warn;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::defaults::{Defaults, Testnet};
@@ -371,7 +370,7 @@ impl Config {
                 let consensus_constants_no_changes = PartialConsensusConstants::default();
                 // Warn the user if the config file contains a non-empty [consensus_constant] section
                 if config.consensus_constants != consensus_constants_no_changes {
-                    warn!(
+                    log::warn!(
                         "Consensus constants in the configuration are ignored when running mainnet"
                     );
                 }

--- a/docs/architecture/managers/chain-manager.md
+++ b/docs/architecture/managers/chain-manager.md
@@ -153,7 +153,7 @@ checkpoint.
 
 ```rust
 fn handle(&mut self, msg: EpochNotification<EpochPayload>, _ctx: &mut Context<Self>) {
-    debug!("Epoch notification received {:?}", msg.checkpoint);
+    log::debug!("Epoch notification received {:?}", msg.checkpoint);
 }
 ```
 

--- a/docs/architecture/managers/epoch-manager.md
+++ b/docs/architecture/managers/epoch-manager.md
@@ -64,7 +64,7 @@ The `GetEpoch` message wraps the `current_epoch()` method:
 ```rust
 fn handle(&mut self, _msg: GetEpoch, _ctx: &mut Self::Context) -> EpochResult<Epoch> {
     let r = self.current_epoch();
-    debug!("Current epoch: {:?}", r);
+    log::debug!("Current epoch: {:?}", r);
     r
 }
 ```
@@ -153,7 +153,7 @@ impl Handler<EpochNotification<EpochPayload>> for BlockManager {
     type Result = ();
 
     fn handle(&mut self, msg: EpochNotification<EpochPayload>, _ctx: &mut Context<Self>) {
-        debug!("Epoch notification received {:?}", msg.checkpoint);
+        log::debug!("Epoch notification received {:?}", msg.checkpoint);
     }
 }
 ```
@@ -191,7 +191,7 @@ impl Handler<EpochNotification<EveryEpochPayload>> for BlockManager {
     type Result = ();
 
     fn handle(&mut self, msg: EpochNotification<EveryEpochPayload>, _ctx: &mut Context<Self>) {
-        debug!("Periodic epoch notification received {:?}", msg.checkpoint);
+        log::debug!("Periodic epoch notification received {:?}", msg.checkpoint);
     }
 }
 ```

--- a/docs/architecture/managers/managers.md
+++ b/docs/architecture/managers/managers.md
@@ -39,7 +39,7 @@ impl Actor for Manager {
     
     /// Method that is executed when the actor is started
     fn started(&mut self, _ctx: &mut Self::Context) {
-        debug!("Manager actor has been started!")
+        log::debug!("Manager actor has been started!")
     }
 }
 ```

--- a/docs/architecture/managers/peers-manager.md
+++ b/docs/architecture/managers/peers-manager.md
@@ -50,7 +50,7 @@ impl Handler<AddPeers> for PeersManager {
 
     fn handle(&mut self, msg: AddPeers, _: &mut Context<Self>) -> Self::Result {
         // Insert address
-        debug!("Add peer handle for addresses: {:?}", msg.addresses);
+        log::debug!("Add peer handle for addresses: {:?}", msg.addresses);
         self.peers.add(msg.addresses)
     }
 }

--- a/docs/architecture/managers/sessions-manager.md
+++ b/docs/architecture/managers/sessions-manager.md
@@ -97,8 +97,8 @@ The way other actors will communicate with the sessions manager is:
         .into_actor(self)
         .then(|res, _act, ctx| {
             match res {
-                Ok(Ok(_)) => debug!("Session successfully registered into the Session Manager"),
-                _ => debug!("Session register into Session Manager failed")
+                Ok(Ok(_)) => log::debug!("Session successfully registered into the Session Manager"),
+                _ => log::debug!("Session register into Session Manager failed")
             }
             actix::fut::ok(())
         })

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -361,6 +361,7 @@ impl ChainManager {
                             self.candidates
                                 .insert(hash_block, (block.clone(), vrf_hash[0]));
                             self.broadcast_item(InventoryItem::Block(block));
+                            log::debug!("Send Candidate");
                         }
                         Err(e) => warn!("{}", e),
                     },

--- a/node/src/actors/connections_manager/actor.rs
+++ b/node/src/actors/connections_manager/actor.rs
@@ -1,5 +1,4 @@
 use actix::{Actor, Context};
-use log::debug;
 
 use super::ConnectionsManager;
 
@@ -10,7 +9,7 @@ impl Actor for ConnectionsManager {
 
     /// Method to be executed when the actor is started
     fn started(&mut self, ctx: &mut Self::Context) {
-        debug!("Connections Manager actor has been started!");
+        log::debug!("Connections Manager actor has been started!");
 
         // Start server
         // FIXME(#72): decide what to do with actor when server cannot be started

--- a/node/src/actors/epoch_manager/actor.rs
+++ b/node/src/actors/epoch_manager/actor.rs
@@ -1,5 +1,3 @@
-use log::debug;
-
 use actix::{Actor, Context};
 
 use super::EpochManager;
@@ -11,7 +9,7 @@ impl Actor for EpochManager {
 
     /// Method to be executed when the actor is started
     fn started(&mut self, ctx: &mut Self::Context) {
-        debug!("Epoch Manager actor has been started!");
+        log::debug!("Epoch Manager actor has been started!");
 
         self.process_config(ctx);
     }

--- a/node/src/actors/epoch_manager/handlers.rs
+++ b/node/src/actors/epoch_manager/handlers.rs
@@ -1,7 +1,5 @@
 use actix::Handler;
 
-use log::{debug, error};
-
 use witnet_data_structures::chain::Epoch;
 
 use super::EpochManager;
@@ -22,13 +20,13 @@ impl Handler<GetEpoch> for EpochManager {
         let checkpoint = self.current_epoch();
         checkpoint
             .as_ref()
-            .map(|checkpoint| debug!("Asked for current epoch (#{})", checkpoint))
+            .map(|checkpoint| log::debug!("Asked for current epoch (#{})", checkpoint))
             .unwrap_or_else(|error| match error {
-                EpochManagerError::CheckpointZeroInTheFuture(_) => debug!(
+                EpochManagerError::CheckpointZeroInTheFuture(_) => log::debug!(
                     "Failed to retrieve epoch when asked to. Error was: {:?}",
                     error
                 ),
-                _ => error!(
+                _ => log::error!(
                     "Failed to retrieve epoch when asked to. Error was: {:?}",
                     error
                 ),
@@ -42,7 +40,7 @@ impl Handler<SubscribeEpoch> for EpochManager {
 
     /// Method to handle SubscribeEpoch messages
     fn handle(&mut self, msg: SubscribeEpoch, _ctx: &mut Self::Context) {
-        debug!("New subscription to checkpoint #{:?}", msg.checkpoint);
+        log::debug!("New subscription to checkpoint #{:?}", msg.checkpoint);
 
         // Store subscription to target checkpoint
         self.subscriptions_epoch
@@ -57,7 +55,7 @@ impl Handler<SubscribeAll> for EpochManager {
 
     /// Method to handle SubscribeAll messages
     fn handle(&mut self, msg: SubscribeAll, _ctx: &mut Self::Context) {
-        debug!("New subscription to every checkpoint");
+        log::debug!("New subscription to every checkpoint");
 
         // Store subscription to all checkpoints
         self.subscriptions_all.push(msg.notification);

--- a/node/src/actors/epoch_manager/mod.rs
+++ b/node/src/actors/epoch_manager/mod.rs
@@ -3,8 +3,6 @@ use actix::prelude::*;
 
 use ansi_term::Color::Purple;
 
-use log::{error, info, warn};
-
 use std::{collections::BTreeMap, time::Duration};
 
 use witnet_data_structures::{
@@ -81,7 +79,7 @@ impl EpochManager {
         mut checkpoints_period: u16,
     ) {
         if checkpoints_period == 0 {
-            warn!("Setting the checkpoint period to the minimum value of 1 second");
+            log::warn!("Setting the checkpoint period to the minimum value of 1 second");
             checkpoints_period = 1;
         }
         self.constants = Some(EpochConstants {
@@ -119,7 +117,7 @@ impl EpochManager {
                     config.consensus_constants.checkpoint_zero_timestamp,
                     config.consensus_constants.checkpoints_period,
                 );
-                info!(
+                log::info!(
                     "Checkpoint zero timestamp: {}, checkpoints period: {}",
                     actor.constants.as_ref().unwrap().checkpoint_zero_timestamp,
                     actor.constants.as_ref().unwrap().checkpoints_period,
@@ -224,7 +222,7 @@ impl EpochManager {
                 // Update last checked epoch
                 act.last_checked_epoch = Some(current_epoch);
 
-                info!(
+                log::info!(
                     "{} We are now in epoch #{}",
                     Purple.bold().paint("[Checkpoints]"),
                     Purple.bold().paint(current_epoch.to_string())
@@ -284,7 +282,7 @@ impl<T: Send> SendableNotification for SingleEpochSubscription<T> {
                 Err(_e) => {}
             };
         } else {
-            error!(
+            log::error!(
                 "No payload to be sent back to the subscribed actor for epoch {:?}",
                 epoch
             );

--- a/node/src/actors/json_rpc/connection.rs
+++ b/node/src/actors/json_rpc/connection.rs
@@ -5,7 +5,6 @@ use actix::{
 use tokio::{io::WriteHalf, net::TcpStream};
 
 use bytes::BytesMut;
-use log::*;
 use std::{io, rc::Rc};
 
 use super::{
@@ -48,22 +47,22 @@ impl WriteHandler<io::Error> for JsonRpc {}
 impl StreamHandler<BytesMut, io::Error> for JsonRpc {
     /// This is main event loop for client requests
     fn handle(&mut self, bytes: BytesMut, ctx: &mut Self::Context) {
-        debug!("Got JSON-RPC message");
+        log::debug!("Got JSON-RPC message");
         let msg = match String::from_utf8(bytes.to_vec()) {
             Ok(msg) => {
                 // A valid utf8 string is forwarded to the JSON-RPC parser
                 // The message is assumed to be a valid JSON-RPC, otherwise an
                 // error is returned through the socket.
                 // For example, an empty string results in a JSON-RPC ParseError (-32700).
-                debug!("{}", msg);
+                log::debug!("{}", msg);
                 msg
             }
             Err(e) => {
                 // When the input is not a valid utf8 string, a
                 // ParseError (-32700) is returned thought the socket
                 // and the message is printed in the debug logs for further inspection.
-                error!("Invalid UTF8 in JSON-RPC input");
-                debug!("{:?}", e);
+                log::error!("Invalid UTF8 in JSON-RPC input");
+                log::debug!("{:?}", e);
 
                 // Generate a ParseError later by trying to parse an empty string
                 "".to_string()

--- a/node/src/actors/json_rpc/newline_codec.rs
+++ b/node/src/actors/json_rpc/newline_codec.rs
@@ -42,7 +42,7 @@ impl Encoder for NewLineCodec {
     /// Method to encode a response into bytes. The input should not contain
     /// any newline characters, as the message will not be decoded correctly.
     fn encode(&mut self, bytes: BytesMut, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        //debug!("Encoding {:?}", bytes);
+        //log::debug!("Encoding {:?}", bytes);
         let mut encoded_msg = vec![];
         // push message
         encoded_msg.append(&mut bytes.to_vec());

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -808,6 +808,19 @@ impl Message for GetConsolidatedPeers {
     type Result = Result<GetConsolidatedPeersResult, ()>;
 }
 
+/// Request logging a session message
+#[derive(Clone, Debug)]
+pub struct LogMessage {
+    /// Message for logging
+    pub log_data: String,
+    /// Server address
+    pub addr: SocketAddr,
+}
+
+impl Message for LogMessage {
+    type Result = SessionsUnitResult;
+}
+
 // JsonRpcServer messages (notifications)
 
 /// New block notification

--- a/node/src/actors/node.rs
+++ b/node/src/actors/node.rs
@@ -2,7 +2,6 @@ use std::{process::exit, result::Result};
 
 use actix::{Actor, System, SystemRegistry};
 use futures::future::Future;
-use log::info;
 
 use crate::actors::{
     chain_manager::ChainManager, connections_manager::ConnectionsManager,
@@ -70,7 +69,7 @@ pub fn run(config: Config, callback: fn()) -> Result<(), failure::Error> {
 
 /// Function to close the main system
 pub fn close() {
-    info!("Closing node");
+    log::info!("Closing node");
 
     // FIXME(#72): find out how to gracefully stop the system
     // System::current().stop();

--- a/node/src/actors/peers_manager/actor.rs
+++ b/node/src/actors/peers_manager/actor.rs
@@ -1,5 +1,4 @@
 use actix::prelude::*;
-use log::{debug, error, info};
 
 use super::PeersManager;
 use crate::{actors::storage_keys, config_mngr, storage_mngr};
@@ -11,7 +10,7 @@ impl Actor for PeersManager {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
-        debug!("Peers Manager actor has been started!");
+        log::debug!("Peers Manager actor has been started!");
 
         // Send message to config manager and process response
         config_mngr::get()
@@ -37,13 +36,13 @@ impl Actor for PeersManager {
                 let feeler_peers_period = config.connections.feeler_peers_period;
 
                 // Add all peers
-                info!(
+                log::info!(
                     "Adding the following peer addresses from config: {:?}",
                     known_peers
                 );
                 match act.peers.add_to_new(known_peers.clone(), server_addr) {
                     Ok(_duplicated_peers) => {}
-                    Err(e) => error!("Error when adding peer addresses from config: {}", e),
+                    Err(e) => log::error!("Error when adding peer addresses from config: {}", e),
                 }
 
                 let consensus_constants = (&config.consensus_constants).clone();
@@ -52,7 +51,7 @@ impl Actor for PeersManager {
 
                 storage_mngr::get::<_, Peers>(&storage_keys::peers_key(magic))
                     .into_actor(act)
-                    .map_err(|e, _, _| error!("Couldn't get peers from storage: {}", e))
+                    .map_err(|e, _, _| log::error!("Couldn't get peers from storage: {}", e))
                     .and_then(move |peers_from_storage, act, _ctx| {
                         // peers_from_storage can be None if the storage does not contain that key
                         if let Some(peers_from_storage) = peers_from_storage {

--- a/node/src/actors/sessions_manager/mod.rs
+++ b/node/src/actors/sessions_manager/mod.rs
@@ -40,6 +40,8 @@ pub struct SessionsManager {
     epoch_constants: Option<EpochConstants>,
     // Current epoch
     current_epoch: Epoch,
+    // Logging message hashset
+    logging_messages: HashSet<String>,
 }
 
 #[derive(Debug, Fail)]

--- a/rad/src/script.rs
+++ b/rad/src/script.rs
@@ -1,4 +1,3 @@
-use log::error;
 use serde_cbor::{
     self as cbor,
     value::{from_value, Value},
@@ -111,7 +110,7 @@ pub fn unpack_subscript(value: &Value) -> Result<Vec<RadonCall>, RadError> {
 }
 
 fn errorify(kind: RadError) -> RadError {
-    error!("Error unpacking a RADON script: {:?}", kind);
+    log::error!("Error unpacking a RADON script: {:?}", kind);
 
     kind
 }

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -11,7 +11,6 @@ use std::{
 use ansi_term::Color::{Purple, Red, White, Yellow};
 use failure::{bail, Fail};
 use itertools::Itertools;
-use log::*;
 use prettytable::{cell, row, Table};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -392,7 +391,7 @@ fn deserialize_and_validate_hex_dr(hex_bytes: String) -> Result<DataRequestOutpu
 
     let dr: DataRequestOutput = ProtobufConvert::from_pb_bytes(&dr_bytes)?;
 
-    debug!("{}", serde_json::to_string(&dr)?);
+    log::debug!("{}", serde_json::to_string(&dr)?);
 
     validate_data_request_output(&dr)?;
     validate_rad_request(&dr.data_request)?;
@@ -402,10 +401,10 @@ fn deserialize_and_validate_hex_dr(hex_bytes: String) -> Result<DataRequestOutpu
     let witnet_dr_bytes = dr.to_pb_bytes()?;
 
     if dr_bytes != witnet_dr_bytes {
-        warn!("Data request uses an invalid serialization, will be ignored.\nINPUT BYTES: {:02x?}\nWIT DR BYTES: {:02x?}",
+        log::warn!("Data request uses an invalid serialization, will be ignored.\nINPUT BYTES: {:02x?}\nWIT DR BYTES: {:02x?}",
               dr_bytes, witnet_dr_bytes
         );
-        warn!(
+        log::warn!(
             "This usually happens when some fields are set to 0. \
              The Rust implementation of ProtocolBuffer skips those fields, \
              as missing fields are deserialized with the default value."


### PR DESCRIPTION
Created a hashset in SessionsManager to avoid showing redundant messages received from different sessions

It also implemented a little fix about new blocks handling, because it should be only handle as a new Candidate, but it was handle as a Candidate and as a requested block

And a little refactor in code to use log::debug!() call instead of only debug!() call