### PR TITLE
Stop slashing commitments with "forced errors"

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -2503,7 +2503,7 @@ pub struct NodeStats {
     /// Last block proposed
     pub last_block_proposed: Hash,
     /// Number of slashed commits
-    pub out_of_consensus_count: u32,
+    pub slashed_count: u32,
 }
 
 /// Blockchain state (valid at a certain epoch)

--- a/data_structures/src/error.rs
+++ b/data_structures/src/error.rs
@@ -175,12 +175,6 @@ pub enum TransactionError {
     /// RadonReport not in Tally Stage
     #[fail(display = "RadonReport not in Tally Stage")]
     NoTallyStage,
-    /// Mismatching number of reveals and liars vector.
-    #[fail(
-        display = "Mismatching number of reveals ({}) and liars vector ({})",
-        reveals_n, inputs_n
-    )]
-    MismatchingLiarsNumber { reveals_n: usize, inputs_n: usize },
     /// Minimum consensus percentage is invalid
     #[fail(
         display = "Minimum consensus percentage {} is invalid. Must be >50 and <100",
@@ -201,12 +195,21 @@ pub enum TransactionError {
     /// Zero amount specified
     #[fail(display = "Cannot build transaction with zero value")]
     ZeroAmount,
-    /// Incorrect value of Rewarded witnesses in Tally
+    /// Incorrect count of out-of-consensus witnesses in Tally
     #[fail(
-        display = "Incorrect value of Slashed witnesses in Tally. Expected: {:?}, found: {:?}",
+        display = "Incorrect count of out-of-consensus witnesses in Tally. Expected: {:?}, found: {:?}",
         expected, found
     )]
-    MismatchingSlashedWitnesses {
+    MismatchingOutOfConsensusCount {
+        expected: Vec<PublicKeyHash>,
+        found: Vec<PublicKeyHash>,
+    },
+    /// Incorrect count of witnesses with errors in Tally
+    #[fail(
+        display = "Incorrect count of witnesses with errors in Tally. Expected: {:?}, found: {:?}",
+        expected, found
+    )]
+    MismatchingErrorCount {
         expected: Vec<PublicKeyHash>,
         found: Vec<PublicKeyHash>,
     },

