### PR TITLE
feat(data_structures): insert block number from input when pkh would …

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -38,15 +38,14 @@
 //! // Default config for mainnet
 //! // Config::from_partial(&PartialConfig::default_mainnet());
 //! ```
-use std::collections::HashSet;
-use std::net::SocketAddr;
-use std::path::PathBuf;
-use std::time::Duration;
+use std::{collections::HashSet, net::SocketAddr, path::PathBuf, time::Duration};
 
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::defaults::{Defaults, Testnet};
-use crate::dirs;
+use crate::{
+    defaults::{Defaults, Testnet},
+    dirs,
+};
 use partial_struct::PartialStruct;
 use witnet_crypto::hash::HashFunction;
 use witnet_data_structures::chain::{ConsensusConstants, Environment, PartialConsensusConstants};
@@ -326,8 +325,12 @@ pub struct Mining {
     pub data_request_timeout: Duration,
     /// Genesis block path
     pub genesis_path: String,
-    /// Binary flag to create a mint with a split reward
-    pub split_mint: bool,
+    /// Percentage to redistribute mint reward in another address
+    pub mint_external_percentage: u8,
+    /// Address where redistribute mint reward
+    #[partial_struct(skip)]
+    #[partial_struct(serde(default))]
+    pub mint_external_address: Option<String>,
 }
 
 /// NTP-related configuration
@@ -598,10 +601,11 @@ impl Mining {
                 .genesis_path
                 .clone()
                 .unwrap_or_else(|| defaults.mining_genesis_path()),
-            split_mint: config
-                .split_mint
+            mint_external_percentage: config
+                .mint_external_percentage
                 .to_owned()
-                .unwrap_or_else(|| defaults.mining_split_mint()),
+                .unwrap_or_else(|| defaults.mining_mint_external_percentage()),
+            mint_external_address: config.mint_external_address.clone(),
         }
     }
 }

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -140,9 +140,9 @@ pub trait Defaults {
         "genesis_block.json".to_string()
     }
 
