### PR TITLE
Enable serde by default for crypto and protected subcrates when imported from node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,15 +102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-macros"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "actix-rt"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,20 +113,6 @@ dependencies = [
  "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "actix-rt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "actix-macros 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-threadpool 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "copyless 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -167,20 +144,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "actix-threadpool"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3369,18 +3332,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4410,7 +4368,6 @@ name = "witnet_wallet"
 version = "0.3.2"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "actix-rt 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-jsonrpc-client 0.1.0 (git+https://github.com/witnet/async-jsonrpc-client)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4469,13 +4426,10 @@ dependencies = [
 "checksum actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2c11af4b06dc935d8e1b1491dad56bfb32febc49096a91e773f8535c176453"
 "checksum actix-connect 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9fade9bd4bb46bacde89f1e726c7a3dd230536092712f5d94d77ca57c087fca0"
 "checksum actix-http 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb50f77cd28240d344fd54afd205bae8760a3b0ad448b1716a2aa31e24db139"
-"checksum actix-macros 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a60f9ba7c4e6df97f3aacb14bb5c0cd7d98a49dcbaed0d7f292912ad9a6a3ed2"
 "checksum actix-rt 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "88c9da1d06603d82ec2b6690fc5b80eb626cd2d6b573f3d9a71d5252e06d098e"
-"checksum actix-rt 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "143fcc2912e0d1de2bcf4e2f720d2a60c28652ab4179685a1ee159e0fb3db227"
 "checksum actix-server-config 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "483a34989c682d93142bacad6300375bb6ad8002d2e0bb249dbad86128b9ff30"
 "checksum actix-service 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bca5b48e928841ff7e7dce1fdb5b0d4582f6b1b976e08f4bac3f640643e0773f"
 "checksum actix-threadpool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b5ae85d13da7e6fb86b1b7bc83185e0e3bd4cc5f421c887e1803796c034d35d"
-"checksum actix-threadpool 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "91164716d956745c79dcea5e66d2aa04506549958accefcede5368c70f2fd4ff"
 "checksum actix-utils 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "908c3109948f5c37a8b57fd343a37dcad5bb1d90bfd06300ac96b17bbe017b95"
 "checksum actix_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0bf5f6d7bf2d220ae8b4a7ae02a572bb35b7c4806b24049af905ab8110de156c"
 "checksum addr2line 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "actix-rt"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +122,20 @@ dependencies = [
  "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "actix-rt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "actix-macros 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-threadpool 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "copyless 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-util 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -144,6 +167,20 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "actix-threadpool"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -802,7 +839,7 @@ version = "0.99.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -973,7 +1010,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1134,7 +1171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2051,7 +2088,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2261,7 +2298,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2324,7 +2361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-error-attr 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2335,7 +2372,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2347,7 +2384,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2433,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2781,7 +2818,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2936,7 +2973,7 @@ version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3106,7 +3143,7 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-error 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3152,7 +3189,7 @@ version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3162,7 +3199,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3172,7 +3209,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3276,7 +3313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3332,13 +3369,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-core 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3859,7 +3901,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3895,7 +3937,7 @@ name = "wasm-bindgen-macro"
 version = "0.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro-support 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3905,7 +3947,7 @@ version = "0.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-shared 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3925,7 +3967,7 @@ dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-backend 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4368,6 +4410,7 @@ name = "witnet_wallet"
 version = "0.3.2"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "actix-rt 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-jsonrpc-client 0.1.0 (git+https://github.com/witnet/async-jsonrpc-client)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4427,10 +4470,13 @@ dependencies = [
 "checksum actix-codec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2c11af4b06dc935d8e1b1491dad56bfb32febc49096a91e773f8535c176453"
 "checksum actix-connect 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9fade9bd4bb46bacde89f1e726c7a3dd230536092712f5d94d77ca57c087fca0"
 "checksum actix-http 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb50f77cd28240d344fd54afd205bae8760a3b0ad448b1716a2aa31e24db139"
+"checksum actix-macros 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a60f9ba7c4e6df97f3aacb14bb5c0cd7d98a49dcbaed0d7f292912ad9a6a3ed2"
 "checksum actix-rt 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "88c9da1d06603d82ec2b6690fc5b80eb626cd2d6b573f3d9a71d5252e06d098e"
+"checksum actix-rt 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "143fcc2912e0d1de2bcf4e2f720d2a60c28652ab4179685a1ee159e0fb3db227"
 "checksum actix-server-config 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "483a34989c682d93142bacad6300375bb6ad8002d2e0bb249dbad86128b9ff30"
 "checksum actix-service 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bca5b48e928841ff7e7dce1fdb5b0d4582f6b1b976e08f4bac3f640643e0773f"
 "checksum actix-threadpool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b5ae85d13da7e6fb86b1b7bc83185e0e3bd4cc5f421c887e1803796c034d35d"
+"checksum actix-threadpool 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "91164716d956745c79dcea5e66d2aa04506549958accefcede5368c70f2fd4ff"
 "checksum actix-utils 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "908c3109948f5c37a8b57fd343a37dcad5bb1d90bfd06300ac96b17bbe017b95"
 "checksum actix_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0bf5f6d7bf2d220ae8b4a7ae02a572bb35b7c4806b24049af905ab8110de156c"
 "checksum addr2line 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"