--- a/data_structures/src/radon_report.rs
+++ b/data_structures/src/radon_report.rs
@@ -148,6 +148,8 @@ pub struct TallyMetaData {
     /// This follows a reverse logic: `false` is truth and `true` is lie.
     /// A liar is an out-of-consensus value
     pub liars: Vec<bool>,
+    /// An error is a RadonError value (or considered as an error due to a RadonError consensus)
+    pub errors: Vec<bool>,
     /// Proportion between total reveals and "truthers" count:
     /// `liars.iter().filter(std::ops::Not).count() / reveals.len()`
     pub consensus: f32,

--- a/data_structures/src/transaction.rs
+++ b/data_structures/src/transaction.rs
@@ -426,12 +426,16 @@ impl RevealTransactionBody {
 #[derive(Debug, Default, Eq, PartialEq, Clone, Serialize, Deserialize, ProtobufConvert)]
 #[protobuf_convert(pb = "witnet::TallyTransaction")]
 pub struct TallyTransaction {
-    // Inputs
-    pub dr_pointer: Hash, // DTTransaction hash
-    // Outputs
+    /// DRTransaction hash
+    pub dr_pointer: Hash,
+    /// Tally result
     pub tally: Vec<u8>,
-    pub outputs: Vec<ValueTransferOutput>, // Witness rewards
-    pub slashed_witnesses: Vec<PublicKeyHash>,
+    /// Witness rewards
+    pub outputs: Vec<ValueTransferOutput>,
+    /// Addresses that are out of consensus (non revealers included)
+    pub out_of_consensus: Vec<PublicKeyHash>,
+    /// Addresses that commit a RadonError (or considered as an Error due to a RadonError consensus)
+    pub error_committers: Vec<PublicKeyHash>,
 
     #[protobuf_convert(skip)]
     #[serde(skip)]
@@ -444,13 +448,15 @@ impl TallyTransaction {
         dr_pointer: Hash,
         tally: Vec<u8>,
         outputs: Vec<ValueTransferOutput>,
-        slashed_witnesses: Vec<PublicKeyHash>,
+        out_of_consensus: Vec<PublicKeyHash>,
+        error_committers: Vec<PublicKeyHash>,
     ) -> Self {
         TallyTransaction {
             dr_pointer,
             tally,
             outputs,
-            slashed_witnesses,
+            out_of_consensus,
+            error_committers,
             hash: MemoHash::new(),
         }
     }

--- a/data_structures/tests/inclusion_proofs.rs
+++ b/data_structures/tests/inclusion_proofs.rs
@@ -78,7 +78,7 @@ fn example_dr(id: usize) -> DRTransaction {
 fn example_ta(id: usize) -> TallyTransaction {
     let dr_pointer = Hash::with_first_u32(u32::try_from(id).unwrap());
     let tally = vec![u8::try_from(id).unwrap(); 32];
-    TallyTransaction::new(dr_pointer, tally, vec![], vec![])
+    TallyTransaction::new(dr_pointer, tally, vec![], vec![], vec![])
 }
 
 #[test]

--- a/node/src/actors/rad_manager/handlers.rs
+++ b/node/src/actors/rad_manager/handlers.rs
@@ -47,6 +47,7 @@ impl Handler<ResolveRA> for RadManager {
                 Ok(TallyPreconditionClauseResult::MajorityOfValues {
                     values,
                     liars: _liars,
+                    errors: _errors,
                 }) => {
                     // Perform aggregation on the values that made it to the output vector after applying the
                     // source scripts (aka _normalization scripts_ in the original whitepaper) and filtering out

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -48,7 +48,7 @@ pub async fn try_data_request(request: &RADRequest) -> RadonReport<RadonTypes> {
         .unwrap_or_else(|error| RadonReport::from_result(Err(error), context))
         .into_inner();
 
-    run_tally_report(vec![aggregation_response], &request.tally, None)
+    run_tally_report(vec![aggregation_response], &request.tally, None, None)
         .unwrap_or_else(|error| RadonReport::from_result(Err(error), context))
 }
 
@@ -155,6 +155,7 @@ pub fn run_tally_report(
     radon_types_vec: Vec<RadonTypes>,
     consensus: &RADTally,
     liars: Option<Vec<bool>>,
+    errors: Option<Vec<bool>>,
 ) -> Result<RadonReport<RadonTypes>> {
     let context = &mut ReportContext::default();
     let mut metadata = TallyMetaData::default();
@@ -162,6 +163,11 @@ pub fn run_tally_report(
         metadata.liars = liars;
     } else {
         metadata.liars = vec![false; radon_types_vec.len()];
+    }
+    if let Some(errors) = errors {
+        metadata.errors = errors;
+    } else {
+        metadata.errors = vec![false; radon_types_vec.len()];
     }
     context.stage = Stage::Tally(metadata);
 
@@ -180,7 +186,7 @@ pub fn run_tally_report(
 
 /// Run tally stage of a data request, return `RadonTypes`.
 pub fn run_tally(radon_types_vec: Vec<RadonTypes>, consensus: &RADTally) -> Result<RadonTypes> {
-    run_tally_report(radon_types_vec, consensus, None).map(RadonReport::into_inner)
+    run_tally_report(radon_types_vec, consensus, None, None).map(RadonReport::into_inner)
 }
 
 #[cfg(test)]
@@ -444,6 +450,7 @@ mod tests {
                 reducer: RadonReducers::Mode as u32,
             },
             None,
+            None,
         )
         .unwrap();
 
@@ -473,6 +480,7 @@ mod tests {
                 filters: vec![],
                 reducer: RadonReducers::Mode as u32,
             },
+            None,
             None,
         )
         .unwrap();
@@ -505,6 +513,7 @@ mod tests {
                 reducer: RadonReducers::Mode as u32,
             },
             None,
+            None,
         )
         .unwrap();
 
@@ -536,6 +545,7 @@ mod tests {
                 }],
                 reducer: RadonReducers::AverageMean as u32,
             },
+            None,
             None,
         )
         .unwrap();
@@ -581,6 +591,7 @@ mod tests {
                 reducer: RadonReducers::AverageMean as u32,
             },
             None,
+            None,
         )
         .unwrap();
 
@@ -613,6 +624,7 @@ mod tests {
                 filters: vec![],
                 reducer: RadonReducers::Mode as u32,
             },
+            None,
             None,
         )
         .unwrap();