-    /// Binary flag to create a mint with a split reward
-    fn mining_split_mint(&self) -> bool {
-        true
+    /// Percentage to redistribute mint reward in another address
+    fn mining_mint_external_percentage(&self) -> u8 {
+        50
     }
 
     fn consensus_constants_max_block_weight(&self) -> u32 {

--- a/data_structures/src/error.rs
+++ b/data_structures/src/error.rs
@@ -268,9 +268,7 @@ pub enum BlockError {
         fees_value: u64,
         reward_value: u64,
     },
-    #[fail(display = "Multiple addresses found in the Mint transaction")]
-    MultiplePkhsInMint,
-    #[fail(display = "MintTransaction was split in outputs smaller than minimum collateral")]
+    #[fail(display = "MintTransaction was split in more than two 'ValueTransferOutput'")]
     TooSplitMint,
     #[fail(
         display = "Mint transaction has invalid epoch: mint {}, block {}",

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -138,8 +138,6 @@ pub struct ChainManager {
     transactions_pool: TransactionsPool,
     /// Mining enabled
     mining_enabled: bool,
-    /// Binary flag to create a mint with a split reward
-    split_mint: bool,
     /// state of the state machine
     sm_state: StateMachine,
     /// The best beacon known to this node—to which it will try to catch up
@@ -169,6 +167,10 @@ pub struct ChainManager {
     tx_pending_timeout: u64,
     /// Magic number from ConsensusConstants
     magic: u16,
+    /// External mint address
+    external_address: Option<PublicKeyHash>,
+    /// Mint Percentage to share with the external address
+    external_percentage: u8,
 }
 
 /// Required trait for being able to retrieve ChainManager address from registry

--- a/node/src/actors/chain_manager/transaction_factory.rs
+++ b/node/src/actors/chain_manager/transaction_factory.rs
@@ -90,7 +90,7 @@ pub fn get_total_balance(all_utxos: &UnspentOutputsPool, pkh: PublicKeyHash) -> 
     // FIXME: this does not scale, we need to be able to get UTXOs by PKH
     all_utxos
         .iter()
-        .filter_map(|(_output_pointer, vto)| {
+        .filter_map(|(_output_pointer, (vto, _))| {
             if vto.pkh == pkh {
                 Some(vto.value)
             } else {

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -110,7 +110,7 @@ fn mint_mismatched_reward() {
         time_lock: 0,
     };
     let mint_tx = MintTransaction::new(epoch, vec![output]);
-    let x = validate_mint_transaction(&mint_tx, total_fees, epoch, 1);
+    let x = validate_mint_transaction(&mint_tx, total_fees, epoch);
     // Error: block reward mismatch
     assert_eq!(
         x.unwrap_err().downcast::<BlockError>().unwrap(),
@@ -134,7 +134,7 @@ fn mint_invalid_epoch() {
     };
     // Build a mint for the next epoch
     let mint_tx = MintTransaction::new(epoch + 1, vec![output]);
-    let x = validate_mint_transaction(&mint_tx, total_fees, epoch, 1);
+    let x = validate_mint_transaction(&mint_tx, total_fees, epoch);
     // Error: invalid mint epoch
     assert_eq!(
         x.unwrap_err().downcast::<BlockError>().unwrap(),
@@ -146,31 +146,7 @@ fn mint_invalid_epoch() {
 }
 
 #[test]
-fn mint_invalid_pkh() {
-    let epoch = 0;
-    let reward = block_reward(epoch);
-    let total_fees = 100;
-    let output1 = ValueTransferOutput {
-        pkh: Default::default(),
-        value: total_fees,
-        time_lock: 0,
-    };
-    let output2 = ValueTransferOutput {
-        pkh: PublicKeyHash::from_bytes(&[1; 20]).unwrap(),
-        value: reward,
-        time_lock: 0,
-    };
-    let mint_tx = MintTransaction::new(epoch, vec![output1, output2]);
-    let x = validate_mint_transaction(&mint_tx, total_fees, epoch, 1);
-    // Error: different pkhs in mint transaction
-    assert_eq!(
-        x.unwrap_err().downcast::<BlockError>().unwrap(),
-        BlockError::MultiplePkhsInMint
-    );
-}
-
-#[test]
-fn mint_small_split() {
+fn mint_multiple_split() {
     let epoch = 0;
     let reward = block_reward(epoch);
     let total_fees = 100;
@@ -184,8 +160,13 @@ fn mint_small_split() {
         value: 0,
         time_lock: 0,
     };
-    let mint_tx = MintTransaction::new(epoch, vec![output1, output2]);
-    let x = validate_mint_transaction(&mint_tx, total_fees, epoch, 1);
+    let output3 = ValueTransferOutput {
+        pkh: Default::default(),
+        value: 0,
+        time_lock: 0,
+    };
+    let mint_tx = MintTransaction::new(epoch, vec![output1, output2, output3]);
+    let x = validate_mint_transaction(&mint_tx, total_fees, epoch);
     // Error: Mint outputs smaller than collateral minimum
     assert_eq!(
         x.unwrap_err().downcast::<BlockError>().unwrap(),
@@ -209,7 +190,7 @@ fn mint_split_valid() {
         time_lock: 0,
     };
     let mint_tx = MintTransaction::new(epoch, vec![output1, output2]);
-    let x = validate_mint_transaction(&mint_tx, total_fees, epoch, 1);
+    let x = validate_mint_transaction(&mint_tx, total_fees, epoch);
     x.unwrap();
 }
 
@@ -224,7 +205,7 @@ fn mint_valid() {
         time_lock: 0,
     };
     let mint_tx = MintTransaction::new(epoch, vec![output]);
-    let x = validate_mint_transaction(&mint_tx, total_fees, epoch, 1);
+    let x = validate_mint_transaction(&mint_tx, total_fees, epoch);
     x.unwrap();
 }
 

--- a/witnet.toml
+++ b/witnet.toml
@@ -68,11 +68,11 @@ enabled = true
 data_request_max_retrievals_per_epoch = 30
 data_request_timeout_milliseconds = 2000
 genesis_path = "genesis_block.json"
-# Enables or disables automatically splitting block mining rewards.
-# If set to `true`, the rewards will be split into multiple outputs of the same value as `collateral_minimum`
-# until the node's set of outputs available for collateralization outnumbers `data_request_max_retrievals_per_epoch`
-# multiplied by `collateral_coinage`, i.e. makes sure it always has spare outputs to collateralize.
-split_mint = true
+# `mint_external_address` and `mint_external_percentage` enable splitting the mint reward between the node's
+# own address and an "external" address, e.g. a the address of a wallet. `mint_external_percentage` indicates
+# the percentage of the block rewards that will be assigned to `mint_external_address` (50% by default)
+#mint_external_address = "twit1jqgf4rxjrgas3kdhj3t4cr3mg3n33m8zw0aulr"
+#mint_external_percentage = 50
 
 [log]
 # Logging level, i.e. from more verbose to quieter: "trace" > "debug" > "info" > "warn" > "error" > "none"


### PR DESCRIPTION
…be the same than output

This PR allows that new ValueTransferOutput keeps the same block inclusion number than their inputs in case that they have the same pkh

Modify pending timeout for commits due to CommitTransactions are only valid in the same Epoch, and you dont need to block that utxos more than one epoch

Remove smart mint splitting and changed by allowing to include a new address (different from node's address) in the MintTransaction, splitting the reward between node and that address