### PR TITLE
Fix node stuck on Synchronizing

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -419,7 +419,7 @@ impl Handler<AddBlocks> for ChainManager {
                             // Target achived, go back to state 1
                             self.sm_state = StateMachine::WaitingConsensus;
                         } else {
-                            self.request_blocks_batch();
+                            self.request_blocks_batch(ctx);
                         }
                     } else {
                         // This branch will happen if this node has forked, but the network has
@@ -693,13 +693,13 @@ impl Handler<PeersBeacons> for ChainManager {
                                 Err(e) => {
                                     log::debug!("Failed to consolidate consensus candidate: {}", e);
 
-                                    self.request_blocks_batch();
+                                    self.request_blocks_batch(ctx);
 
                                     StateMachine::Synchronizing
                                 }
                             }
                         } else {
-                            self.request_blocks_batch();
+                            self.request_blocks_batch(ctx);
 
                             StateMachine::Synchronizing
                         }
@@ -798,7 +798,7 @@ impl Handler<PeersBeacons> for ChainManager {
                     >= how_many_epochs_are_we_willing_to_wait_for_one_block_batch
                 {
                     log::warn!("Timeout for waiting for blocks achieved. Requesting blocks again.");
-                    self.request_blocks_batch();
+                    self.request_blocks_batch(ctx);
                 }
             }
         }

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -52,8 +52,8 @@ use crate::{
         inventory_manager::InventoryManager,
         json_rpc::JsonRpcServer,
         messages::{
-            AddItems, AddTransaction, Broadcast, NewBlock, SendInventoryItem, SendSuperBlockVote,
-            StoreInventoryItem,
+            AddItems, AddTransaction, Anycast, Broadcast, NewBlock, SendInventoryItem,
+            SendLastBeacon, SendSuperBlockVote, StoreInventoryItem,
         },
         sessions_manager::SessionsManager,
         storage_keys,
@@ -843,6 +843,16 @@ impl ChainManager {
         });
 
         Box::new(fut)
+    }
+
+    fn request_blocks_batch(&mut self) {
+        // Send Anycast<SendLastBeacon> to a safu peer in order to begin the synchronization
+        SessionsManager::from_registry().do_send(Anycast {
+            command: SendLastBeacon {
+                beacon: self.get_chain_beacon(),
+            },
+            safu: true,
+        });
     }
 }
 

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -153,6 +153,10 @@ pub struct ChainManager {
     sm_state: StateMachine,
     /// The best beacon known to this node—to which it will try to catch up
     target_beacon: Option<CheckpointBeacon>,
+    /// The node asked for a batch of blocks on this epoch. This is used to implement a timeout
+    /// that will move the node back to WaitingConsensus state if it does not receive any AddBlocks
+    /// message after a certain number of epochs
+    sync_waiting_for_add_blocks_since: Option<Epoch>,
     /// Map that stores candidate blocks for further validation and consolidation as tip of the blockchain
     /// (block_hash, (block, block_vrf_hash))
     candidates: HashMap<Hash, (Block, Hash)>,
@@ -853,6 +857,8 @@ impl ChainManager {
             },
             safu: true,
         });
+        let epoch = self.current_epoch.unwrap();
+        self.sync_waiting_for_add_blocks_since = Some(epoch);
     }
 }
 

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -782,7 +782,7 @@ where
     T::Result: Send,
     Session: Handler<T>,
 {
-    type Result = ();
+    type Result = Result<T::Result, ()>;
 }
 
 /// Message indicating a message is to be forwarded to all the consolidated outbound sessions

--- a/node/src/actors/sessions_manager/mod.rs
+++ b/node/src/actors/sessions_manager/mod.rs
@@ -1,8 +1,8 @@
 use std::{net::SocketAddr, time::Duration};
 
 use actix::{
-    fut::FutureResult, ActorFuture, Addr, AsyncContext, Context, ContextFutureSpawner, Handler,
-    MailboxError, Message, SystemService, WrapFuture,
+    fut::FutureResult, ActorFuture, Addr, AsyncContext, Context, ContextFutureSpawner,
+    MailboxError, SystemService, WrapFuture,
 };
 
 use ansi_term::Color::Cyan;
@@ -157,21 +157,6 @@ impl SessionsManager {
 
         // Convert to FutureResult<Vec<SocketAddr>, (), Self>
         actix::fut::ok(peers)
-    }
-
-    /// Method to process Session SendMessage response
-    fn process_command_response<T>(
-        &mut self,
-        response: &Result<T::Result, MailboxError>,
-    ) -> FutureResult<(), (), Self>
-    where
-        T: Message,
-        Session: Handler<T>,
-    {
-        match response {
-            Ok(_) => actix::fut::ok(()),
-            Err(_) => actix::fut::err(()),
-        }
     }
 
     /// Subscribe to all future epochs


### PR DESCRIPTION
The purpose of this PR is to fix a strange issue where the node can get stuck in `Synchronizing` state forever. It is unknown if it actually fixes that issue though, as it is hard to reproduce.

Also, since this removes a check between the current epoch and the block epoch, now all the blocks that are not "expected" are assumed to be candidates and are sent to the ChainManager. Therefore we can see some new warnings:

    [2020-05-26T14:53:03Z WARN  witnet_node::actors::chain_manager] Block candidate's epoch differs from current epoch (9989 != 9988)

Update: we believe that are are 3 different issues that can get the node stuck in `Synchronizing`:

* If the node has 0 outbound consolidated peers when sending the `Anycast<LastBeacon>` message, it will be waiting for an `AddBlocks` message that will never arrive. This is now fixed by checking the result of the `Anycast` message, and moving back to `WaitingConsensus` on the error case.
* If the node tries to send an `Anycast<LastBeacon>` message to a `Session` that has just closed the connection (or a `Session` that was unregistered for being out of consensus), the `Anycast` will fail with error `Mailbox has closed`. This is fixed the same way as the previous point.
* If a `Session` actor sends a message to `SessionsManager` using `.wait(ctx)` while the `SessionsManager` actor is sending a message to this `Session` also using `.wait(ctx)`, both actors can enter into a deadlock, each one waiting for the message response from the other. It is not clear if this is exactly what happens, but removing the `.wait` from the `Anycast` handler should help with this issue.

To make sure that the node cannot get stuck in `Synchronizing` state anymore, we now have an additional timeout in `ChainManager` that will move the node back to `WaitingConsensus` state after N epochs in `Synchronizing` state, if the node does not receive any blocks.