### PR TITLE
Ars merkelization

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1177,6 +1177,13 @@ impl Bn256PublicKey {
         })
     }
 
+    pub fn to_uncompressed(self) -> Result<Vec<u8>, failure::Error> {
+        // Verify that this slice is a valid public key
+        let uncompressed =
+            bn256::PublicKey::from_compressed(&self.public_key.clone())?.to_uncompressed()?;
+        Ok(uncompressed)
+    }
+
     pub fn to_bytes(&self) -> Vec<u8> {
         self.public_key.clone()
     }
@@ -4174,7 +4181,6 @@ mod tests {
             public_key: vec![3; 65],
         };
 
-
         alt_keys.insert_bn256(p1.pkh(), p1_bls.clone());
         alt_keys.insert_bn256(p2.pkh(), p2_bls.clone());
         alt_keys.insert_bn256(p3.pkh(), p3_bls.clone());
@@ -4211,11 +4217,10 @@ mod tests {
             public_key: vec![3; 65],
         };
 
-
         alt_keys.insert_bn256(p1.pkh(), p1_bls.clone());
         alt_keys.insert_bn256(p2.pkh(), p2_bls.clone());
         alt_keys.insert_bn256(p3.pkh(), p3_bls.clone());
-        
+
         let v4 = vec![
             (p1.pkh(), Reputation(3)),
             (p2.pkh(), Reputation(1)),

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -3,7 +3,6 @@ use actix::{
 };
 use ansi_term::Color::{White, Yellow};
 use futures::future::{join_all, Future};
-use itertools::Itertools;
 use std::{
     cmp::Ordering,
     collections::HashSet,
@@ -144,12 +143,6 @@ impl ChainManager {
             // block reorganization
             let ars_members = self.chain_state.last_ars.clone();
             let ars_ordered_keys = self.chain_state.last_ars_ordered_keys.clone();
-/*            let ars_members: Vec<PublicKeyHash> = rep_engine
-                .ars()
-                .active_identities()
-                .cloned()
-                .sorted()
-                .collect();*/
             self.superblock_creating_and_broadcasting(
                 ctx,
                 current_epoch,
@@ -587,7 +580,7 @@ impl ChainManager {
         ctx: &mut Context<Self>,
         current_epoch: u32,
         superblock_period: u32,
-        ars_members: AltKeys,
+        ars_members: Vec<PublicKeyHash>,
         ars_ordered_keys: Vec<Bn256PublicKey>,
         genesis_hash: Hash,
     ) {
@@ -659,8 +652,8 @@ impl ChainManager {
         .and_then(move |(block_headers, last_hash), act, _ctx| {
             let superblock = act.superblock_state.build_superblock(
                 &block_headers,
-                ars_members,
-                ars_ordered_keys,
+                &ars_members,
+                &ars_ordered_keys,
                 superblock_index,
                 last_hash,
             );

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 use witnet_data_structures::{
     chain::{
-        Block, BlockHeader, BlockMerkleRoots, BlockTransactions, Bn256PublicKey, CheckpointBeacon,
+        AltKeys, Block, BlockHeader, BlockMerkleRoots, BlockTransactions, Bn256PublicKey, CheckpointBeacon,
         CheckpointVRF, DataRequestOutput, EpochConstants, Hash, Hashable, Input, PublicKeyHash,
         ReputationEngine, SuperBlockVote, TransactionsPool, UnspentOutputsPool,
         ValueTransferOutput,
@@ -142,18 +142,20 @@ impl ChainManager {
             // FIXME: After Reputation Merkelitation, only the ARS Members from the previous consolidated
             // Superblock will be added, to avoid include addresses that could be wrong later by
             // block reorganization
-            let ars_members: Vec<PublicKeyHash> = rep_engine
+            let ars_members = self.chain_state.last_ars.clone();
+            let ars_ordered_keys = self.chain_state.last_ars_ordered_keys.clone();
+/*            let ars_members: Vec<PublicKeyHash> = rep_engine
                 .ars()
                 .active_identities()
                 .cloned()
                 .sorted()
-                .collect();
-
+                .collect();*/
             self.superblock_creating_and_broadcasting(
                 ctx,
                 current_epoch,
                 superblock_period,
                 ars_members,
+                ars_ordered_keys,
                 genesis_hash,
             );
         }
@@ -585,7 +587,8 @@ impl ChainManager {
         ctx: &mut Context<Self>,
         current_epoch: u32,
         superblock_period: u32,
-        ars_members: Vec<PublicKeyHash>,
+        ars_members: AltKeys,
+        ars_ordered_keys: Vec<Bn256PublicKey>,
         genesis_hash: Hash,
     ) {
         let superblock_index = current_epoch / superblock_period;
@@ -656,7 +659,8 @@ impl ChainManager {
         .and_then(move |(block_headers, last_hash), act, _ctx| {
             let superblock = act.superblock_state.build_superblock(
                 &block_headers,
-                &ars_members,
+                ars_members,
+                ars_ordered_keys,
                 superblock_index,
                 last_hash,
             );

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -494,7 +494,6 @@ impl ChainManager {
                     .ars()
                     .active_identities()
                     .cloned()
-                    .sorted()
                     .collect();
                 let alt_keys = &self.chain_state.alt_keys;
 

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -488,6 +488,15 @@ impl ChainManager {
                 chain_info.highest_block_checkpoint = beacon;
                 chain_info.highest_vrf_output = vrf_input;
 
+                // Store the ARS and the order of the keys
+                let trs = reputation_engine.trs();
+                let alt_keys = self.chain_state.alt_keys.clone();
+
+                let ordered_alts: Vec<Bn256PublicKey> = alt_keys.get_rep_ordered_bn256_list(trs);
+                // last ars with previous block ars info
+                self.chain_state.last_ars = alt_keys;
+                self.chain_state.last_ars_ordered_keys = ordered_alts;
+
                 let rep_info = update_pools(
                     &block,
                     &mut self.chain_state.unspent_outputs_pool,
@@ -515,6 +524,7 @@ impl ChainManager {
                         self.own_pkh.unwrap_or_default(),
                     );
                 }
+
 
                 // Update bn256 public keys with block information
                 self.chain_state.alt_keys.insert_keys_from_block(&block);

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -490,11 +490,17 @@ impl ChainManager {
 
                 // Store the ARS and the order of the keys
                 let trs = reputation_engine.trs();
+                let current_ars = reputation_engine
+                    .ars()
+                    .active_identities()
+                    .cloned()
+                    .sorted()
+                    .collect();
                 let alt_keys = self.chain_state.alt_keys.clone();
 
                 let ordered_alts: Vec<Bn256PublicKey> = alt_keys.get_rep_ordered_bn256_list(trs);
                 // last ars with previous block ars info
-                self.chain_state.last_ars = alt_keys;
+                self.chain_state.last_ars = current_ars;
                 self.chain_state.last_ars_ordered_keys = ordered_alts;
 
                 let rep_info = update_pools(
@@ -524,7 +530,6 @@ impl ChainManager {
                         self.own_pkh.unwrap_or_default(),
                     );
                 }
-
 
                 // Update bn256 public keys with block information
                 self.chain_state.alt_keys.insert_keys_from_block(&block);

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -496,7 +496,7 @@ impl ChainManager {
                     .cloned()
                     .sorted()
                     .collect();
-                let alt_keys = self.chain_state.alt_keys.clone();
+                let alt_keys = &self.chain_state.alt_keys;
 
                 let ordered_alts: Vec<Bn256PublicKey> = alt_keys.get_rep_ordered_bn256_list(trs);
                 // last ars with previous block ars info

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -317,12 +317,13 @@ message DataRequestEligibilityClaim {
 }
 
 message SuperBlock {
-    Hash ars_root = 1;
-    Hash data_request_root = 2;
-    uint32 index = 3;
-    Hash last_block = 4;
-    Hash last_block_in_previous_superblock = 5;
-    Hash tally_root = 6;
+    uint64 ars_length = 1;
+    Hash ars_root = 2;
+    Hash data_request_root = 3;
+    uint32 index = 4;
+    Hash last_block = 5;
+    Hash last_block_in_previous_superblock = 6;
+    Hash tally_root = 7;
 }
 
 message SuperBlockVote {

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -316,16 +316,6 @@ message DataRequestEligibilityClaim {
     VrfProof proof = 1;
 }
 
-message SuperBlock {
-    uint64 ars_length = 1;
-    Hash ars_root = 2;
-    Hash data_request_root = 3;
-    uint32 index = 4;
-    Hash last_block = 5;
-    Hash last_block_in_previous_superblock = 6;
-    Hash tally_root = 7;
-}
-
 message SuperBlockVote {
     Bn256Signature bn256_signature = 1;
     KeyedSignature secp256k1_signature = 2;


### PR DESCRIPTION
This PR:

- Stores the prior to last ARS.
- Stores the prior to last bn256 ARS keys ordered by reputation. In case of tie, identities are ordered by pkh.
- Computes the superblock with the prior to last oordered bn256 ARS keys.
- Checks the validity of a b2n56 key before inserting it to AltKeys.
- Adds the ARS length to the superblock