### PR TITLE
feat: disable telemetry when compiling `debug` target

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -81,7 +81,7 @@ fn init_logger(opts: LogOptions) -> Option<sentry::internals::ClientInitGuard> {
         .filter_module("witnet_node", opts.level);
 
     // Initialize Sentry (automated bug reporting) if explicitly enabled in configuration
-    if opts.sentry_telemetry {
+    if cfg!(not(debug_assertions)) && opts.sentry_telemetry {
         // Initialize client
         let guard = sentry::init(
             "https://def0c5d0fb354ef9ad6dddb576a21624@o394464.ingest.sentry.io/5244595",


### PR DESCRIPTION
For convenience of the developers.