### PR TITLE
Superblock broadcasting

### DIFF
--- a/data_structures/src/builders.rs
+++ b/data_structures/src/builders.rs
@@ -7,6 +7,7 @@ use witnet_util::timestamp::get_timestamp;
 use crate::{
     chain::{
         Block, BlockHeader, BlockTransactions, CheckpointBeacon, InventoryEntry, KeyedSignature,
+        SuperBlockVote,
     },
     error::BuildersError,
     transaction::Transaction,
@@ -149,6 +150,11 @@ impl Message {
                 highest_block_checkpoint,
             }),
         )
+    }
+
+    /// Function to build SuperBlockVote messages
+    pub fn build_superblock_vote(magic: u16, superblock_vote: SuperBlockVote) -> Message {
+        Message::build_message(magic, Command::SuperBlockVote(superblock_vote))
     }
 
     /// Function to build a message from a command

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -3045,6 +3045,46 @@ mod tests {
     }
 
     #[test]
+    fn test_superblock_hashable_trait() {
+        let superblock = SuperBlock {
+            ars_root: Hash::SHA256([1; 32]),
+            data_request_root: Hash::SHA256([2; 32]),
+            index: 1,
+            last_block: Hash::SHA256([3; 32]),
+            last_block_in_previous_superblock: Hash::SHA256([4; 32]),
+            tally_root: Hash::SHA256([5; 32]),
+        };
+        let expected = "4ee0395751a5b8d94217ba71623414721ab8dc8c1634a5c79769d5196a1b3993";
+        assert_eq!(superblock.hash().to_string(), expected);
+    }
+
+    #[test]
+    fn test_superblock_vote_bn256_signature_message() {
+        // If this test fails, the bridge will also fail
+        let superblock_hash = "4ee0395751a5b8d94217ba71623414721ab8dc8c1634a5c79769d5196a1b3993"
+            .parse()
+            .unwrap();
+        let superblock_vote = SuperBlockVote::new_unsigned(superblock_hash, 1);
+        let expected_bls =
+            hex::decode("000000014ee0395751a5b8d94217ba71623414721ab8dc8c1634a5c79769d5196a1b3993")
+                .unwrap();
+        assert_eq!(superblock_vote.bn256_signature_message(), expected_bls);
+    }
+
+    #[test]
+    fn test_superblock_vote_secp256k1_signature_message() {
+        let superblock_hash = "4ee0395751a5b8d94217ba71623414721ab8dc8c1634a5c79769d5196a1b3993"
+            .parse()
+            .unwrap();
+        let mut superblock_vote = SuperBlockVote::new_unsigned(superblock_hash, 1);
+        superblock_vote.bn256_signature.signature =
+            hex::decode("03100709d625d82c4eedf5f330d538b0cfa0dd68a5c505b6896902ed935b5cce0e")
+                .unwrap();
+        let expected_secp = hex::decode("000000014ee0395751a5b8d94217ba71623414721ab8dc8c1634a5c79769d5196a1b399303100709d625d82c4eedf5f330d538b0cfa0dd68a5c505b6896902ed935b5cce0e").unwrap();
+        assert_eq!(superblock_vote.secp256k1_signature_message(), expected_secp);
+    }
+
+    #[test]
     fn test_output_pointer_from_str() {
         let result_success = OutputPointer::from_str(
             "1111111111111111111111111111111111111111111111111111111111111111:1",

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -572,6 +572,13 @@ impl Hashable for SuperBlock {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, ProtobufConvert)]
+#[protobuf_convert(pb = "witnet::SuperBlockVote")]
+pub struct SuperBlockVote {
+    pub signature: Bn256KeyedSignature,
+    pub superblock_hash: Hash,
+}
+
 /// Digital signatures structure (based on supported cryptosystems)
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, ProtobufConvert)]
 #[protobuf_convert(pb = "witnet::Signature")]

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -575,9 +575,9 @@ impl Hashable for SuperBlock {
 #[derive(Debug, Eq, PartialEq, Clone, Hash, ProtobufConvert)]
 #[protobuf_convert(pb = "witnet::SuperBlockVote")]
 pub struct SuperBlockVote {
-    pub superblock_hash: Hash,
     pub bn256_signature: Bn256Signature,
     pub secp256k1_signature: KeyedSignature,
+    pub superblock_hash: Hash,
     pub superblock_index: u32,
 }
 

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -572,7 +572,7 @@ impl Hashable for SuperBlock {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, ProtobufConvert)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash, ProtobufConvert)]
 #[protobuf_convert(pb = "witnet::SuperBlockVote")]
 pub struct SuperBlockVote {
     pub superblock_hash: Hash,
@@ -613,7 +613,7 @@ impl SuperBlockVote {
 }
 
 /// Digital signatures structure (based on supported cryptosystems)
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, ProtobufConvert)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash, Serialize, Deserialize, ProtobufConvert)]
 #[protobuf_convert(pb = "witnet::Signature")]
 pub enum Signature {
     /// ECDSA over secp256k1
@@ -649,7 +649,7 @@ impl Signature {
 }
 
 /// ECDSA (over secp256k1) signature
-#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize, ProtobufConvert)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Hash, Serialize, Deserialize, ProtobufConvert)]
 #[protobuf_convert(pb = "witnet::Secp256k1Signature")]
 pub struct Secp256k1Signature {
     /// The signature serialized in DER
@@ -1047,7 +1047,7 @@ impl DataRequestOutput {
 }
 
 /// Keyed signature data structure
-#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize, ProtobufConvert)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Hash, Serialize, Deserialize, ProtobufConvert)]
 #[protobuf_convert(pb = "witnet::KeyedSignature")]
 pub struct KeyedSignature {
     pub signature: Signature,
@@ -1055,7 +1055,7 @@ pub struct KeyedSignature {
 }
 
 /// Public Key data structure
-#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Hash, Serialize, Deserialize)]
 pub struct PublicKey {
     pub compressed: u8,
     pub bytes: [u8; 32],
@@ -1116,7 +1116,7 @@ pub struct ExtendedSecretKey {
 
 /// BLS data structures
 
-#[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize, ProtobufConvert)]
+#[derive(Debug, Default, Eq, PartialEq, Clone, Hash, Serialize, Deserialize, ProtobufConvert)]
 #[protobuf_convert(pb = "witnet::Bn256PublicKey")]
 pub struct Bn256PublicKey {
     /// Compressed form of a BN256 public key
@@ -1126,12 +1126,12 @@ pub struct Bn256PublicKey {
 pub struct Bn256SecretKey {
     pub bytes: Protected,
 }
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, ProtobufConvert)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash, Serialize, Deserialize, ProtobufConvert)]
 #[protobuf_convert(pb = "witnet::Bn256Signature")]
 pub struct Bn256Signature {
     pub signature: Vec<u8>,
 }
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, ProtobufConvert)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash, Serialize, Deserialize, ProtobufConvert)]
 #[protobuf_convert(pb = "witnet::Bn256KeyedSignature")]
 pub struct Bn256KeyedSignature {
     pub signature: Bn256Signature,
@@ -2956,6 +2956,9 @@ pub enum SignaturesToVerify {
         public_key: Secp256k1_PublicKey,
         data: Vec<u8>,
         signature: Secp256k1_Signature,
+    },
+    SuperBlockVote {
+        superblock_vote: SuperBlockVote,
     },
 }
 

--- a/data_structures/src/types.rs
+++ b/data_structures/src/types.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::{
-    chain::{Block, CheckpointBeacon, Hashable, InventoryEntry},
+    chain::{Block, CheckpointBeacon, Hashable, InventoryEntry, SuperBlockVote},
     proto::{schema::witnet, ProtobufConvert},
     transaction::Transaction,
 };
@@ -34,6 +34,9 @@ pub enum Command {
     InventoryAnnouncement(InventoryAnnouncement),
     InventoryRequest(InventoryRequest),
     LastBeacon(LastBeacon),
+
+    // Superblock
+    SuperBlockVote(SuperBlockVote),
 }
 
 impl fmt::Display for Command {
@@ -69,6 +72,7 @@ impl fmt::Display for Command {
                 }
                 write!(f, ": {}", tx.hash())
             }
+            Command::SuperBlockVote(sbv) => write!(f, "SUPERBLOCK_VOTE: {}", sbv.superblock_hash),
         }
     }
 }