@@ -652,6 +664,7 @@ mod tests {
                 ],
                 reducer: RadonReducers::AverageMean as u32,
             },
+            None,
             None,
         )
         .unwrap_err();
@@ -693,6 +706,7 @@ mod tests {
                 reducer: RadonReducers::AverageMean as u32,
             },
             None,
+            None,
         )
         .unwrap_err();
 
@@ -733,6 +747,7 @@ mod tests {
                 reducer: RadonReducers::AverageMean as u32,
             },
             None,
+            None,
         )
         .unwrap_err();
 
@@ -755,6 +770,7 @@ mod tests {
                 filters: vec![],
                 reducer: RadonReducers::AverageMean as u32,
             },
+            None,
             None,
         )
         .unwrap()

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -197,7 +197,8 @@ message TallyTransaction {
     Hash dr_pointer = 1;
     bytes tally = 2;
     repeated ValueTransferOutput outputs = 3;
-    repeated PublicKeyHash slashed_witnesses = 4;
+    repeated PublicKeyHash out_of_consensus = 4;
+    repeated PublicKeyHash error_committers = 5;
 }
 
 message MintTransaction {

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -719,7 +719,10 @@ pub fn data_request_report(
                         let honest = match dr_info.tally.as_ref() {
                             None => format!(""),
                             Some(tally) => {
-                                if tally.slashed_witnesses.contains(&pkh) {
+                                // TODO: Need review by tmpolaczyk
+                                if tally.out_of_consensus.contains(&pkh)
+                                    && !tally.error_committers.contains(&pkh)
+                                {
                                     let reward = 0;
 
                                     format!("-{}", reward)
@@ -835,7 +838,7 @@ pub fn get_node_stats(addr: SocketAddr) -> Result<(), failure::Error> {
         node_stats.dr_eligibility_count,
         node_stats.commits_proposed_count,
         node_stats.commits_count,
-        node_stats.out_of_consensus_count
+        node_stats.slashed_count
     );
 
     Ok(())

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -1086,9 +1086,9 @@ fn build_tally_report(
                 .collect::<Result<HashMap<PublicKeyHash, model::Reveal>>>()?;
 
             // Set not `in_consensus` reveals
-            for pkh in &tally.slashed_witnesses {
-                let liar = reveals.get_mut(&pkh).cloned();
-                if let Some(mut reveal) = liar {
+            for pkh in &tally.out_of_consensus {
+                let outlier = reveals.get_mut(&pkh).cloned();
+                if let Some(mut reveal) = outlier {
                     reveal.in_consensus = false;
                 } else {
                     reveals.insert(


### PR DESCRIPTION
This PR adds the next logic:
- If you commit a RadonError you can not be slashed
- If you commit a RadonError and you are in consensus, you will earn the wits reward
- If you commit more RadonErrors than normal values (truths) in an epoch, you will not earn reputation.

![image](https://user-images.githubusercontent.com/44392885/83633296-0460ec80-a5a1-11ea-9109-befc8938c841.png)
![image](https://user-images.githubusercontent.com/44392885/83633369-23f81500-a5a1-11ea-8f07-88956e222a6b.png)

Close #1261 
