### PR TITLE
New folders layout

### DIFF
--- a/docker/witnet-rust/Dockerfile
+++ b/docker/witnet-rust/Dockerfile
@@ -22,11 +22,11 @@ EXPOSE 21338
 EXPOSE 11212
 
 # Run the install script
-RUN ["chmod", "+x", "./downloader.sh", "./ip_detector.sh", "./migrator.sh", "./runner.sh"]
+RUN ["chmod", "+x", "./downloader.sh", "./ip_detector.sh", "./migrator.sh", "./runner.sh", "./executer.sh"]
 RUN ["./downloader.sh"]
 
-# Set compilation entry point (always gets executed)
+# Set entry point (always gets executed)
 ENTRYPOINT ["./runner.sh"]
 
 # Set default command (can be overridden)
-CMD ["-c", "/.witnet/config/witnet.toml", "node", "server"]
+CMD ["node", "server"]

--- a/docker/witnet-rust/Dockerfile
+++ b/docker/witnet-rust/Dockerfile
@@ -13,8 +13,8 @@ ENV RUST_BACKTRACE=1
 ARG WITNET_VERSION
 
 # Copy context and cd into it
-COPY / /
-WORKDIR /
+COPY / /tmp
+WORKDIR /tmp
 
 # Expose server ports
 EXPOSE 21337
@@ -22,11 +22,11 @@ EXPOSE 21338
 EXPOSE 11212
 
 # Run the install script
-RUN ["chmod", "+x", "./downloader.sh", "./ip_detector.sh", "./runner.sh"]
+RUN ["chmod", "+x", "./downloader.sh", "./ip_detector.sh", "./migrator.sh", "./runner.sh"]
 RUN ["./downloader.sh"]
 
 # Set compilation entry point (always gets executed)
 ENTRYPOINT ["./runner.sh"]
 
-# Set default command (can be overriden)
-CMD ["node", "server"]
+# Set default command (can be overridden)
+CMD ["-c", "/.witnet/config/witnet.toml", "node", "server"]

--- a/docker/witnet-rust/downloader.sh
+++ b/docker/witnet-rust/downloader.sh
@@ -2,25 +2,30 @@
 
 VERSION=${WITNET_VERSION:-"latest"}
 
+function log {
+  echo "[DOWNLOADER] $1"
+}
+
 if [[ "$VERSION" == "latest" ]]; then