@@ -4686,7 +4732,7 @@ dependencies = [
 "checksum protoc-rust 2.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "30fe03ab363474c2f5d1062f5d169ba8defd1d30c161261d7c71afd8412727d8"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4427,7 +4427,6 @@ dependencies = [
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_config 0.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -271,8 +271,8 @@ dependencies = [
  "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -343,7 +343,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -545,7 +545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -758,7 +758,7 @@ name = "debugid"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -918,8 +918,8 @@ dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1573,7 +1573,7 @@ name = "impl-serde"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1581,7 +1581,7 @@ name = "impl-serde"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1663,8 +1663,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1675,8 +1675,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1688,7 +1688,7 @@ dependencies = [
  "jsonrpc-core 14.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2119,7 +2119,7 @@ dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitvec 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-slice-cast 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2219,7 +2219,7 @@ name = "partial_struct"
 version = "0.3.2"
 dependencies = [
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2377,8 +2377,8 @@ name = "protobuf"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2684,7 +2684,7 @@ dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2833,7 +2833,7 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "secp256k1-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2907,7 +2907,7 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "debugid 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2915,10 +2915,10 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.104"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2927,12 +2927,12 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "half 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.104"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2947,7 +2947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2957,7 +2957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3127,7 +3127,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3593,7 +3593,7 @@ name = "toml"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3757,7 +3757,7 @@ dependencies = [
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3766,7 +3766,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3845,7 +3845,7 @@ version = "0.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3961,7 +3961,7 @@ dependencies = [
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4102,7 +4102,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4142,7 +4142,7 @@ dependencies = [
  "futures-locks 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4163,7 +4163,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "partial_struct 0.3.2",
  "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_crypto 0.3.2",
  "witnet_data_structures 0.3.2",
@@ -4186,7 +4186,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-bip39 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_protected 0.3.2",
@@ -4213,7 +4213,7 @@ dependencies = [
  "protobuf-convert 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "vrf 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4235,7 +4235,7 @@ dependencies = [
  "jsonrpc-pubsub 14.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-ws-server 14.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4262,7 +4262,7 @@ dependencies = [
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_config 0.3.2",
@@ -4283,7 +4283,7 @@ dependencies = [
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_crypto 0.3.2",
  "witnet_util 0.3.2",
 ]
@@ -4293,7 +4293,7 @@ name = "witnet_protected"
 version = "0.3.2"
 dependencies = [
  "memzero 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4308,7 +4308,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_enum 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "surf 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4323,7 +4323,7 @@ version = "0.3.2"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4345,7 +4345,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ntp 0.5.0 (git+https://github.com/witnet/ntp)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4383,7 +4383,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_config 0.3.2",
@@ -4737,9 +4737,9 @@ dependencies = [
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum sentry 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8b01b723fc1b0a0f9394ca1a8451daec6e20206d47f96c3dceea7fd11ec9eec0"
 "checksum sentry-types 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "12ec406c11c060c8a7d5d67fc6f4beb2888338dcb12b9af409451995f124749d"
-"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+"checksum serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
 "checksum serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
-"checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+"checksum serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 "checksum serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)" = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4384,6 +4384,7 @@ dependencies = [
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_config 0.3.2",

--- a/data_structures/src/radon_error.rs
+++ b/data_structures/src/radon_error.rs
@@ -74,7 +74,7 @@ pub trait ErrorLike: Clone + Fail {
 }
 
 /// This structure is aimed to be the error type for the `result` field of `witnet_data_structures::radon_report::Report`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct RadonError<IE>
 where
     IE: ErrorLike,

--- a/data_structures/src/radon_report.rs
+++ b/data_structures/src/radon_report.rs
@@ -50,10 +50,10 @@ where
         context: &ReportContext,
     ) -> Self {
         let intercepted: Vec<RT> = partial_results.into_iter().map(RT::intercept).collect();
-        let result = match intercepted.last() {
-            None => unreachable!("Partial result vectors always contain at least 1 item"),
-            Some(x) => (*x).clone(),
-        };
+        let result = (*intercepted
+            .last()
+            .expect("Partial result vectors must always contain at least 1 item"))
+        .clone();
 
         RadonReport {
             metadata: context.stage.clone(),
@@ -84,7 +84,7 @@ where
 
 /// This trait identifies a RADON-compatible type system, i.e. most likely an `enum` with different
 /// cases for different data types.
-pub trait TypeLike: std::clone::Clone + std::marker::Sized {
+pub trait TypeLike: Clone + Sized {
     type Error: ErrorLike;
 
     fn encode(&self) -> Result<Vec<u8>, Self::Error>;

--- a/data_structures/src/radon_report.rs
+++ b/data_structures/src/radon_report.rs
@@ -84,23 +84,6 @@ where
     }
 }
 
-/*impl<RT> Serialize for RadonReport<RT>
-where
-    RT: TypeLike + Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
-    where
-        S: Serializer,
-    {
-        let mut state = serializer.serialize_struct("RadonReport", 4)?;
-        state.serialize_field("metadata", &self.metadata)?;
-        state.serialize_field("partial_results", &self.partial_results)?;
-        state.serialize_field("result", &self.result)?;
-        state.serialize_field("running_time", &self.running_time)?;
-        state.end()
-    }
-}*/
-
 /// This trait identifies a RADON-compatible type system, i.e. most likely an `enum` with different
 /// cases for different data types.
 pub trait TypeLike: Clone + Sized {

--- a/data_structures/src/radon_report.rs
+++ b/data_structures/src/radon_report.rs
@@ -18,7 +18,7 @@ where
     /// Stage-specific metadata.
     pub metadata: Stage,
     /// Vector of partial results (the results in between each of the operators in a script)
-    pub partial_results: Vec<RT>,
+    pub partial_results: Option<Vec<RT>>,
     /// This the intercepted result of the script execution: any `IE` raised in runtime has already
     /// been mapped into a `RT` (e.g. `RadError` -> `RadonTypes::RadonError`.
     pub result: RT,
@@ -34,7 +34,13 @@ where
     /// Factory for constructing a `RadonReport` from the `Result` of something that could be
     /// `TypeLike` or `ErrorLike` plus a `ReportContext`.
     pub fn from_result(result: Result<RT, RT::Error>, context: &ReportContext) -> Self {
-        Self::from_partial_results(vec![result], context)
+        let intercepted = RT::intercept(result);
+        RadonReport {
+            metadata: context.stage.clone(),
+            partial_results: None,
+            result: intercepted,
+            running_time: context.duration(),
+        }
     }
 
     /// Factory for constructing a `RadonReport` from a vector of partial results, which could be
@@ -51,7 +57,7 @@ where
 
         RadonReport {
             metadata: context.stage.clone(),
-            partial_results: intercepted,
+            partial_results: Some(intercepted),
             result,
             running_time: context.duration(),
         }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -29,10 +29,10 @@ serde_json = "1.0.47"
 tokio = "0.1.22"
 
 witnet_config = { path = "../config" }
-witnet_crypto = { path = "../crypto" }
+witnet_crypto = { path = "../crypto", features = ["with-serde"] }
 witnet_data_structures = { path = "../data_structures" }
 witnet_p2p = { path = "../p2p" }
-witnet_protected = { path = "../protected" }
+witnet_protected = { path = "../protected", features = ["with-serde"]  }
 witnet_rad = { path = "../rad" }
 witnet_storage = { path = "../storage", features = ["rocksdb-backend", "crypto-backend"] }
 witnet_util = { path = "../util" }

--- a/node/src/actors/rad_manager/handlers.rs
+++ b/node/src/actors/rad_manager/handlers.rs
@@ -14,6 +14,7 @@ use witnet_validations::validations::{
 use crate::actors::messages::{ResolveRA, RunTally};
 
 use super::RadManager;
+use witnet_rad::script::RadonScriptExecutionSettings;
 
 impl Handler<ResolveRA> for RadManager {
     type Result = ResponseFuture<RadonReport<RadonTypes>, RadError>;
@@ -52,7 +53,11 @@ impl Handler<ResolveRA> for RadManager {
                     // Perform aggregation on the values that made it to the output vector after applying the
                     // source scripts (aka _normalization scripts_ in the original whitepaper) and filtering out
                     // failures.
-                    witnet_rad::run_aggregation_report(values, &aggregator)
+                    witnet_rad::run_aggregation_report(
+                        values,
+                        &aggregator,
+                        RadonScriptExecutionSettings::all_but_partial_results(),
+                    )
                 }
                 Ok(TallyPreconditionClauseResult::MajorityOfErrors { errors_mode }) => {
                     Ok(RadonReport::from_result(

--- a/node/src/actors/rad_manager/handlers.rs
+++ b/node/src/actors/rad_manager/handlers.rs
@@ -5,7 +5,7 @@ use futures::Future;
 use tokio::util::FutureExt;
 
 use witnet_data_structures::radon_report::{RadonReport, ReportContext};
-use witnet_rad::{error::RadError, types::RadonTypes};
+use witnet_rad::{error::RadError, script::RadonScriptExecutionSettings, types::RadonTypes};
 use witnet_validations::validations::{
     construct_report_from_clause_result, evaluate_tally_precondition_clause,
     TallyPreconditionClauseResult,
@@ -14,7 +14,6 @@ use witnet_validations::validations::{
 use crate::actors::messages::{ResolveRA, RunTally};
 
 use super::RadManager;
-use witnet_rad::script::RadonScriptExecutionSettings;
 
 impl Handler<ResolveRA> for RadManager {
     type Result = ResponseFuture<RadonReport<RadonTypes>, RadError>;

--- a/node/tests/data_request_examples.rs
+++ b/node/tests/data_request_examples.rs
@@ -6,6 +6,7 @@ use std::{
 };
 use witnet_data_structures::chain::DataRequestOutput;
 use witnet_node::actors::messages::BuildDrt;
+use witnet_rad::script::RadonScriptExecutionSettings;
 use witnet_rad::types::{
     float::RadonFloat, integer::RadonInteger, string::RadonString, RadonTypes,
 };
@@ -44,7 +45,11 @@ fn run_dr_locally_with_data(
     let mut retrieval_results = vec![];
     for (r, d) in dr.data_request.retrieve.iter().zip(data.iter()) {
         log::info!("Running retrieval for {}", r.url);
-        retrieval_results.push(witnet_rad::run_retrieval_with_data(r, (*d).to_string())?);
+        retrieval_results.push(witnet_rad::run_retrieval_with_data(
+            r,
+            (*d).to_string(),
+            RadonScriptExecutionSettings::disable_all(),
+        )?);
     }
 
     log::info!("Running aggregation with values {:?}", retrieval_results);

--- a/node/tests/data_request_examples.rs
+++ b/node/tests/data_request_examples.rs
@@ -49,7 +49,7 @@ fn run_dr_locally_with_data(
         log::info!("Running retrieval for {}", r.url);
         retrieval_results.push(witnet_rad::run_retrieval_with_data(
             r,
-            (*d).to_string(),
+            *d,
             RadonScriptExecutionSettings::disable_all(),
         )?);
     }

--- a/node/tests/data_request_examples.rs
+++ b/node/tests/data_request_examples.rs
@@ -1,14 +1,16 @@
-use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
     fs,
 };
+
+use serde::{Deserialize, Serialize};
+
 use witnet_data_structures::chain::DataRequestOutput;
 use witnet_node::actors::messages::BuildDrt;
-use witnet_rad::script::RadonScriptExecutionSettings;
-use witnet_rad::types::{
-    float::RadonFloat, integer::RadonInteger, string::RadonString, RadonTypes,
+use witnet_rad::{
+    script::RadonScriptExecutionSettings,
+    types::{float::RadonFloat, integer::RadonInteger, string::RadonString, RadonTypes},
 };
 
 /// Id. Can be null, a number, or a string

--- a/rad/Cargo.toml
+++ b/rad/Cargo.toml
@@ -15,7 +15,7 @@ json = "0.12.1"
 log = "0.4.8"
 num_enum = "0.4.2"
 reqwest = "0.10.1"
-serde = "1.0.104"
+serde = "1.0.111"
 serde_cbor = "0.11.1"
 surf = { version = "1.0.3", default-features = false, features = ["native-client"] }
 url = "2.1.1"

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -19,10 +19,16 @@ pub enum RadError {
     Unknown,
     /// Failed to decode a type from other
     #[fail(display = "Failed to decode {} from {}", to, from)]
-    Decode { from: String, to: String },
+    Decode {
+        from: &'static str,
+        to: &'static str,
+    },
     /// Failed to encode a type into other
     #[fail(display = "Failed to encode {} into {}", from, to)]
-    Encode { from: String, to: String },
+    Encode {
+        from: &'static str,
+        to: &'static str,
+    },
     /// Failed to calculate the hash of a RADON value or structure
     #[fail(display = "Failed to calculate the hash of a RADON value or structure")]
     Hash,
@@ -138,7 +144,7 @@ pub enum RadError {
         input_type, operator, args
     )]
     WrongArguments {
-        input_type: String,
+        input_type: &'static str,
         operator: String,
         args: Vec<SerdeCborValue>,
     },
@@ -179,8 +185,8 @@ pub enum RadError {
     )]
     MismatchingTypes {
         method: String,
-        expected: String,
-        found: String,
+        expected: &'static str,
+        found: &'static str,
     },
     /// Arrays to be reduced have different sizes
     #[fail(
@@ -598,8 +604,8 @@ impl From<std::str::ParseBoolError> for RadError {
 impl From<cbor::encoder::EncodeError> for RadError {
     fn from(_err: cbor::encoder::EncodeError) -> Self {
         RadError::Encode {
-            from: String::from("RadonTypes"),
-            to: String::from("CBOR"),
+            from: "RadonTypes",
+            to: "CBOR",
         }
     }
 }
@@ -607,8 +613,8 @@ impl From<cbor::encoder::EncodeError> for RadError {
 impl From<cbor::decoder::DecodeError> for RadError {
     fn from(_err: cbor::decoder::DecodeError) -> Self {
         RadError::Decode {
-            from: String::from("CBOR"),
-            to: String::from("RadonTypes"),
+            from: "CBOR",
+            to: "RadonTypes",
         }
     }
 }

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -87,7 +87,7 @@ pub async fn try_data_request(
 /// Run retrieval without performing any external network requests, return `RadonReport`.
 pub fn run_retrieval_with_data_report(
     retrieve: &RADRetrieve,
-    response: String,
+    response: &str,
     context: &mut ReportContext,
     settings: RadonScriptExecutionSettings,
 ) -> Result<RadonReport<RadonTypes>> {
@@ -104,7 +104,7 @@ pub fn run_retrieval_with_data_report(
 /// Run retrieval without performing any external network requests, return `RadonTypes`.
 pub fn run_retrieval_with_data(
     retrieve: &RADRetrieve,
-    response: String,
+    response: &str,
     settings: RadonScriptExecutionSettings,
 ) -> Result<RadonTypes> {
     let context = &mut ReportContext::default();
@@ -151,7 +151,7 @@ pub async fn run_retrieval_report(
                 })?;
 
             let result =
-                run_retrieval_with_data_report(retrieve, response_string, context, settings);
+                run_retrieval_with_data_report(retrieve, &response_string, context, settings);
 
             match &result {
                 Ok(report) => {
@@ -299,7 +299,7 @@ mod tests {
 
         let result = run_retrieval_with_data(
             &retrieve,
-            response.to_string(),
+            response,
             RadonScriptExecutionSettings::disable_all(),
         )
         .unwrap();
@@ -364,7 +364,7 @@ mod tests {
 
         let retrieved = run_retrieval_with_data(
             &retrieve,
-            response.to_string(),
+            response,
             RadonScriptExecutionSettings::disable_all(),
         )
         .unwrap();
@@ -397,7 +397,7 @@ mod tests {
 
         let retrieved = run_retrieval_with_data(
             &retrieve,
-            response.to_string(),
+            response,
             RadonScriptExecutionSettings::disable_all(),
         )
         .unwrap();
@@ -446,7 +446,7 @@ mod tests {
 
         let retrieved = run_retrieval_with_data(
             &retrieve,
-            response.to_string(),
+            response,
             RadonScriptExecutionSettings::disable_all(),
         )
         .unwrap();
@@ -486,7 +486,7 @@ mod tests {
 
         let retrieved = run_retrieval_with_data(
             &retrieve,
-            response.to_string(),
+            response,
             RadonScriptExecutionSettings::disable_all(),
         )
         .unwrap();
@@ -526,7 +526,7 @@ mod tests {
         let response = r#"{"event":{"homeTeam":{"name":"Ryazan-VDV","slug":"ryazan-vdv","gender":"F","national":false,"id":171120,"shortName":"Ryazan-VDV","subTeams":[]},"awayTeam":{"name":"Olympique Lyonnais","slug":"olympique-lyonnais","gender":"F","national":false,"id":26245,"shortName":"Lyon","subTeams":[]},"homeScore":{"current":0,"display":0,"period1":0,"normaltime":0},"awayScore":{"current":9,"display":9,"period1":5,"normaltime":9}}}"#;
         let retrieved = run_retrieval_with_data(
             &retrieve,
-            response.to_string(),
+            response,
             RadonScriptExecutionSettings::disable_all(),
         )
         .unwrap();

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -132,7 +132,16 @@ pub async fn run_retrieval_report(
             let result =
                 run_retrieval_with_data_report(retrieve, response_string, context, settings);
 
-            log::debug!("Result for URL {}: {:?}", retrieve.url, result);
+            match &result {
+                Ok(report) => {
+                    log::debug!(
+                        "Successful result for source {}: {:?}",
+                        retrieve.url,
+                        report.result
+                    );
+                }
+                Err(e) => log::debug!("Failed result for source {}: {:?}", retrieve.url, e),
+            }
 
             result
         }

--- a/rad/src/operators/array.rs
+++ b/rad/src/operators/array.rs
@@ -272,7 +272,7 @@ pub fn transpose(input: &RadonArray) -> Result<RadonArray, RadError> {
             }
             _ => {
                 return Err(RadError::MismatchingTypes {
-                    method: "RadonArray::transpose".to_string(),
+                    method: "T of RadonArray<T>::transpose".to_string(),
                     expected: RadonArray::radon_type_name(),
                     found: item.radon_type_name(),
                 });
@@ -413,7 +413,7 @@ mod tests {
 
         assert_eq!(
             &result.unwrap_err().to_string(),
-            "Mismatching types in RadonArray::transpose. Expected: RadonArray<RadonArray>, found: RadonArray<RadonFloat>",
+            "Mismatching types in T of RadonArray<T>::transpose. Expected: RadonArray, found: RadonFloat",
         );
     }
 
@@ -439,7 +439,7 @@ mod tests {
 
         assert_eq!(
             &result.unwrap_err().to_string(),
-            "Mismatching types in RadonArray::transpose. Expected: RadonArray<RadonArray>, found: RadonArray<RadonFloat>",
+            "Mismatching types in T of RadonArray<T>::transpose. Expected: RadonArray, found: RadonFloat",
         );
     }
 

--- a/rad/src/operators/array.rs
+++ b/rad/src/operators/array.rs
@@ -22,7 +22,7 @@ pub fn count(input: &RadonArray) -> RadonInteger {
 
 pub fn reduce(input: &RadonArray, args: &[Value]) -> Result<RadonTypes, RadError> {
     let wrong_args = || RadError::WrongArguments {
-        input_type: "RadonArray".to_string(),
+        input_type: RadonArray::radon_type_name(),
         operator: "Reduce".to_string(),
         args: args.to_vec(),
     };
@@ -40,7 +40,7 @@ pub fn reduce(input: &RadonArray, args: &[Value]) -> Result<RadonTypes, RadError
 
 pub fn get(input: &RadonArray, args: &[Value]) -> Result<RadonTypes, RadError> {
     let wrong_args = || RadError::WrongArguments {
-        input_type: "RadonArray".to_string(),
+        input_type: RadonArray::radon_type_name(),
         operator: "Get".to_string(),
         args: args.to_vec(),
     };
@@ -95,7 +95,7 @@ pub fn get_string(input: &RadonArray, args: &[Value]) -> Result<RadonString, Rad
 
 pub fn map(input: &RadonArray, args: &[Value]) -> Result<RadonTypes, RadError> {
     let wrong_args = || RadError::WrongArguments {
-        input_type: "RadonArray".to_string(),
+        input_type: RadonArray::radon_type_name(),
         operator: "Map".to_string(),
         args: args.to_vec(),
     };
@@ -130,7 +130,7 @@ pub fn filter(
     context: &mut ReportContext,
 ) -> Result<RadonTypes, RadError> {
     let wrong_args = || RadError::WrongArguments {
-        input_type: "RadonArray".to_string(),
+        input_type: RadonArray::radon_type_name(),
         operator: "Filter".to_string(),
         args: args.to_vec(),
     };
@@ -179,7 +179,7 @@ pub fn filter(
 
 pub fn sort(input: &RadonArray, args: &[Value]) -> Result<RadonArray, RadError> {
     let wrong_args = || RadError::WrongArguments {
-        input_type: "RadonArray".to_string(),
+        input_type: RadonArray::radon_type_name(),
         operator: "Sort".to_string(),
         args: args.to_vec(),
     };
@@ -271,11 +271,10 @@ pub fn transpose(input: &RadonArray) -> Result<RadonArray, RadError> {
                 }
             }
             _ => {
-                let radon_array_type_name = RadonArray::radon_type_name();
                 return Err(RadError::MismatchingTypes {
                     method: "RadonArray::transpose".to_string(),
-                    expected: format!("{}<{}>", radon_array_type_name, radon_array_type_name),
-                    found: format!("{}<{}>", radon_array_type_name, item.radon_type_name()),
+                    expected: RadonArray::radon_type_name(),
+                    found: item.radon_type_name(),
                 });
             }
         }
@@ -615,7 +614,7 @@ mod tests {
         let result = map(&input, &script);
 
         let expected_err = RadError::WrongArguments {
-            input_type: "RadonArray".to_string(),
+            input_type: "RadonArray",
             operator: "Map".to_string(),
             args: vec![],
         };
@@ -637,7 +636,7 @@ mod tests {
         let result = map(&input, &args);
 
         let expected_err = RadError::WrongArguments {
-            input_type: "RadonArray".to_string(),
+            input_type: "RadonArray",
             operator: "Map".to_string(),
             args,
         };
@@ -1180,7 +1179,7 @@ mod tests {
         let (input, index, _item) = radon_array_of_floats();
         let output = get_array(&input, &[Value::Integer(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonArray::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -1198,7 +1197,7 @@ mod tests {
         let (input, index, _item) = radon_array_of_floats();
         let output = get_boolean(&input, &[Value::Integer(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonBoolean::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -1216,7 +1215,7 @@ mod tests {
         let (input, index, _item) = radon_array_of_floats();
         let output = get_bytes(&input, &[Value::Integer(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonBytes::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -1234,7 +1233,7 @@ mod tests {
         let (input, index, _item) = radon_array_of_floats();
         let output = get_integer(&input, &[Value::Integer(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonInteger::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -1252,7 +1251,7 @@ mod tests {
         let (input, index, _item) = radon_array_of_arrays();
         let output = get_float(&input, &[Value::Integer(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonFloat::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -1270,7 +1269,7 @@ mod tests {
         let (input, index, _item) = radon_array_of_floats();
         let output = get_map(&input, &[Value::Integer(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonMap::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -1288,7 +1287,7 @@ mod tests {
         let (input, index, _item) = radon_array_of_floats();
         let output = get_string(&input, &[Value::Integer(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "serde_cbor::value::Value".to_string(),
+            from: "serde_cbor::value::Value",
             to: RadonString::radon_type_name(),
         };
         assert_eq!(output, expected_err);

--- a/rad/src/operators/map.rs
+++ b/rad/src/operators/map.rs
@@ -352,7 +352,7 @@ mod tests {
         let (input, index, _item) = radon_map_of_floats();
         let output = get_array(&input, &[Value::Text(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonArray::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -370,7 +370,7 @@ mod tests {
         let (input, index, _item) = radon_map_of_floats();
         let output = get_boolean(&input, &[Value::Text(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonBoolean::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -388,7 +388,7 @@ mod tests {
         let (input, index, _item) = radon_map_of_floats();
         let output = get_bytes(&input, &[Value::Text(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonBytes::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -406,7 +406,7 @@ mod tests {
         let (input, index, _item) = radon_map_of_booleans();
         let output = get_integer(&input, &[Value::Text(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonInteger::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -424,7 +424,7 @@ mod tests {
         let (input, index, _item) = radon_map_of_booleans();
         let output = get_float(&input, &[Value::Text(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonFloat::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -442,7 +442,7 @@ mod tests {
         let (input, index, _item) = radon_map_of_booleans();
         let output = get_map(&input, &[Value::Text(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonMap::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -460,7 +460,7 @@ mod tests {
         let (input, index, _item) = radon_map_of_booleans();
         let output = get_string(&input, &[Value::Text(index)]).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "serde_cbor::value::Value".to_string(),
+            from: "serde_cbor::value::Value",
             to: RadonString::radon_type_name(),
         };
         assert_eq!(output, expected_err);

--- a/rad/src/operators/mod.rs
+++ b/rad/src/operators/mod.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use num_enum::TryFromPrimitive;
+use serde::Serialize;
 
 use witnet_data_structures::radon_report::ReportContext;
 
@@ -17,7 +18,7 @@ pub mod string;
 /// List of RADON operators.
 /// **WARNING: these codes are consensus-critical.** They can be renamed but they cannot be
 /// re-assigned without causing a non-backwards-compatible protocol upgrade.
-#[derive(Copy, Clone, Debug, PartialEq, TryFromPrimitive)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, TryFromPrimitive)]
 #[repr(u8)]
 pub enum RadonOpCodes {
     /// Only for the sake of allowing catch-alls when matching
@@ -145,8 +146,9 @@ pub fn identity(input: RadonTypes) -> Result<RadonTypes, RadError> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::types::string::RadonString;
+
+    use super::*;
 
     #[test]
     pub fn test_identity() {

--- a/rad/src/operators/string.rs
+++ b/rad/src/operators/string.rs
@@ -67,7 +67,7 @@ pub fn to_uppercase(input: &RadonString) -> RadonString {
 
 pub fn hash(input: &RadonString, args: &[Value]) -> Result<RadonString, RadError> {
     let wrong_args = || RadError::WrongArguments {
-        input_type: "RadonString".to_string(),
+        input_type: RadonString::radon_type_name(),
         operator: "Hash".to_string(),
         args: args.to_vec(),
     };
@@ -88,7 +88,7 @@ pub fn hash(input: &RadonString, args: &[Value]) -> Result<RadonString, RadError
 
 pub fn string_match(input: &RadonString, args: &[Value]) -> Result<RadonTypes, RadError> {
     let wrong_args = || RadError::WrongArguments {
-        input_type: "RadonString".to_string(),
+        input_type: RadonString::radon_type_name(),
         operator: "String match".to_string(),
         args: args.to_vec(),
     };
@@ -165,7 +165,7 @@ mod tests {
         let json_array = RadonString::from(r#"[1,2,3]"#);
         let output = parse_json_map(&json_array).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonMap::radon_type_name(),
         };
         assert_eq!(output, expected_err);
@@ -198,7 +198,7 @@ mod tests {
         let json_map = RadonString::from(r#"{ "Hello": "world" }"#);
         let output = parse_json_array(&json_map).unwrap_err();
         let expected_err = RadError::Decode {
-            from: "cbor::value::Value".to_string(),
+            from: "cbor::value::Value",
             to: RadonArray::radon_type_name(),
         };
         assert_eq!(output, expected_err);

--- a/rad/src/script.rs
+++ b/rad/src/script.rs
@@ -273,16 +273,14 @@ fn test_execute_radon_script() {
     // Test contextful execution
     let mut context = ReportContext::default();
     let output = execute_radon_script(
-        input,
+        input.clone(),
         &script,
         &mut context,
         RadonScriptExecutionSettings::enable_all(),
     )
     .unwrap();
     let partial_expected = vec![
-        RadonTypes::from(RadonString::from(
-            r#"{"coord":{"lon":13.41,"lat":52.52},"weather":[{"id":600,"main":"Snow","description":"light snow","icon":"13n"}],"base":"stations","main":{"temp":-4,"pressure":1013,"humidity":73,"temp_min":-4,"temp_max":-4},"visibility":10000,"wind":{"speed":2.6,"deg":90},"clouds":{"all":75},"dt":1548346800,"sys":{"type":1,"id":1275,"message":0.0038,"country":"DE","sunrise":1548313160,"sunset":1548344298},"id":2950159,"name":"Berlin","cod":200}"#,
-        )),
+        input,
         RadonTypes::from(RadonMap::from(
             vec![
                 (

--- a/rad/src/script.rs
+++ b/rad/src/script.rs
@@ -25,9 +25,14 @@ pub type RadonScript = Vec<RadonCall>;
 /// metadata to collect.
 #[derive(Clone, Copy)]
 pub struct RadonScriptExecutionSettings {
-    pub partial_results: bool,
-    pub timing: bool,
+    /// Keep track of which call index is being executed in every moment, so that any error can be
+    /// pinpointed to a specific call in the script.
     pub breakpoints: bool,
+    /// Keep the result of each of the calls in the script, so that the full execution trace can be
+    /// reconstructed.
+    pub partial_results: bool,
+    /// Measure total execution time for the script.
+    pub timing: bool,
 }
 
 /// Default to enabling all execution features except `partial_results`.

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -1,4 +1,3 @@
-use serde::Serialize;
 use serde_cbor::value::{from_value, Value};
 use std::{
     convert::{TryFrom, TryInto},
@@ -16,7 +15,7 @@ use crate::{
 
 const RADON_ARRAY_TYPE_NAME: &str = "RadonArray";
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RadonArray {
     value: Vec<RadonTypes>,
     is_homogeneous: bool,

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -1,3 +1,4 @@
+use serde::Serialize;
 use serde_cbor::value::{from_value, Value};
 use std::{
     convert::{TryFrom, TryInto},
@@ -15,7 +16,7 @@ use crate::{
 
 pub const RADON_ARRAY_TYPE_NAME: &str = "RadonArray";
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct RadonArray {
     value: Vec<RadonTypes>,
     is_homogeneous: bool,

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -14,7 +14,7 @@ use crate::{
     types::{RadonType, RadonTypes},
 };
 
-pub const RADON_ARRAY_TYPE_NAME: &str = "RadonArray";
+const RADON_ARRAY_TYPE_NAME: &str = "RadonArray";
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct RadonArray {
@@ -33,8 +33,9 @@ impl RadonType<Vec<RadonTypes>> for RadonArray {
         self.value.clone()
     }
 
-    fn radon_type_name() -> String {
-        RADON_ARRAY_TYPE_NAME.to_string()
+    #[inline]
+    fn radon_type_name() -> &'static str {
+        RADON_ARRAY_TYPE_NAME
     }
 }
 
@@ -78,8 +79,8 @@ impl TryFrom<Value> for RadonArray {
                     .collect::<Vec<RadonTypes>>()
             })
             .map_err(|_| RadError::Decode {
-                from: "cbor::value::Value".to_string(),
-                to: RADON_ARRAY_TYPE_NAME.to_string(),
+                from: "cbor::value::Value",
+                to: RadonArray::radon_type_name(),
             })
             .map(Self::from)
     }

--- a/rad/src/types/boolean.rs
+++ b/rad/src/types/boolean.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use witnet_data_structures::radon_report::ReportContext;
 
-pub const RADON_BOOLEAN_TYPE_NAME: &str = "RadonBoolean";
+const RADON_BOOLEAN_TYPE_NAME: &str = "RadonBoolean";
 
 #[derive(Clone, Debug, PartialEq, Default, Serialize)]
 pub struct RadonBoolean {
@@ -30,8 +30,9 @@ impl RadonType<bool> for RadonBoolean {
         self.value
     }
 
-    fn radon_type_name() -> String {
-        RADON_BOOLEAN_TYPE_NAME.to_string()
+    #[inline]
+    fn radon_type_name() -> &'static str {
+        RADON_BOOLEAN_TYPE_NAME
     }
 }
 
@@ -41,8 +42,8 @@ impl TryFrom<Value> for RadonBoolean {
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         from_value::<bool>(value)
             .map_err(|_| RadError::Decode {
-                from: "cbor::value::Value".to_string(),
-                to: RADON_BOOLEAN_TYPE_NAME.to_string(),
+                from: "cbor::value::Value",
+                to: RadonBoolean::radon_type_name(),
             })
             .map(Self::from)
     }

--- a/rad/src/types/boolean.rs
+++ b/rad/src/types/boolean.rs
@@ -1,7 +1,6 @@
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 
-use serde::Serialize;
 use serde_cbor::value::{from_value, Value};
 
 use crate::{
@@ -14,7 +13,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 const RADON_BOOLEAN_TYPE_NAME: &str = "RadonBoolean";
 
-#[derive(Clone, Debug, PartialEq, Default, Serialize)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct RadonBoolean {
     value: bool,
 }

--- a/rad/src/types/boolean.rs
+++ b/rad/src/types/boolean.rs
@@ -1,6 +1,7 @@
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 
+use serde::Serialize;
 use serde_cbor::value::{from_value, Value};
 
 use crate::{
@@ -13,7 +14,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 pub const RADON_BOOLEAN_TYPE_NAME: &str = "RadonBoolean";
 
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq, Default, Serialize)]
 pub struct RadonBoolean {
     value: bool,
 }

--- a/rad/src/types/bytes.rs
+++ b/rad/src/types/bytes.rs
@@ -12,7 +12,7 @@ use std::{
 };
 use witnet_data_structures::radon_report::ReportContext;
 
-pub const RADON_BYTES_TYPE_NAME: &str = "RadonBytes";
+const RADON_BYTES_TYPE_NAME: &str = "RadonBytes";
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct RadonBytes {
@@ -30,8 +30,9 @@ impl RadonType<Vec<u8>> for RadonBytes {
         self.value.clone()
     }
 
-    fn radon_type_name() -> String {
-        RADON_BYTES_TYPE_NAME.to_string()
+    #[inline]
+    fn radon_type_name() -> &'static str {
+        RADON_BYTES_TYPE_NAME
     }
 }
 
@@ -40,8 +41,8 @@ impl TryFrom<Value> for RadonBytes {
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         let error = || RadError::Decode {
-            from: "cbor::value::Value".to_string(),
-            to: RADON_BYTES_TYPE_NAME.to_string(),
+            from: "cbor::value::Value",
+            to: RadonBytes::radon_type_name(),
         };
 
         match value {

--- a/rad/src/types/bytes.rs
+++ b/rad/src/types/bytes.rs
@@ -4,6 +4,7 @@ use crate::{
     script::RadonCall,
     types::{RadonType, RadonTypes},
 };
+use serde::Serialize;
 use serde_cbor::value::Value;
 use std::{
     convert::{TryFrom, TryInto},
@@ -13,7 +14,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 pub const RADON_BYTES_TYPE_NAME: &str = "RadonBytes";
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct RadonBytes {
     value: Vec<u8>,
 }

--- a/rad/src/types/bytes.rs
+++ b/rad/src/types/bytes.rs
@@ -4,7 +4,6 @@ use crate::{
     script::RadonCall,
     types::{RadonType, RadonTypes},
 };
-use serde::Serialize;
 use serde_cbor::value::Value;
 use std::{
     convert::{TryFrom, TryInto},
@@ -14,7 +13,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 const RADON_BYTES_TYPE_NAME: &str = "RadonBytes";
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct RadonBytes {
     value: Vec<u8>,
 }

--- a/rad/src/types/float.rs
+++ b/rad/src/types/float.rs
@@ -4,6 +4,7 @@ use std::{
     str::FromStr,
 };
 
+use serde::Serialize;
 use serde_cbor::value::Value;
 
 use crate::{
@@ -16,7 +17,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 pub const RADON_FLOAT_TYPE_NAME: &str = "RadonFloat";
 
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct RadonFloat {
     value: f64,
 }

--- a/rad/src/types/float.rs
+++ b/rad/src/types/float.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use witnet_data_structures::radon_report::ReportContext;
 
-pub const RADON_FLOAT_TYPE_NAME: &str = "RadonFloat";
+const RADON_FLOAT_TYPE_NAME: &str = "RadonFloat";
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct RadonFloat {
@@ -27,8 +27,9 @@ impl RadonType<f64> for RadonFloat {
         self.value
     }
 
-    fn radon_type_name() -> String {
-        RADON_FLOAT_TYPE_NAME.to_string()
+    #[inline]
+    fn radon_type_name() -> &'static str {
+        RADON_FLOAT_TYPE_NAME
     }
 }
 
@@ -39,8 +40,8 @@ impl TryFrom<Value> for RadonFloat {
     #[allow(clippy::cast_precision_loss)]
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         let error = || RadError::Decode {
-            from: "cbor::value::Value".to_string(),
-            to: RADON_FLOAT_TYPE_NAME.to_string(),
+            from: "cbor::value::Value",
+            to: RadonFloat::radon_type_name(),
         };
 
         match value {

--- a/rad/src/types/float.rs
+++ b/rad/src/types/float.rs
@@ -4,7 +4,6 @@ use std::{
     str::FromStr,
 };
 
-use serde::Serialize;
 use serde_cbor::value::Value;
 
 use crate::{
@@ -17,7 +16,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 const RADON_FLOAT_TYPE_NAME: &str = "RadonFloat";
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct RadonFloat {
     value: f64,
 }

--- a/rad/src/types/integer.rs
+++ b/rad/src/types/integer.rs
@@ -4,7 +4,6 @@ use std::{
     str::FromStr,
 };
 
-use serde::Serialize;
 use serde_cbor::value::Value;
 
 use crate::{
@@ -17,7 +16,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 const RADON_INTEGER_TYPE_NAME: &str = "RadonInteger";
 
-#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct RadonInteger {
     value: i128,
 }

--- a/rad/src/types/integer.rs
+++ b/rad/src/types/integer.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use witnet_data_structures::radon_report::ReportContext;
 
-pub const RADON_INTEGER_TYPE_NAME: &str = "RadonInteger";
+const RADON_INTEGER_TYPE_NAME: &str = "RadonInteger";
 
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct RadonInteger {
@@ -27,8 +27,9 @@ impl RadonType<i128> for RadonInteger {
         self.value
     }
 
-    fn radon_type_name() -> String {
-        RADON_INTEGER_TYPE_NAME.to_string()
+    #[inline]
+    fn radon_type_name() -> &'static str {
+        RADON_INTEGER_TYPE_NAME
     }
 }
 
@@ -37,8 +38,8 @@ impl TryFrom<Value> for RadonInteger {
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         let error = || RadError::Decode {
-            from: "cbor::value::Value".to_string(),
-            to: RADON_INTEGER_TYPE_NAME.to_string(),
+            from: "cbor::value::Value",
+            to: RadonInteger::radon_type_name(),
         };
 
         match value {

--- a/rad/src/types/integer.rs
+++ b/rad/src/types/integer.rs
@@ -4,6 +4,7 @@ use std::{
     str::FromStr,
 };
 
+use serde::Serialize;
 use serde_cbor::value::Value;
 
 use crate::{
@@ -16,7 +17,7 @@ use witnet_data_structures::radon_report::ReportContext;
 
 pub const RADON_INTEGER_TYPE_NAME: &str = "RadonInteger";
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Default)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct RadonInteger {
     value: i128,
 }

--- a/rad/src/types/map.rs
+++ b/rad/src/types/map.rs
@@ -4,7 +4,6 @@ use std::{
     fmt,
 };
 
-use serde::Serialize;
 use serde_cbor::value::{from_value, to_value, Value};
 
 use witnet_data_structures::radon_report::ReportContext;
@@ -18,7 +17,7 @@ use crate::{
 
 const RADON_MAP_TYPE_NAME: &str = "RadonMap";
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct RadonMap {
     value: HashMap<String, RadonTypes>,
 }

--- a/rad/src/types/map.rs
+++ b/rad/src/types/map.rs
@@ -1,9 +1,13 @@
-use serde_cbor::value::{from_value, to_value, Value};
 use std::{
     collections::{btree_map::BTreeMap, HashMap},
     convert::{TryFrom, TryInto},
     fmt,
 };
+
+use serde::Serialize;
+use serde_cbor::value::{from_value, to_value, Value};
+
+use witnet_data_structures::radon_report::ReportContext;
 
 use crate::{
     error::RadError,
@@ -11,11 +15,10 @@ use crate::{
     script::RadonCall,
     types::{RadonType, RadonTypes},
 };
-use witnet_data_structures::radon_report::ReportContext;
 
 pub const RADON_MAP_TYPE_NAME: &str = "RadonMap";
 
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct RadonMap {
     value: HashMap<String, RadonTypes>,
 }
@@ -163,9 +166,11 @@ impl Operable for RadonMap {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::types::integer::RadonInteger;
     use witnet_data_structures::radon_report::TypeLike;
+
+    use crate::types::integer::RadonInteger;
+
+    use super::*;
 
     #[test]
     fn test_operate_identity() {

--- a/rad/src/types/map.rs
+++ b/rad/src/types/map.rs
@@ -16,7 +16,7 @@ use crate::{
     types::{RadonType, RadonTypes},
 };
 
-pub const RADON_MAP_TYPE_NAME: &str = "RadonMap";
+const RADON_MAP_TYPE_NAME: &str = "RadonMap";
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize)]
 pub struct RadonMap {
@@ -28,8 +28,9 @@ impl RadonType<HashMap<String, RadonTypes>> for RadonMap {
         self.value.clone()
     }
 
-    fn radon_type_name() -> String {
-        RADON_MAP_TYPE_NAME.to_string()
+    #[inline]
+    fn radon_type_name() -> &'static str {
+        RADON_MAP_TYPE_NAME
     }
 }
 
@@ -52,8 +53,8 @@ impl TryFrom<Value> for RadonMap {
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         let error = |_| RadError::Decode {
-            from: "cbor::value::Value".to_string(),
-            to: RADON_MAP_TYPE_NAME.to_string(),
+            from: "cbor::value::Value",
+            to: RadonMap::radon_type_name(),
         };
 
         let hm = from_value::<HashMap<String, Value>>(value)
@@ -87,8 +88,8 @@ impl TryInto<Value> for RadonMap {
 
     fn try_into(self) -> Result<Value, Self::Error> {
         let error = || RadError::Encode {
-            from: RADON_MAP_TYPE_NAME.to_string(),
-            to: "cbor::value::Value".to_string(),
+            from: Self::radon_type_name(),
+            to: "cbor::value::Value",
         };
 
         let map = self

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use cbor::value::Value as CborValue;
+use serde::{Serialize, Serializer};
 use serde_cbor::{to_vec, Value};
 
 use witnet_crypto::hash::calculate_sha256;
@@ -146,6 +147,26 @@ impl TypeLike for RadonTypes {
                 }))
             }
             Ok(x) => x,
+        }
+    }
+}
+
+impl Serialize for RadonTypes {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        match &self {
+            RadonTypes::Array(radon_array) => serializer.collect_seq(radon_array.value().iter()),
+            RadonTypes::Boolean(radon_type) => serializer.serialize_bool(radon_type.value()),
+            RadonTypes::Bytes(radon_type) => {
+                serializer.serialize_bytes(radon_type.value().as_slice())
+            }
+            RadonTypes::RadonError(radon_error) => radon_error.serialize(serializer),
+            RadonTypes::Float(radon_type) => serializer.serialize_f64(radon_type.value()),
+            RadonTypes::Integer(radon_type) => serializer.serialize_i128(radon_type.value()),
+            RadonTypes::Map(radon_type) => serializer.collect_map(radon_type.value().iter()),
+            RadonTypes::String(radon_type) => serializer.serialize_str(&radon_type.value()),
         }
     }
 }

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -38,7 +38,7 @@ where
     T: fmt::Debug,
 {
     fn value(&self) -> T;
-    fn radon_type_name() -> String;
+    fn radon_type_name() -> &'static str;
 }
 
 #[derive(Clone, Debug)]
@@ -62,7 +62,7 @@ impl RadonTypes {
     }
 
     /// Returns the name of the internal type of a `RadonTypes` item.
-    pub fn radon_type_name(&self) -> String {
+    pub fn radon_type_name(&self) -> &'static str {
         match self {
             RadonTypes::Array(_) => RadonArray::radon_type_name(),
             RadonTypes::Boolean(_) => RadonBoolean::radon_type_name(),
@@ -73,7 +73,7 @@ impl RadonTypes {
             // `RadonError` does not implement `RadonType` nor `Operable` (it is not a type per se),
             // but exists inside `RadonTypes` for the sake of dealing with error encoding / decoding
             // in a more convenient way.
-            RadonTypes::RadonError(_) => String::from("RadonError"),
+            RadonTypes::RadonError(_) => "RadonError",
             RadonTypes::String(_) => RadonString::radon_type_name(),
         }
     }
@@ -282,12 +282,12 @@ impl TryFrom<Value> for RadonTypes {
             Value::Integer(_) => RadonInteger::try_from(value).map(Into::into),
             Value::Bytes(_) => RadonBytes::try_from(value).map(Into::into),
             Value::Null => Err(RadError::Decode {
-                from: String::from("serde_cbor::Value::Null"),
-                to: String::from("RadonTypes"),
+                from: "serde_cbor::Value::Null",
+                to: "RadonTypes",
             }),
             _ => Err(RadError::Decode {
-                from: String::from("serde_cbor::Value"),
-                to: String::from("RadonTypes"),
+                from: "serde_cbor::Value",
+                to: "RadonTypes",
             }),
         }
     }
@@ -345,14 +345,14 @@ impl TryFrom<RadonTypes> for Vec<u8> {
                     .encode_tagged_bytes()
                     .map_err(|_| RadError::Encode {
                         from: type_name,
-                        to: "Vec<u8>".to_string(),
+                        to: "Vec<u8>",
                     })
             }
             _ => {
                 let value: Value = radon_types.try_into()?;
                 to_vec(&value).map_err(|_| RadError::Encode {
                     from: type_name,
-                    to: "Vec<u8>".to_string(),
+                    to: "Vec<u8>",
                 })
             }
         }

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -156,18 +156,27 @@ impl Serialize for RadonTypes {
     where
         S: Serializer,
     {
+        use serde::ser::SerializeStruct;
+
+        let mut state = serializer.serialize_struct("RadonTypes", 2)?;
+        state.serialize_field("type", &self.radon_type_name())?;
         match &self {
-            RadonTypes::Array(radon_array) => serializer.collect_seq(radon_array.value().iter()),
-            RadonTypes::Boolean(radon_type) => serializer.serialize_bool(radon_type.value()),
-            RadonTypes::Bytes(radon_type) => {
-                serializer.serialize_bytes(radon_type.value().as_slice())
+            RadonTypes::Array(radon_type) => state.serialize_field("value", &radon_type.value())?,
+            RadonTypes::Boolean(radon_type) => {
+                state.serialize_field("value", &radon_type.value())?
             }
-            RadonTypes::RadonError(radon_error) => radon_error.serialize(serializer),
-            RadonTypes::Float(radon_type) => serializer.serialize_f64(radon_type.value()),
-            RadonTypes::Integer(radon_type) => serializer.serialize_i128(radon_type.value()),
-            RadonTypes::Map(radon_type) => serializer.collect_map(radon_type.value().iter()),
-            RadonTypes::String(radon_type) => serializer.serialize_str(&radon_type.value()),
+            RadonTypes::Bytes(radon_type) => state.serialize_field("value", &radon_type.value())?,
+            RadonTypes::RadonError(radon_error) => state.serialize_field("value", &radon_error)?,
+            RadonTypes::Float(radon_type) => state.serialize_field("value", &radon_type.value())?,
+            RadonTypes::Integer(radon_type) => {
+                state.serialize_field("value", &radon_type.value())?
+            }
+            RadonTypes::Map(radon_type) => state.serialize_field("value", &radon_type.value())?,
+            RadonTypes::String(radon_type) => {
+                state.serialize_field("value", &radon_type.value())?
+            }
         }
+        state.end()
     }
 }
 

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -158,22 +158,32 @@ impl Serialize for RadonTypes {
     {
         use serde::ser::SerializeStruct;
 
-        let mut state = serializer.serialize_struct("RadonTypes", 2)?;
-        state.serialize_field("type", &self.radon_type_name())?;
+        let mut state = serializer.serialize_struct("RadonTypes", 1)?;
+        let radon_type_name = self.radon_type_name();
         match &self {
-            RadonTypes::Array(radon_type) => state.serialize_field("value", &radon_type.value())?,
+            RadonTypes::Array(radon_type) => {
+                state.serialize_field(radon_type_name, &radon_type.value())?
+            }
             RadonTypes::Boolean(radon_type) => {
-                state.serialize_field("value", &radon_type.value())?
+                state.serialize_field(radon_type_name, &radon_type.value())?
             }
-            RadonTypes::Bytes(radon_type) => state.serialize_field("value", &radon_type.value())?,
-            RadonTypes::RadonError(radon_error) => state.serialize_field("value", &radon_error)?,
-            RadonTypes::Float(radon_type) => state.serialize_field("value", &radon_type.value())?,
+            RadonTypes::Bytes(radon_type) => {
+                state.serialize_field(radon_type_name, &radon_type.value())?
+            }
+            RadonTypes::RadonError(radon_error) => {
+                state.serialize_field(radon_type_name, &radon_error.inner())?
+            }
+            RadonTypes::Float(radon_type) => {
+                state.serialize_field(radon_type_name, &radon_type.value())?
+            }
             RadonTypes::Integer(radon_type) => {
-                state.serialize_field("value", &radon_type.value())?
+                state.serialize_field(radon_type_name, &radon_type.value())?
             }
-            RadonTypes::Map(radon_type) => state.serialize_field("value", &radon_type.value())?,
+            RadonTypes::Map(radon_type) => {
+                state.serialize_field(radon_type_name, &radon_type.value())?
+            }
             RadonTypes::String(radon_type) => {
-                state.serialize_field("value", &radon_type.value())?
+                state.serialize_field(radon_type_name, &radon_type.value())?
             }
         }
         state.end()

--- a/rad/src/types/string.rs
+++ b/rad/src/types/string.rs
@@ -3,7 +3,6 @@ use std::{
     fmt,
 };
 
-use serde::Serialize;
 use serde_cbor::value::{from_value, Value};
 
 use witnet_data_structures::radon_report::ReportContext;
@@ -17,7 +16,7 @@ use crate::{
 
 const RADON_STRING_TYPE_NAME: &str = "RadonString";
 
-#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 pub struct RadonString {
     value: String,
 }

--- a/rad/src/types/string.rs
+++ b/rad/src/types/string.rs
@@ -15,7 +15,7 @@ use crate::{
     types::{RadonType, RadonTypes},
 };
 
-pub const RADON_STRING_TYPE_NAME: &str = "RadonString";
+const RADON_STRING_TYPE_NAME: &str = "RadonString";
 
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct RadonString {
@@ -27,8 +27,9 @@ impl RadonType<String> for RadonString {
         self.value.clone()
     }
 
-    fn radon_type_name() -> String {
-        RADON_STRING_TYPE_NAME.to_string()
+    #[inline]
+    fn radon_type_name() -> &'static str {
+        RADON_STRING_TYPE_NAME
     }
 }
 
@@ -39,8 +40,8 @@ impl TryFrom<Value> for RadonString {
         from_value::<String>(value)
             .map(Self::from)
             .map_err(|_| RadError::Decode {
-                from: "serde_cbor::value::Value".to_string(),
-                to: RADON_STRING_TYPE_NAME.to_string(),
+                from: "serde_cbor::value::Value",
+                to: RadonString::radon_type_name(),
             })
     }
 }

--- a/rad/src/types/string.rs
+++ b/rad/src/types/string.rs
@@ -3,7 +3,10 @@ use std::{
     fmt,
 };
 
+use serde::Serialize;
 use serde_cbor::value::{from_value, Value};
+
+use witnet_data_structures::radon_report::ReportContext;
 
 use crate::{
     error::RadError,
@@ -11,11 +14,10 @@ use crate::{
     script::RadonCall,
     types::{RadonType, RadonTypes},
 };
-use witnet_data_structures::radon_report::ReportContext;
 
 pub const RADON_STRING_TYPE_NAME: &str = "RadonString";
 
-#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Default)]
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct RadonString {
     value: String,
 }

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -533,7 +533,11 @@ pub fn construct_report_from_clause_result(
     match clause_result {
         // The reveals passed the precondition clause (a parametric majority of them were successful
         // values). Run the tally, which will add more liars if any.
-        Ok(TallyPreconditionClauseResult::MajorityOfValues { values, liars }) => {
+        Ok(TallyPreconditionClauseResult::MajorityOfValues {
+            values,
+            liars,
+            errors,
+        }) => {
             let mut metadata = TallyMetaData::default();
             metadata.update_liars(vec![false; reports_len]);
 
@@ -554,20 +558,6 @@ pub fn construct_report_from_clause_result(
                 ),
             }
         }
-        Ok(TallyPreconditionClauseResult::MajorityOfValues {
-            values,
-            liars,
-            errors,
-        }) => match run_tally_report(values, script, Some(liars), Some(errors), settings) {
-            Ok(x) => x,
-            Err(e) => RadonReport::from_result(
-                Err(RadError::TallyExecution {
-                    inner: Some(Box::new(e)),
-                    message: None,
-                }),
-                &ReportContext::from_stage(Stage::Tally(metadata)),
-            ),
-        },
         // The reveals did not pass the precondition clause (a parametric majority of them were
         // errors). Tally will not be run, and the mode of the errors will be committed.
         Ok(TallyPreconditionClauseResult::MajorityOfErrors { errors_mode }) => {

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -36,4 +36,3 @@ witnet_validations = { path = "../validations" }
 
 [dev-dependencies]
 actix-rt = "1.1.1"
-serde_cbor = "0.11.1"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -33,3 +33,6 @@ witnet_crypto = { path = "../crypto", features = ["with-serde"] }
 witnet_protected = { path = "../protected", features = ["with-serde"] }
 witnet_data_structures = { path = "../data_structures" }
 witnet_validations = { path = "../validations" }
+
+[dev-dependencies]
+serde_cbor = "0.11.1"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -33,6 +33,3 @@ witnet_crypto = { path = "../crypto", features = ["with-serde"] }
 witnet_protected = { path = "../protected", features = ["with-serde"] }
 witnet_data_structures = { path = "../data_structures" }
 witnet_validations = { path = "../validations" }
-
-[dev-dependencies]
-actix-rt = "1.1.1"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -37,6 +37,3 @@ witnet_validations = { path = "../validations" }
 [dev-dependencies]
 actix-rt = "1.1.1"
 serde_cbor = "0.11.1"
-
-[features]
-side_effected = []

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -35,4 +35,8 @@ witnet_data_structures = { path = "../data_structures" }
 witnet_validations = { path = "../validations" }
 
 [dev-dependencies]
+actix-rt = "1.1.1"
 serde_cbor = "0.11.1"
+
+[features]
+side_effected = []

--- a/wallet/src/actors/app/handlers/run_rad_req.rs
+++ b/wallet/src/actors/app/handlers/run_rad_req.rs
@@ -1,5 +1,5 @@
 use actix::prelude::*;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 use crate::actors::app;
 use crate::types;
@@ -11,17 +11,7 @@ pub struct RunRadReqRequest {
 
 #[derive(Debug, Serialize)]
 pub struct RunRadReqResponse {
-    #[serde(serialize_with = "debug_serialize")]
     pub result: types::RadonReport<types::RadonTypes>,
-}
-
-// Serialize a type as a string, using its debug representation
-fn debug_serialize<S, T>(x: &T, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    T: std::fmt::Debug,
-{
-    s.serialize_str(&format!("{:?}", x))
 }
 
 impl Message for RunRadReqRequest {

--- a/wallet/src/actors/app/handlers/run_rad_req.rs
+++ b/wallet/src/actors/app/handlers/run_rad_req.rs
@@ -11,7 +11,7 @@ pub struct RunRadReqRequest {
 
 #[derive(Debug, Serialize)]
 pub struct RunRadReqResponse {
-    pub result: types::RadonReport<types::RadonTypes>,
+    pub result: types::RADRequestExecutionReport,
 }
 
 impl Message for RunRadReqRequest {

--- a/wallet/src/actors/app/methods.rs
+++ b/wallet/src/actors/app/methods.rs
@@ -160,7 +160,7 @@ impl App {
     pub fn run_rad_request(
         &self,
         req: types::RADRequest,
-    ) -> ResponseFuture<types::RadonReport<types::RadonTypes>> {
+    ) -> ResponseFuture<types::RADRequestExecutionReport> {
         let f = self
             .params
             .worker

--- a/wallet/src/actors/worker/handlers/run_rad_request.rs
+++ b/wallet/src/actors/worker/handlers/run_rad_request.rs
@@ -7,7 +7,7 @@ use crate::types;
 pub struct RunRadRequest(pub types::RADRequest);
 
 impl Message for RunRadRequest {
-    type Result = worker::Result<types::RadonReport<types::RadonTypes>>;
+    type Result = worker::Result<types::RADRequestExecutionReport>;
 }
 
 impl Handler<RunRadRequest> for worker::Worker {

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -4,6 +4,8 @@ use futures_util::compat::Compat01As03;
 use jsonrpc_core as rpc;
 use serde_json::json;
 
+use witnet_rad::script::RadonScriptExecutionSettings;
+
 use crate::types::{ChainEntry, CheckpointBeacon, DynamicSink, GetBlockChainParams, Hashable};
 use crate::{account, constants, crypto, db::Database as _, model, params};
 
@@ -40,7 +42,10 @@ impl Worker {
     ) -> types::RadonReport<types::RadonTypes> {
         // Block on data request retrieval because the wallet was designed with a blocking run retrieval in mind.
         // This can be made non-blocking by returning a future here and updating.
-        futures03::executor::block_on(witnet_rad::try_data_request(&request))
+        futures03::executor::block_on(witnet_rad::try_data_request(
+            &request,
+            RadonScriptExecutionSettings::enable_all(),
+        ))
     }
 
     pub fn gen_mnemonic(&self, length: types::MnemonicLength) -> String {

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -42,6 +42,7 @@ impl Worker {
         futures03::executor::block_on(witnet_rad::try_data_request(
             &request,
             RadonScriptExecutionSettings::enable_all(),
+            None,
         ))
     }
 

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -37,13 +37,7 @@ impl Worker {
     }
 
     pub fn run_rad_request(&self, request: types::RADRequest) -> types::RADRequestExecutionReport {
-        // Block on data request retrieval because the wallet was designed with a blocking run retrieval in mind.
-        // This can be made non-blocking by returning a future here and updating.
-        futures03::executor::block_on(witnet_rad::try_data_request(
-            &request,
-            RadonScriptExecutionSettings::enable_all(),
-            None,
-        ))
+        witnet_rad::try_data_request(&request, RadonScriptExecutionSettings::enable_all(), None)
     }
 
     pub fn gen_mnemonic(&self, length: types::MnemonicLength) -> String {

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -36,10 +36,7 @@ impl Worker {
         })
     }
 
-    pub fn run_rad_request(
-        &self,
-        request: types::RADRequest,
-    ) -> types::RadonReport<types::RadonTypes> {
+    pub fn run_rad_request(&self, request: types::RADRequest) -> types::RADRequestExecutionReport {
         // Block on data request retrieval because the wallet was designed with a blocking run retrieval in mind.
         // This can be made non-blocking by returning a future here and updating.
         futures03::executor::block_on(witnet_rad::try_data_request(

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -31,7 +31,7 @@ pub use witnet_data_structures::{
 };
 pub use witnet_net::client::tcp::jsonrpc::Request as RpcRequest;
 use witnet_protected::{Protected, ProtectedString};
-pub use witnet_rad::{error::RadError, types::RadonTypes};
+pub use witnet_rad::{error::RadError, types::RadonTypes, RADRequestExecutionReport};
 
 use crate::model;
 use crate::types::signature::Signature;

--- a/wallet/tests/data_requests.rs
+++ b/wallet/tests/data_requests.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+
+use serde_cbor::Value;
+
+use witnet_data_structures::{radon_error::RadonError, radon_report::ReportContext};
+use witnet_rad::{
+    error::RadError,
+    operators::RadonOpCodes,
+    script::{execute_radon_script, RadonScriptExecutionSettings},
+    types::{
+        array::RadonArray, boolean::RadonBoolean, bytes::RadonBytes, float::RadonFloat,
+        integer::RadonInteger, map::RadonMap, string::RadonString, RadonTypes,
+    },
+};
+
+#[test]
+fn test_radon_types_json_serialization() {
+    let radon_type = RadonTypes::from(RadonArray::from(vec![
+        RadonTypes::from(RadonString::from("foo")),
+        RadonTypes::from(RadonFloat::from(std::f64::consts::PI)),
+    ]));
+    let expected_json =
+        r#"{"RadonArray":[{"RadonString":"foo"},{"RadonFloat":3.141592653589793}]}"#;
+    assert_eq!(serde_json::to_string(&radon_type).unwrap(), expected_json);
+
+    let radon_type = RadonTypes::from(RadonBoolean::from(true));
+    let expected_json = r#"{"RadonBoolean":true}"#;
+    assert_eq!(serde_json::to_string(&radon_type).unwrap(), expected_json);
+
+    let radon_type = RadonTypes::from(RadonBytes::from(vec![1, 2, 3]));
+    let expected_json = r#"{"RadonBytes":[1,2,3]}"#;
+    assert_eq!(serde_json::to_string(&radon_type).unwrap(), expected_json);
+
+    let radon_type = RadonTypes::from(RadonFloat::from(std::f64::consts::PI));
+    let expected_json = r#"{"RadonFloat":3.141592653589793}"#;
+    assert_eq!(serde_json::to_string(&radon_type).unwrap(), expected_json);
+
+    let radon_type = RadonTypes::from(RadonInteger::from(42));
+    let expected_json = r#"{"RadonInteger":42}"#;
+    assert_eq!(serde_json::to_string(&radon_type).unwrap(), expected_json);
+
+    let radon_type = RadonTypes::from(RadonMap::from(
+        vec![(
+            String::from("foo"),
+            RadonTypes::from(RadonString::from("bar")),
+        )]
+        .iter()
+        .cloned()
+        .collect::<HashMap<String, RadonTypes>>(),
+    ));
+    let expected_json = r#"{"RadonMap":{"foo":{"RadonString":"bar"}}}"#;
+    assert_eq!(serde_json::to_string(&radon_type).unwrap(), expected_json);
+
+    let radon_type = RadonTypes::from(RadonString::from("foo"));
+    let expected_json = r#"{"RadonString":"foo"}"#;
+    assert_eq!(serde_json::to_string(&radon_type).unwrap(), expected_json);
+}
+
+#[test]
+fn test_radon_error_json_serialization() {
+    let radon_error = RadonTypes::RadonError(RadonError::new(RadError::default()));
+    let expected_json = r#"{"RadonError":"Unknown error"}"#;
+    assert_eq!(serde_json::to_string(&radon_error).unwrap(), expected_json);
+}
+
+#[test]
+/// This is a rather end-2-end test that applies a script on some JSON input and checks whether the
+/// final `RadonReport` complies with the Witnet Wallet API.
+fn test_data_request_report_json_serialization() {
+    let input = RadonTypes::from(RadonString::from(
+        r#"{"coord":{"lon":13.41,"lat":52.52},"weather":[{"id":600,"main":"Snow","description":"light snow","icon":"13n"}],"base":"stations","main":{"temp":-4,"pressure":1013,"humidity":73,"temp_min":-4,"temp_max":-4},"visibility":10000,"wind":{"speed":2.6,"deg":90},"clouds":{"all":75},"dt":1548346800,"sys":{"type":1,"id":1275,"message":0.0038,"country":"DE","sunrise":1548313160,"sunset":1548344298},"id":2950159,"name":"Berlin","cod":200}"#,
+    ));
+    let script = vec![
+        (RadonOpCodes::StringParseJSONMap, None),
+        (
+            RadonOpCodes::MapGetMap,
+            Some(vec![Value::Text(String::from("main"))]),
+        ),
+        (
+            RadonOpCodes::MapGetFloat,
+            Some(vec![Value::Text(String::from("temp"))]),
+        ),
+    ];
+    let mut context = ReportContext::default();
+    let report = execute_radon_script(
+        input,
+        &script,
+        &mut context,
+        RadonScriptExecutionSettings::enable_all(),
+    )
+    .unwrap();
+
+    let json = serde_json::ser::to_string(&report).unwrap();
+
+    assert_eq!(json, "");
+}

--- a/wallet/tests/data_requests.rs
+++ b/wallet/tests/data_requests.rs
@@ -1,12 +1,15 @@
 use std::collections::HashMap;
 
-use serde_cbor::Value;
-
-use witnet_data_structures::{radon_error::RadonError, radon_report::ReportContext};
+use witnet_data_structures::chain::RADType;
+use witnet_data_structures::{
+    chain::{RADAggregate, RADRequest, RADRetrieve, RADTally},
+    radon_error::RadonError,
+};
+use witnet_rad::script::unpack_radon_script;
 use witnet_rad::{
     error::RadError,
-    operators::RadonOpCodes,
-    script::{execute_radon_script, RadonScriptExecutionSettings},
+    script::RadonScriptExecutionSettings,
+    try_data_request,
     types::{
         array::RadonArray, boolean::RadonBoolean, bytes::RadonBytes, float::RadonFloat,
         integer::RadonInteger, map::RadonMap, string::RadonString, RadonTypes,

--- a/wallet/tests/data_requests.rs
+++ b/wallet/tests/data_requests.rs
@@ -69,7 +69,6 @@ fn test_radon_error_json_serialization() {
 /// This is a rather end-2-end test that applies a script on some JSON input and checks whether the
 /// final `RadonReport` complies with the Witnet Wallet API.
 #[actix_rt::test]
-#[cfg(feature = "side_effected")]
 async fn test_data_request_report_json_serialization() {
     let request = RADRequest {
         time_lock: 0,
@@ -98,7 +97,16 @@ async fn test_data_request_report_json_serialization() {
         },
     };
 
-    let report = try_data_request(&request, RadonScriptExecutionSettings::enable_all()).await;
+    let inputs = [
+        r#"{"high": "9897.46000000", "last": "9723.56", "timestamp": "1591720963", "bid": "9717.67", "vwap": "9711.68", "volume": "6279.09256801", "low": "9566.81000000", "ask": "9723.56", "open": 9786.64}"#,
+        r#"{"time":{"updated":"Jun 9, 2020 16:42:00 UTC","updatedISO":"2020-06-09T16:42:00+00:00","updateduk":"Jun 9, 2020 at 17:42 BST"},"disclaimer":"This data was produced from the CoinDesk Bitcoin Price Index (USD). Non-USD currency data converted using hourly conversion rate from openexchangerates.org","chartName":"Bitcoin","bpi":{"USD":{"code":"USD","symbol":"&#36;","rate":"9,724.8354","description":"United States Dollar","rate_float":9724.8354},"GBP":{"code":"GBP","symbol":"&pound;","rate":"7,692.6949","description":"British Pound Sterling","rate_float":7692.6949},"EUR":{"code":"EUR","symbol":"&euro;","rate":"8,635.1092","description":"Euro","rate_float":8635.1092}}}"#,
+    ];
+    let report = try_data_request(
+        &request,
+        RadonScriptExecutionSettings::enable_all(),
+        Some(&inputs),
+    )
+    .await;
     let aggregate_report = report.aggregate.clone();
     let tally_report = report.tally.clone();
 

--- a/wallet/tests/data_requests.rs
+++ b/wallet/tests/data_requests.rs
@@ -1,15 +1,8 @@
 use std::collections::HashMap;
 
-use witnet_data_structures::chain::RADType;
-use witnet_data_structures::{
-    chain::{RADAggregate, RADRequest, RADRetrieve, RADTally},
-    radon_error::RadonError,
-};
-use witnet_rad::script::unpack_radon_script;
+use witnet_data_structures::radon_error::RadonError;
 use witnet_rad::{
     error::RadError,
-    script::RadonScriptExecutionSettings,
-    try_data_request,
     types::{
         array::RadonArray, boolean::RadonBoolean, bytes::RadonBytes, float::RadonFloat,
         integer::RadonInteger, map::RadonMap, string::RadonString, RadonTypes,
@@ -68,8 +61,14 @@ fn test_radon_error_json_serialization() {
 
 /// This is a rather end-2-end test that applies a script on some JSON input and checks whether the
 /// final `RadonReport` complies with the Witnet Wallet API.
-#[actix_rt::test]
-async fn test_data_request_report_json_serialization() {
+#[test]
+fn test_data_request_report_json_serialization() {
+    use witnet_data_structures::chain::{RADAggregate, RADRequest, RADRetrieve, RADTally, RADType};
+    use witnet_rad::{
+        script::{unpack_radon_script, RadonScriptExecutionSettings},
+        try_data_request,
+    };
+
     let request = RADRequest {
         time_lock: 0,
         retrieve: vec![
@@ -105,8 +104,7 @@ async fn test_data_request_report_json_serialization() {
         &request,
         RadonScriptExecutionSettings::enable_all(),
         Some(&inputs),
-    )
-    .await;
+    );
 
     // Number of retrieval reports should match number of sources
     assert_eq!(report.retrieve.len(), request.retrieve.len());
@@ -135,12 +133,12 @@ async fn test_data_request_report_json_serialization() {
 
     // Number of aggregation partial results must equal number of filters + 2
     assert_eq!(
-        (&report).aggregate.partial_results.as_ref().unwrap().len(),
+        report.aggregate.partial_results.as_ref().unwrap().len(),
         &request.aggregate.filters.len() + 2
     );
     // Number of tally partial results must equal number of filters + 2
     assert_eq!(
-        (&report).tally.partial_results.as_ref().unwrap().len(),
+        report.tally.partial_results.as_ref().unwrap().len(),
         &request.tally.filters.len() + 2
     );
 

--- a/wallet/tests/data_requests.rs
+++ b/wallet/tests/data_requests.rs
@@ -107,11 +107,9 @@ async fn test_data_request_report_json_serialization() {
         Some(&inputs),
     )
     .await;
-    let aggregate_report = report.aggregate.clone();
-    let tally_report = report.tally.clone();
 
     // Number of retrieval reports should match number of sources
-    assert_eq!(&report.retrieve.len(), &request.retrieve.len());
+    assert_eq!(report.retrieve.len(), request.retrieve.len());
 
     for (index, retrieve_report) in report.retrieve.iter().enumerate() {
         // Each retrieval result must match last item in each retrieval partial results
@@ -119,7 +117,7 @@ async fn test_data_request_report_json_serialization() {
             &retrieve_report.result,
             retrieve_report
                 .partial_results
-                .clone()
+                .as_ref()
                 .unwrap()
                 .last()
                 .unwrap()
@@ -127,7 +125,7 @@ async fn test_data_request_report_json_serialization() {
 
         // Number of partial results for each source should match source's script length + 1
         assert_eq!(
-            retrieve_report.partial_results.clone().unwrap().len(),
+            retrieve_report.partial_results.as_ref().unwrap().len(),
             unpack_radon_script(&request.retrieve.get(index).unwrap().script)
                 .unwrap()
                 .len()
@@ -137,24 +135,24 @@ async fn test_data_request_report_json_serialization() {
 
     // Number of aggregation partial results must equal number of filters + 2
     assert_eq!(
-        report.aggregate.partial_results.unwrap().len(),
+        (&report).aggregate.partial_results.as_ref().unwrap().len(),
         &request.aggregate.filters.len() + 2
     );
     // Number of tally partial results must equal number of filters + 2
     assert_eq!(
-        report.tally.partial_results.unwrap().len(),
+        (&report).tally.partial_results.as_ref().unwrap().len(),
         &request.tally.filters.len() + 2
     );
 
     // Aggregation result must match last item in aggregation partial results
     assert_eq!(
         &report.aggregate.result,
-        aggregate_report.partial_results.unwrap().last().unwrap()
+        report.aggregate.partial_results.unwrap().last().unwrap()
     );
 
     // Tally result must match last item in tally partial results
     assert_eq!(
         &report.tally.result,
-        tally_report.partial_results.unwrap().last().unwrap()
+        report.tally.partial_results.unwrap().last().unwrap()
     );
 }


### PR DESCRIPTION
This avoids compilation errors when using `witnet_node` as a dependency or compiling it separately from other crates that already enable the `with-serde` feature:
![image](https://user-images.githubusercontent.com/1316439/84414050-bb004500-ac11-11ea-8d8d-8ea558be6810.png)