--- a/data_structures/src/types.rs
+++ b/data_structures/src/types.rs
@@ -72,7 +72,11 @@ impl fmt::Display for Command {
                 }
                 write!(f, ": {}", tx.hash())
             }
-            Command::SuperBlockVote(sbv) => write!(f, "SUPERBLOCK_VOTE: {}", sbv.superblock_hash),
+            Command::SuperBlockVote(sbv) => write!(
+                f,
+                "SUPERBLOCK_VOTE #{}: {}",
+                sbv.superblock_index, sbv.superblock_hash
+            ),
         }
     }
 }

--- a/data_structures/src/types.rs
+++ b/data_structures/src/types.rs
@@ -74,8 +74,10 @@ impl fmt::Display for Command {
             }
             Command::SuperBlockVote(sbv) => write!(
                 f,
-                "SUPERBLOCK_VOTE #{}: {}",
-                sbv.superblock_index, sbv.superblock_hash
+                "SUPERBLOCK_VOTE {} #{}: {}",
+                sbv.secp256k1_signature.public_key.pkh(),
+                sbv.superblock_index,
+                sbv.superblock_hash
             ),
         }
     }

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -21,8 +21,8 @@ use crate::{
     actors::{
         chain_manager::process_validations,
         messages::{
-            AddBlocks, AddCandidates, AddCommitReveal, AddTransaction, Anycast, Broadcast,
-            BuildDrt, BuildVtt, EpochNotification, GetBalance, GetBlocksEpochRange,
+            AddBlocks, AddCandidates, AddCommitReveal, AddSuperBlockVote, AddTransaction, Anycast,
+            Broadcast, BuildDrt, BuildVtt, EpochNotification, GetBalance, GetBlocksEpochRange,
             GetDataRequestReport, GetHighestCheckpointBeacon, GetMemoryTransaction, GetNodeStats,
             GetReputation, GetReputationAll, GetReputationStatus, GetReputationStatusResult,
             GetState, GetUtxoInfo, PeersBeacons, SendLastBeacon, SessionUnitResult, TryMineBlock,
@@ -438,6 +438,19 @@ impl Handler<AddCandidates> for ChainManager {
         for block in msg.blocks {
             self.process_candidate(block);
         }
+    }
+}
+
+/// Handler for AddSuperBlockVote message
+impl Handler<AddSuperBlockVote> for ChainManager {
+    type Result = Result<(), failure::Error>;
+
+    fn handle(
+        &mut self,
+        AddSuperBlockVote { superblock_vote }: AddSuperBlockVote,
+        ctx: &mut Context<Self>,
+    ) -> Self::Result {
+        self.add_superblock_vote(superblock_vote, ctx)
     }
 }
 

--- a/node/src/actors/chain_manager/superblock.rs
+++ b/node/src/actors/chain_manager/superblock.rs
@@ -1,0 +1,278 @@
+use std::collections::HashSet;
+use witnet_data_structures::chain::{
+    BlockHeader, Hash, Hashable, PublicKeyHash, SuperBlock, SuperBlockVote,
+};
+use witnet_validations::validations::hash_merkle_tree_root;
+
+/// Possible result of SuperBlockState::add_vote
+pub enum AddSuperBlockVote {
+    AlreadySeen,
+    NotInArs,
+    ValidButDifferent,
+    ValidWithSameHash,
+}
+
+/// State related to superblocks
+#[derive(Debug, Default)]
+pub struct SuperBlockState {
+    // Set of ARS identities that can currently send superblock votes
+    ars_identities: HashSet<PublicKeyHash>,
+    // Current superblock hash created by this node
+    current_superblock_hash: Option<Hash>,
+    // Set of received superblock votes
+    // This is cleared when we try to create a new superblock
+    received_superblocks: HashSet<SuperBlockVote>,
+    // Set of votes that agree with current_superblock_hash
+    // This is cleared when we try to create a new superblock
+    votes_on_local_superlock: HashSet<SuperBlockVote>,
+}
+
+impl SuperBlockState {
+    /// Add a vote sent by another peer.
+    /// This method assumes that the signatures are valid, they must be checked by the caller.
+    pub fn add_vote(&mut self, sbv: &SuperBlockVote) -> AddSuperBlockVote {
+        if self.received_superblocks.contains(sbv) {
+            // Already processed before
+            AddSuperBlockVote::AlreadySeen
+        } else {
+            // Insert to avoid validating again
+            self.received_superblocks.insert(sbv.clone());
+
+            let valid = self.is_valid(sbv);
+
+            if valid {
+                // If the superblock vote is valid and agrees with the local superblock hash,
+                // store it
+                if Some(sbv.superblock_hash) == self.current_superblock_hash {
+                    self.votes_on_local_superlock.insert(sbv.clone());
+
+                    AddSuperBlockVote::ValidWithSameHash
+                } else {
+                    AddSuperBlockVote::ValidButDifferent
+                }
+            } else {
+                AddSuperBlockVote::NotInArs
+            }
+        }
+    }
+
+    /// Since we do not check signatures here, a superblock vote is valid if the signing identity
+    /// is in the ARS
+    fn is_valid(&self, sbv: &SuperBlockVote) -> bool {
+        self.ars_identities
+            .contains(&sbv.secp256k1_signature.public_key.pkh())
+    }
+
+    /// Produces a `SuperBlock` that includes the blocks in `block_headers` if there is at least one of them.
+    /// `sorted_ars_identities` will be used to validate all the superblock votes received until the
+    /// next superblock is built (only those identities can sign superblock votes), so it must be accurate.
+    pub fn build_superblock(
+        &mut self,
+        block_headers: &[BlockHeader],
+        sorted_ars_identities: &[PublicKeyHash],
+        index: u32,
+        last_block_in_previous_superblock: Hash,
+    ) -> Option<SuperBlock> {
+        self.votes_on_local_superlock.clear();
+        self.ars_identities = sorted_ars_identities.iter().cloned().collect();
+
+        match mining_build_superblock(
+            block_headers,
+            sorted_ars_identities,
+            index,
+            last_block_in_previous_superblock,
+        ) {
+            None => {
+                // Clear state when there is no superblock
+                self.current_superblock_hash = None;
+                self.received_superblocks.clear();
+
+                None
+            }
+            Some(superblock) => {
+                let superblock_hash = superblock.hash();
+                self.current_superblock_hash = Some(superblock_hash);
+
+                let old_superblocks =
+                    std::mem::replace(&mut self.received_superblocks, HashSet::new());
+
+                for sbv in old_superblocks {
+                    // Validate again, check if they are valid now
+                    let valid = self.is_valid(&sbv);
+
+                    // If the superblock vote is valid and agrees with the local superblock hash,
+                    // store it
+                    if valid && Some(sbv.superblock_hash) == self.current_superblock_hash {
+                        // TODO: should be broadcast valid votes again?
+                        // Ideally we want to broadcast votes that are valid now but were not valid
+                        // before, so we must store whether the votes were valid before
+                        // But if we do that there is a high chance that old superblock votes will
+                        // never be deleted, as they will be valid as long as the identity is in the
+                        // ARS
+                        self.votes_on_local_superlock.insert(sbv);
+                    }
+                }
+
+                Some(superblock)
+            }
+        }
+    }
+}
+
+/// Produces a `SuperBlock` that includes the blocks in `block_headers` if there is at least one of them.
+pub fn mining_build_superblock(
+    block_headers: &[BlockHeader],
+    sorted_ars_identities: &[PublicKeyHash],
+    index: u32,
+    last_block_in_previous_superblock: Hash,
+) -> Option<SuperBlock> {
+    let last_block = block_headers.last()?.hash();
+    let merkle_drs: Vec<Hash> = block_headers
+        .iter()
+        .map(|b| b.merkle_roots.dr_hash_merkle_root)
+        .collect();
+    let merkle_tallies: Vec<Hash> = block_headers
+        .iter()
+        .map(|b| b.merkle_roots.tally_hash_merkle_root)
+        .collect();
+
+    let pkh_hashes: Vec<Hash> = sorted_ars_identities.iter().map(|pkh| pkh.hash()).collect();
+
+    Some(SuperBlock {
+        data_request_root: hash_merkle_tree_root(&merkle_drs),
+        tally_root: hash_merkle_tree_root(&merkle_tallies),
+        ars_root: hash_merkle_tree_root(&pkh_hashes),
+        index,
+        last_block,
+        last_block_in_previous_superblock,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use witnet_data_structures::chain::{BlockMerkleRoots, CheckpointBeacon};
+    use witnet_data_structures::vrf::BlockEligibilityClaim;
+
+    #[test]
+    fn test_superblock_creation_no_blocks() {
+        let default_hash = Hash::default();
+        let superblock = mining_build_superblock(&[], &[], 0, default_hash);
+        assert_eq!(superblock, None);
+    }
+
+    static DR_MERKLE_ROOT_1: &str =
+        "0000000000000000000000000000000000000000000000000000000000000000";
+    static TALLY_MERKLE_ROOT_1: &str =
+        "1111111111111111111111111111111111111111111111111111111111111111";
+    static DR_MERKLE_ROOT_2: &str =
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    static TALLY_MERKLE_ROOT_2: &str =
+        "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+    #[test]
+    fn test_superblock_creation_one_block() {
+        let default_hash = Hash::default();
+        let default_proof = BlockEligibilityClaim::default();
+        let default_beacon = CheckpointBeacon::default();
+        let dr_merkle_root_1 = DR_MERKLE_ROOT_1.parse().unwrap();
+        let tally_merkle_root_1 = TALLY_MERKLE_ROOT_1.parse().unwrap();
+
+        let block = BlockHeader {
+            version: 1,
+            beacon: default_beacon,
+            merkle_roots: BlockMerkleRoots {
+                mint_hash: default_hash,
+                vt_hash_merkle_root: default_hash,
+                dr_hash_merkle_root: dr_merkle_root_1,
+                commit_hash_merkle_root: default_hash,
+                reveal_hash_merkle_root: default_hash,
+                tally_hash_merkle_root: tally_merkle_root_1,
+            },
+            proof: default_proof,
+            bn256_public_key: None,
+        };
+
+        let expected_superblock = SuperBlock {
+            data_request_root: dr_merkle_root_1,
+            tally_root: tally_merkle_root_1,
+            ars_root: PublicKeyHash::default().hash(),
+            index: 0,
+            last_block: block.hash(),
+            last_block_in_previous_superblock: default_hash,
+        };
+
+        let superblock =
+            mining_build_superblock(&[block], &[PublicKeyHash::default()], 0, default_hash)
+                .unwrap();
+        assert_eq!(superblock, expected_superblock);
+    }
+
+    #[test]
+    fn test_superblock_creation_two_blocks() {
+        let default_hash = Hash::default();
+        let default_proof = BlockEligibilityClaim::default();
+        let default_beacon = CheckpointBeacon::default();
+        let dr_merkle_root_1 = DR_MERKLE_ROOT_1.parse().unwrap();
+        let tally_merkle_root_1 = TALLY_MERKLE_ROOT_1.parse().unwrap();
+        let dr_merkle_root_2 = DR_MERKLE_ROOT_2.parse().unwrap();
+        let tally_merkle_root_2 = TALLY_MERKLE_ROOT_2.parse().unwrap();
+        // Sha256(dr_merkle_root_1 || dr_merkle_root_2)
+        let expected_superblock_dr_root =
+            "bba91ca85dc914b2ec3efb9e16e7267bf9193b14350d20fba8a8b406730ae30a"
+                .parse()
+                .unwrap();
+        // Sha256(tally_merkle_root_1 || tally_merkle_root_2)
+        let expected_superblock_tally_root =
+            "83a70a79e9bef7bd811df52736eb61373095d7a8936aed05d0dc96d959b30b50"
+                .parse()
+                .unwrap();
+
+        let block_1 = BlockHeader {
+            version: 1,
+            beacon: default_beacon,
+            merkle_roots: BlockMerkleRoots {
+                mint_hash: default_hash,
+                vt_hash_merkle_root: default_hash,
+                dr_hash_merkle_root: dr_merkle_root_1,
+                commit_hash_merkle_root: default_hash,
+                reveal_hash_merkle_root: default_hash,
+                tally_hash_merkle_root: tally_merkle_root_1,
+            },
+            proof: default_proof.clone(),
+            bn256_public_key: None,
+        };
+
+        let block_2 = BlockHeader {
+            version: 1,
+            beacon: default_beacon,
+            merkle_roots: BlockMerkleRoots {
+                mint_hash: default_hash,
+                vt_hash_merkle_root: default_hash,
+                dr_hash_merkle_root: dr_merkle_root_2,
+                commit_hash_merkle_root: default_hash,
+                reveal_hash_merkle_root: default_hash,
+                tally_hash_merkle_root: tally_merkle_root_2,
+            },
+            proof: default_proof,
+            bn256_public_key: None,
+        };
+
+        let expected_superblock = SuperBlock {
+            data_request_root: expected_superblock_dr_root,
+            tally_root: expected_superblock_tally_root,
+            ars_root: PublicKeyHash::default().hash(),
+            index: 0,
+            last_block: block_2.hash(),
+            last_block_in_previous_superblock: default_hash,
+        };
+
+        let superblock = mining_build_superblock(
+            &[block_1, block_2],
+            &[PublicKeyHash::default()],
+            0,
+            default_hash,
+        )
+        .unwrap();
+        assert_eq!(superblock, expected_superblock);
+    }
+}

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -19,7 +19,7 @@ use witnet_data_structures::{
     chain::{
         Block, CheckpointBeacon, DataRequestInfo, DataRequestOutput, Epoch, EpochConstants, Hash,
         InventoryEntry, InventoryItem, NodeStats, PointerToBlock, PublicKeyHash, RADRequest,
-        RADTally, Reputation, UtxoInfo, UtxoSelectionStrategy, ValueTransferOutput,
+        RADTally, Reputation, SuperBlockVote, UtxoInfo, UtxoSelectionStrategy, ValueTransferOutput,
     },
     radon_report::RadonReport,
     transaction::{CommitTransaction, RevealTransaction, Transaction},
@@ -668,6 +668,19 @@ pub struct SendLastBeacon {
 impl fmt::Display for SendLastBeacon {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SendLastBeacon")
+    }
+}
+
+/// Message to send beacon through the network
+#[derive(Clone, Debug, Message)]
+pub struct SendSuperBlockVote {
+    /// The superblock vote
+    pub superblock_vote: SuperBlockVote,
+}
+
+impl fmt::Display for SendSuperBlockVote {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SendSuperBlockVote")
     }
 }
 

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -75,6 +75,16 @@ impl Message for AddCandidates {
     type Result = SessionUnitResult;
 }
 
+/// Add a superblock vote
+pub struct AddSuperBlockVote {
+    /// Superblock vote
+    pub superblock_vote: SuperBlockVote,
+}
+
+impl Message for AddSuperBlockVote {
+    type Result = Result<(), failure::Error>;
+}
+
 /// Add a new transaction
 pub struct AddTransaction {
     /// Transaction

--- a/node/src/actors/session/mod.rs
+++ b/node/src/actors/session/mod.rs
@@ -127,7 +127,7 @@ impl Session {
         match ProtobufConvert::to_pb_bytes(&msg) {
             Ok(bytes) => {
                 match msg.kind {
-                    Command::Transaction(_) | Command::Block(_) => {
+                    Command::Transaction(_) | Command::Block(_) | Command::SuperBlockVote(_) => {
                         let log_data = format!(
                             "{} Sending {} message ({} bytes)",
                             Green.bold().paint("[>]"),
@@ -166,7 +166,7 @@ impl Session {
     // This method is useful to align the logs from receive_message with logs from send_message
     fn log_received_message(&self, msg: &WitnetMessage, bytes: &[u8]) {
         match msg.kind {
-            Command::Transaction(_) | Command::Block(_) => {
+            Command::Transaction(_) | Command::Block(_) | Command::SuperBlockVote(_) => {
                 let log_data = format!(
                     "{} Received {} message ({} bytes)",
                     Green.bold().paint("[<]"),

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -14,6 +14,7 @@ message Message {
             InventoryRequest InventoryRequest = 7;
             LastBeacon LastBeacon = 8;
             Transaction Transaction = 9;
+            SuperBlockVote SuperBlockVote = 10;
         }
     }
 
@@ -322,4 +323,9 @@ message SuperBlock {
     Hash last_block = 4;
     Hash last_block_in_previous_superblock = 5;
     Hash tally_root = 6;
+}
+
+message SuperBlockVote {
+    Bn256KeyedSignature signature = 1;
+    Hash superblock_hash = 2;
 }

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -326,6 +326,7 @@ message SuperBlock {
 }
 
 message SuperBlockVote {
-    Bn256KeyedSignature signature = 1;
-    Hash superblock_hash = 2;
+    Hash superblock_hash = 1;
+    Bn256Signature bn256_signature = 2;
+    KeyedSignature secp256k1_signature = 3;
 }

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -329,4 +329,5 @@ message SuperBlockVote {
     Hash superblock_hash = 1;
     Bn256Signature bn256_signature = 2;
     KeyedSignature secp256k1_signature = 3;
+    fixed32 superblock_index = 4;
 }

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -326,8 +326,8 @@ message SuperBlock {
 }
 
 message SuperBlockVote {
-    Hash superblock_hash = 1;
-    Bn256Signature bn256_signature = 2;
-    KeyedSignature secp256k1_signature = 3;
+    Bn256Signature bn256_signature = 1;
+    KeyedSignature secp256k1_signature = 2;
+    Hash superblock_hash = 3;
     fixed32 superblock_index = 4;
 }


### PR DESCRIPTION
Close #1233
Close #1236 

This PR has a long list of unresolved questions:

### Superblock votes

```
message SuperBlockVote {
    Hash superblock_hash = 1;
    Bn256Signature bn256_signature = 2;
    KeyedSignature secp256k1_signature = 3;
    fixed32 superblock_index = 4;
}
```

We sign (superblock_index || block_hash) using bn256, and then we sign (superblock_index || block_hash || bls_signature) using secp256k1. The superblock_index is serialized in big endian. The bn256 public key is not needed because it can be obtained using the secp256k1 public key and the `AltKeys` mapping, so it is not included.

The `superblock_hash` field is also technically not needed because we can just try to verify the signature using our local `superblock_hash`, and if it fails it means it's a vote for a different superblock. But it is included for debugging purposes, we can remove it later after making sure it's not needed.

The `superblock_index` field is only used to make the forwarding easier to implement, we could remove it and the worst that will happen is that some invalid superblock votes will be forwarded when they shouldn't.

Normally when signing messages we define them in schema.proto, but this time since there are two different signatures in the same structure, I decided to just create some simple helper methods: `secp256k1_signature_message` and `bn256_signature_message`. They return the data that needs to be signed. An alternative strategy would be to use protocol buffers: serialize the incomplete SuperBlockVote, sign that with bn256, add the bn256 signature, serialize again, sign that with secp256k1, and add the secp256k1 signature. Same with verification, we would need to clone the vote, remove some fields, and serialize that. The good news is that thanks to the usage of helper methods we could easily change it.

### Superblock creation

Before this PR, only ARS members created superblocks. Now, everyone creates superblocks but only ARS members broadcast them. The reason is that in order to be able to be used by the bridge, the node needs to store the superblock votes. Also, the node needs to know the list of ARS members in order to validate the superblock votes, although a node could just forward all the received superblocks without validating ARS membership. We can discuss the different alternatives when we implement an option to allow node operators to disable superblock creation.

### Superblock forwarding

The node will forward all superblock votes that have a valid secp256k1 signature, are from the current superblock epoch, and are signed by members of the ARS. And also all the superblock votes that have a valid secp256k1 signature and are from the previous or the next superblock epoch, without checking ARS membership. This should prevent race conditions.