-    VERSION=`curl https://github.com/witnet/witnet-rust/releases/latest --cacert /etc/ssl/certs/ca-certificates.crt 2>/dev/null | egrep -o "[0-9|\.]{5}(-rc[0-9]+)?"`
+    VERSION=$(curl https://github.com/witnet/witnet-rust/releases/latest --cacert /etc/ssl/certs/ca-certificates.crt 2>/dev/null | egrep -o "[0-9|\.]{5}(-rc[0-9]+)?")
 fi
 
-TRIPLET=`bash --version | head -1 | sed -En 's/^.*\ \((.+)-(.+)-(.+)\)$/\1-\2-\3/p'`
+TRIPLET=$(bash --version | head -1 | sed -En 's/^.*\ \((.+)-(.+)-(.+)\)$/\1-\2-\3/p')
 
 if [[ "$TRIPLET" == *"linux"* ]]; then
-    TRIPLET=`echo $TRIPLET | sed 's/pc/unknown/g'`
+    TRIPLET=${TRIPLET/pc/unknown}
 fi
 
 URL="https://github.com/witnet/witnet-rust/releases/download/$VERSION/witnet-$VERSION-$TRIPLET.tar.gz"
 
 FILENAME="$VERSION.tar.gz"
-FOLDERNAME="."
+WITNET_FOLDER="/.witnet"
 
-echo "Downloading 'witnet-$VERSION-$TRIPLET.tar.gz'. It may take a few seconds..."
-curl -L $URL -o /tmp/${FILENAME} --cacert /etc/ssl/certs/ca-certificates.crt >/dev/null 2>&1 &&
-tar -zxf /tmp/${FILENAME} --directory ${FOLDERNAME} >/dev/null 2>&1 &&
-chmod +x $FOLDERNAME/witnet &&
-rm -f /tmp/${FILENAME} &&
-${FOLDERNAME}/witnet --version ||
-echo "Error downloading and installing witnet-rust on version $VERSION for $TRIPLET"
+log "Downloading 'witnet-$VERSION-$TRIPLET.tar.gz'. It may take a few seconds..."
+curl -L "$URL" -o "/tmp/$FILENAME" --cacert /etc/ssl/certs/ca-certificates.crt >/dev/null 2>&1 &&
+tar -zxf "/tmp/$FILENAME" --directory . >/dev/null 2>&1 &&
+chmod +x ./witnet &&
+cp ./witnet /usr/local/bin/ &&
+rm -f "/tmp/$FILENAME" &&
+witnet --version ||
+log "Error downloading and installing witnet-rust on version $VERSION for $TRIPLET"

--- a/docker/witnet-rust/downloader.sh
+++ b/docker/witnet-rust/downloader.sh
@@ -19,13 +19,19 @@ fi
 URL="https://github.com/witnet/witnet-rust/releases/download/$VERSION/witnet-$VERSION-$TRIPLET.tar.gz"
 
 FILENAME="$VERSION.tar.gz"
-WITNET_FOLDER="/.witnet"
 
+# Download and extract release bundle
 log "Downloading 'witnet-$VERSION-$TRIPLET.tar.gz'. It may take a few seconds..."
 curl -L "$URL" -o "/tmp/$FILENAME" --cacert /etc/ssl/certs/ca-certificates.crt >/dev/null 2>&1 &&
 tar -zxf "/tmp/$FILENAME" --directory . >/dev/null 2>&1 &&
-chmod +x ./witnet &&
-cp ./witnet /usr/local/bin/ &&
+# Rename the actual binary to 'witnet-raw'
+mv witnet witnet-raw &&
+chmod +x ./witnet-raw &&
+# Make executer.sh hijack command './witnet'
+cp ./executer.sh ./witnet &&
+# Make executer.sh hijack command 'witnet'
+cp ./executer.sh /usr/local/bin/witnet &&
+# Delete release bundle
 rm -f "/tmp/$FILENAME" &&
 witnet --version ||
 log "Error downloading and installing witnet-rust on version $VERSION for $TRIPLET"

--- a/docker/witnet-rust/executer.sh
+++ b/docker/witnet-rust/executer.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd /
+
+/tmp/witnet-raw -c /.witnet/config/witnet.toml  "$@"

--- a/docker/witnet-rust/ip_detector.sh
+++ b/docker/witnet-rust/ip_detector.sh
@@ -1,23 +1,26 @@
 #!/bin/bash
 
-CONFIG_FILE_FROM_CMD=`echo "$@" | sed -E 's/(.*-c\s*)?(.*\.toml)?.*/\2/'`
-CONFIG_FILE=${CONFIG_FILE_FROM_CMD:-witnet.toml}
+WITNET_FOLDER="/.witnet"
+CONFIG_FILE_FROM_CMD=$(echo "$@" | sed -E 's/(.*-c\s*)?(.*\.toml)?.*/\2/')
+CONFIG_FILE=${CONFIG_FILE_FROM_CMD:-$WITNET_FOLDER/config/witnet.toml}
 DEFAULT_IP="0.0.0.0"
 DEFAULT_PORT="21337"
 DEFAULT_ADDR="$DEFAULT_IP:$DEFAULT_PORT"
 
-echo "Reading configuration from $CONFIG_FILE"
+function log {
+  echo "[IP_DETECTOR] $1"
+}
 
 function read_public_addr_from_config {
-    echo "Reading public_addr from config file";
-    PUBLIC_ADDR_FROM_CONFIG=`grep public_addr $CONFIG_FILE | cut -d "\"" -f2`;
-    LISTENING_PORT_FROM_CONFIG=`grep "server_addr" $CONFIG_FILE | head -1 | cut -d "\"" -f2 | cut -d ":" -f2`
+    log "Reading 'public_addr' from config file";
+    PUBLIC_ADDR_FROM_CONFIG=$(grep public_addr "$CONFIG_FILE" | cut -d "\"" -f2);
+    LISTENING_PORT_FROM_CONFIG=$(grep "server_addr" "$CONFIG_FILE" | head -1 | cut -d "\"" -f2 | cut -d ":" -f2)
 }
 
 function guess_public_addr {
-    echo "Trying to guess public_addr";
+    log "Trying to guess 'public_addr'";
     API_URL="http://bot.whatismyipaddress.com/";
-    PUBLIC_ADDR_FROM_API="`curl $API_URL 2>/dev/null || echo $DEFAULT_IP`:${LISTENING_PORT_FROM_CONFIG:-$DEFAULT_PORT}";
+    PUBLIC_ADDR_FROM_API="$(curl $API_URL 2>/dev/null || log $DEFAULT_IP):${LISTENING_PORT_FROM_CONFIG:-$DEFAULT_PORT}";
 }
 
 function replace_ip_in_config_if_not_set {
@@ -25,17 +28,18 @@ function replace_ip_in_config_if_not_set {
     if [[ "$PUBLIC_ADDR_FROM_CONFIG" == "$DEFAULT_ADDR" ]]; then
         guess_public_addr;
         if [[ "$PUBLIC_ADDR_FROM_API" != "$DEFAULT_ADDR" ]]; then
-           echo "Trying to replace public_address ($PUBLIC_ADDR_FROM_API) into config file ($CONFIG_FILE)";
-           sed -i -E "s/public_addr\s*=\s*\"$DEFAULT_ADDR\"/public_addr = \"$PUBLIC_ADDR_FROM_API\"/" $CONFIG_FILE;
+           log "Trying to replace 'public_address' ($PUBLIC_ADDR_FROM_API) into config file ($CONFIG_FILE)";
+           sed -i -E "s/public_addr\s*=\s*\"$DEFAULT_ADDR\"/public_addr = \"$PUBLIC_ADDR_FROM_API\"/" "$CONFIG_FILE";
         fi
     else
       if [[ "$PUBLIC_ADDR_FROM_CONFIG" == "" ]]; then
         guess_public_addr;
-        echo "Trying to write public_address ($PUBLIC_ADDR_FROM_API) into config file ($CONFIG_FILE)";
-        sed -i -E "s/^\[connections\]$/[connections]\npublic_addr = \"$PUBLIC_ADDR_FROM_API\"/" $CONFIG_FILE;
+        log "Trying to write 'public_address' ($PUBLIC_ADDR_FROM_API) into config file ($CONFIG_FILE)";
+        sed -i -E "s/^\[connections\]$/[connections]\npublic_addr = \"$PUBLIC_ADDR_FROM_API\"/" "$CONFIG_FILE";
       fi
     fi
     return 0; # This is best effort, it's a pity if it didn't work out, but we need to keep running the node anyway.
 }
 
+log "Using configuration from '$CONFIG_FILE'"
 replace_ip_in_config_if_not_set

--- a/docker/witnet-rust/migrator.sh
+++ b/docker/witnet-rust/migrator.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+CONFIG_FILE_FROM_CMD=$(echo "$@" | sed -E 's/(.*-c\s*)?(.*\.toml)?.*/\2/')
+WITNET_FOLDER="/.witnet"
+WITNET_CONFIG_FOLDER="$WITNET_FOLDER/config"
+WITNET_STORAGE_FOLDER="$WITNET_FOLDER/storage"
+CONFIG_FILE=${CONFIG_FILE_FROM_CMD:-./witnet.toml}
+
+function log {
+  echo "[MIGRATOR] $1"
+}
+
+function migrate_storage {
+  OLD_FOLDER="/.witnet"
+  find "$OLD_FOLDER" -type f -maxdepth 1 -exec cp -n {} "$WITNET_STORAGE_FOLDER" \;
+}
+
+function migrate {
+  log "Ensuring that configuration folder '$WITNET_CONFIG_FOLDER' does exist" &&
+  mkdir -p "$WITNET_CONFIG_FOLDER" &&
+  log "Ensuring that storage folder '$WITNET_STORAGE_FOLDER' does exist" &&
+  mkdir -p "$WITNET_STORAGE_FOLDER" &&
+  log "Moving configuration files into configuration folder '$WITNET_FOLDER/config'" &&
+  cp -n "$CONFIG_FILE" "$WITNET_CONFIG_FOLDER" &&
+  cp "genesis_block.json" "$WITNET_CONFIG_FOLDER" &&
+  chmod -R 777 "$WITNET_FOLDER/config" &&
+  log "Copying old storage (if any) into new storage path" &&
+  migrate_storage
+}
+
+log "Using configuration from '$CONFIG_FILE'"
+migrate

--- a/docker/witnet-rust/migrator.sh
+++ b/docker/witnet-rust/migrator.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-CONFIG_FILE_FROM_CMD=$(echo "$@" | sed -E 's/(.*-c\s*)?(.*\.toml)?.*/\2/')
 WITNET_FOLDER="/.witnet"
 WITNET_CONFIG_FOLDER="$WITNET_FOLDER/config"
 WITNET_STORAGE_FOLDER="$WITNET_FOLDER/storage"
-CONFIG_FILE=${CONFIG_FILE_FROM_CMD:-./witnet.toml}
+CONFIG_FILE="./witnet.toml"
 
 function log {
   echo "[MIGRATOR] $1"
@@ -12,7 +11,7 @@ function log {
 
 function migrate_storage {
   OLD_FOLDER="/.witnet"
-  find "$OLD_FOLDER" -type f -maxdepth 1 -exec cp -n {} "$WITNET_STORAGE_FOLDER" \;
+  find "$OLD_FOLDER" -maxdepth 1 -type f -exec mv -n {} "$WITNET_STORAGE_FOLDER" \;
 }
 
 function migrate {
@@ -21,7 +20,7 @@ function migrate {
   log "Ensuring that storage folder '$WITNET_STORAGE_FOLDER' does exist" &&
   mkdir -p "$WITNET_STORAGE_FOLDER" &&
   log "Moving configuration files into configuration folder '$WITNET_FOLDER/config'" &&
-  cp -n "$CONFIG_FILE" "$WITNET_CONFIG_FOLDER" &&
+  mv -n "$CONFIG_FILE" "$WITNET_CONFIG_FOLDER" &&
   cp "genesis_block.json" "$WITNET_CONFIG_FOLDER" &&
   chmod -R 777 "$WITNET_FOLDER/config" &&
   log "Copying old storage (if any) into new storage path" &&

--- a/docker/witnet-rust/runner.sh
+++ b/docker/witnet-rust/runner.sh
@@ -8,4 +8,6 @@ if [[ "$PUBLIC_ADDR_DISCOVERY" == "true" ]]; then
     ./ip_detector.sh
 fi
 
-witnet "$@"
+cd /
+
+/tmp/witnet-raw -c /.witnet/config/witnet.toml  "$@"

--- a/docker/witnet-rust/runner.sh
+++ b/docker/witnet-rust/runner.sh
@@ -2,8 +2,10 @@
 
 PUBLIC_ADDR_DISCOVERY=${PUBLIC_ADDR_DISCOVERY:-"true"}
 
+./migrator.sh
+
 if [[ "$PUBLIC_ADDR_DISCOVERY" == "true" ]]; then
     ./ip_detector.sh
 fi
 
-./witnet "$@"
+witnet "$@"

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -1,4 +1,8 @@
-use std::{net::SocketAddr, path::PathBuf, time::Duration};
+use std::{
+    net::SocketAddr,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use structopt::StructOpt;
 
@@ -7,7 +11,11 @@ use witnet_node as node;
 
 use super::json_rpc_client as rpc;
 
-pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Error> {
+pub fn exec_cmd(
+    command: Command,
+    config_path: Option<PathBuf>,
+    mut config: Config,
+) -> Result<(), failure::Error> {
     match command {
         Command::GetBlock { node, hash } => {
             rpc::get_block(node.unwrap_or(config.jsonrpc.server_address), hash)
@@ -145,8 +153,8 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
             let write_to_path = match (write, write_to) {
                 // Don't write
                 (false, None) => None,
-                // Write to default storage path
-                (true, None) => Some(config.storage.db_path),
+                // Write to the same folder where the config file is located
+                (true, None) => config_path.and_then(|path| path.parent().map(Path::to_path_buf)),
                 // Write to custom path
                 (_, Some(path)) => Some(path),
             };

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -154,7 +154,11 @@ pub fn exec_cmd(
                 // Don't write
                 (false, None) => None,
                 // Write to the same folder where the config file is located
-                (true, None) => config_path.and_then(|path| path.parent().map(Path::to_path_buf)),
+                // Fail if using default configuration (not sourced from a file in the filesystem)
+                (true, None) => config_path
+                    .expect("Cannot guess a file system path for writing the master key file. Please specify a valid path right after the `--write` flag.")
+                    .parent()
+                    .map(Path::to_path_buf),
                 // Write to custom path
                 (_, Some(path)) => Some(path),
             };

--- a/src/cli/node/without_node.rs
+++ b/src/cli/node/without_node.rs
@@ -1,8 +1,13 @@
 use structopt::StructOpt;
 
+use std::path::PathBuf;
 use witnet_config::config::Config;
 
-pub fn exec_cmd(_command: Command, _config: Config) -> Result<(), failure::Error> {
+pub fn exec_cmd(
+    _command: Command,
+    _config_path: Option<PathBuf>,
+    _config: Config,
+) -> Result<(), failure::Error> {
     println!("This executable has been compiled without the ability of running a Witnet node.");
     Ok(())
 }

--- a/witnet.toml
+++ b/witnet.toml
@@ -45,7 +45,7 @@ outbound_limit = 8
 bootstrap_peers_period_seconds = 1
 
 [storage]
-db_path = ".witnet"
+db_path = ".witnet/storage"
 
 [jsonrpc]
 enabled = true
@@ -67,7 +67,7 @@ update_period_seconds = 8000000
 enabled = true
 data_request_max_retrievals_per_epoch = 30
 data_request_timeout_milliseconds = 2000
-genesis_path = "genesis_block.json"
+genesis_path = ".witnet/config/genesis_block.json"
 # `mint_external_address` and `mint_external_percentage` enable splitting the mint reward between the node's
 # own address and an "external" address, e.g. a the address of a wallet. `mint_external_percentage` indicates
 # the percentage of the block rewards that will be assigned to `mint_external_address` (50% by default)


### PR DESCRIPTION
- divides the `.witnet` folder into `.witnet/config` and `.witnet/storage`
- updates `witnet.toml` so it uses the new folders
- makes the `witnet-rust` Docker image migrate old storage files into the new storage folder
- allows the host to directly modify `witnet.toml` of a existing container
- copies `./witnet` into `/usr/local/bin`, so that `docker exec` commands also work as `docker exec witnet_node witnet node ...`
- makes `masterKeyExport` write to config folder, not storage folder, so that you don't delete our master key backup if a storage wipe is needed

Existing non-Docker setups should keep working, provided that they use a custom `witnet.toml` file that points directly to their storage folder. 