### PR TITLE
Validate candidates once

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -89,6 +89,7 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
             self.sm_state = StateMachine::WaitingConsensus;
             // Clear candidates
             self.candidates.clear();
+            self.seen_candidates.clear();
         }
 
         if let Some(last_checked_epoch) = last_checked_epoch {
@@ -252,6 +253,7 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
 
                         // Clear candidates
                         self.candidates.clear();
+                        self.seen_candidates.clear();
                     }
 
                     _ => {
@@ -659,6 +661,7 @@ impl Handler<PeersBeacons> for ChainManager {
                         let candidate = self.candidates.remove(&consensus_block_hash);
                         // Clear candidates, as they are only valid for one epoch
                         self.candidates.clear();
+                        self.seen_candidates.clear();
                         // TODO: Be functional my friend
                         if let Some((consensus_block, _consensus_block_vrf_hash)) = candidate {
                             match self.process_requested_block(ctx, &consensus_block) {

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -201,7 +201,11 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                                         utxo_diff,
                                     ))
                                 }
-                                Err(e) => log::warn!("{}", e),
+                                Err(e) => log::warn!(
+                                    "Error when processing a block candidate {}: {}",
+                                    block_candidate.hash(),
+                                    e
+                                ),
                             }
                         }
 
@@ -800,7 +804,7 @@ impl Handler<BuildVtt> for ChainManager {
             msg.utxo_strategy,
         ) {
             Err(e) => {
-                log::error!("{}", e);
+                log::error!("Error when building value transfer transaction: {}", e);
                 Box::new(actix::fut::err(e.into()))
             }
             Ok(vtt) => {
@@ -816,7 +820,7 @@ impl Handler<BuildVtt> for ChainManager {
                             actix::fut::ok(tx_hash)
                         }
                         Err(e) => {
-                            log::error!("{}", e);
+                            log::error!("Failed to sign value transfer transaction: {}", e);
 
                             actix::fut::err(e)
                         }
@@ -849,7 +853,7 @@ impl Handler<BuildDrt> for ChainManager {
             self.tx_pending_timeout,
         ) {
             Err(e) => {
-                log::error!("{}", e);
+                log::error!("Error when building data request transaction: {}", e);
                 Box::new(actix::fut::err(e.into()))
             }
             Ok(drt) => {
@@ -866,7 +870,7 @@ impl Handler<BuildDrt> for ChainManager {
                             actix::fut::ok(tx_hash)
                         }
                         Err(e) => {
-                            log::error!("{}", e);
+                            log::error!("Failed to sign data request transaction: {}", e);
 
                             actix::fut::err(e)
                         }

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -4808,6 +4808,7 @@ fn test_block_with_drpool_and_utxo_set<F: FnMut(&mut Block) -> bool>(
     validate_candidate(
         &b,
         current_epoch,
+        last_block_hash,
         vrf_input,
         &mut signatures_to_verify,
         u32::try_from(rep_eng.ars().active_identities_number())?,
@@ -5056,6 +5057,7 @@ fn block_difficult_proof() {
             validate_candidate(
                 &b,
                 current_epoch,
+                last_block_hash,
                 vrf_input,
                 &mut signatures_to_verify,
                 u32::try_from(rep_eng.ars().active_identities_number())?,
@@ -5625,6 +5627,7 @@ fn test_blocks(txns: Vec<(BlockTransactions, u64)>) -> Result<(), failure::Error
         validate_candidate(
             &b,
             current_epoch,
+            last_block_hash,
             vrf_input,
             &mut signatures_to_verify,
             u32::try_from(rep_eng.ars().active_identities_number())?,


### PR DESCRIPTION
Prior to this PR, the node did not store invalid candidates anywhere. So valid candidates were only validate once, but invalid candidates were validated every time they were received. This PR will validate all received block candidates once (per epoch). So receiving the same candidate twice will only trigger two validations if we receive it in different epochs. Which may make sense because the validity of a candidate depends on the current epoch.

Before this PR, the candidate validation consisted of comparing the block epoch with the current epoch and verifying the VRF hash. This PR adds an additional verification in between, check that the candidate builds on top of our current top of the blockchain. This changes an error that happens during synchronization: `The block has an invalid PoE`. Now that error is
```
Tried to validate candidate 1a626639804d5e676d5c9b5f332abc20849d86d01238d86977514c6e937af519: Ignoring block because previous hash ("675ddac30b85bec25b4f71f1dc1b7995fc136b0ca623c523fc171d77d2ad53a9") is different from our top block hash ("34652a0402b8a7cb89fa432ca13689f6bd4444ffd785f66d1b444a8a33666a54")

```
This allows us to skip the VRF verification when we know for sure that it will fail.

I tested this PR on the current testnet and the node synced successfully, but we should make sure that there are no strange issues when consolidating the last block.