### PR TITLE
Attach node address to telemetry reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4261,6 +4261,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sentry 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ edition = "2018"
 members = ["config", "node", "crypto", "data_structures", "p2p", "storage", "wallet", "validations", "protected", "reputation", "net", "bridges/ethereum"]
 
 [features]
-default = ["wallet", "node", "sentry"]
+default = ["wallet", "node", "telemetry"]
 node = ["witnet_node"]
+telemetry = ["sentry", "witnet_node/telemetry"]
 wallet = ["witnet_wallet"]
 
 [badges]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,6 +23,7 @@ log = "0.4.8"
 rand = "0.7.3"
 rayon = "1.3.0"
 secp256k1 = "0.17.2"
+sentry = { version = "0.18.1", features = ["with_env_logger"], optional = true }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.47"
 tokio = "0.1.22"
@@ -39,3 +40,7 @@ witnet_validations = { path = "../validations" }
 
 [dev-dependencies]
 glob = "0.3.0"
+
+[features]
+default = []
+telemetry = ["sentry"]


### PR DESCRIPTION
This attaches node addresses to telemetry reports for any errors or panics happening in the node runtime, after the node address has been already loaded into `ChainManager`.

This also allows compiling with no telemetry features at all.