### PR TITLE
Add synchronization progress to nodeStatus command

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -23,9 +23,10 @@ use crate::{
         messages::{
             AddBlocks, AddCandidates, AddCommitReveal, AddSuperBlockVote, AddTransaction,
             Broadcast, BuildDrt, BuildVtt, EpochNotification, GetBalance, GetBlocksEpochRange,
-            GetDataRequestReport, GetHighestCheckpointBeacon, GetMemoryTransaction, GetNodeStats,
-            GetReputation, GetReputationAll, GetReputationStatus, GetReputationStatusResult,
-            GetState, GetUtxoInfo, PeersBeacons, SendLastBeacon, SessionUnitResult, TryMineBlock,
+            GetDataRequestReport, GetHighestCheckpointBeacon, GetMemoryTransaction, GetMempool,
+            GetMempoolResult, GetNodeStats, GetReputation, GetReputationAll, GetReputationStatus,
+            GetReputationStatusResult, GetState, GetUtxoInfo, PeersBeacons, SendLastBeacon,
+            SessionUnitResult, TryMineBlock,
         },
         sessions_manager::SessionsManager,
     },
@@ -1145,6 +1146,19 @@ impl Handler<GetMemoryTransaction> for ChainManager {
 
     fn handle(&mut self, msg: GetMemoryTransaction, _ctx: &mut Self::Context) -> Self::Result {
         self.transactions_pool.get(&msg.hash).ok_or(())
+    }
+}
+
+impl Handler<GetMempool> for ChainManager {
+    type Result = Result<GetMempoolResult, failure::Error>;
+
+    fn handle(&mut self, _msg: GetMempool, _ctx: &mut Self::Context) -> Self::Result {
+        let res = GetMempoolResult {
+            value_transfer: self.transactions_pool.vt_iter().map(|t| t.hash()).collect(),
+            data_request: self.transactions_pool.dr_iter().map(|t| t.hash()).collect(),
+        };
+
+        Ok(res)
     }
 }
 

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -279,6 +279,23 @@ impl Message for GetReputationStatus {
     type Result = Result<GetReputationStatusResult, failure::Error>;
 }
 
+/// Get all the pending transactions
+#[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct GetMempool;
+
+impl Message for GetMempool {
+    type Result = Result<GetMempoolResult, failure::Error>;
+}
+
+/// Result of GetMempool message: list of pending transactions categorized by type
+#[derive(Serialize)]
+pub struct GetMempoolResult {
+    /// Pending value transfer transactions
+    pub value_transfer: Vec<Hash>,
+    /// Pending data request transactions
+    pub data_request: Vec<Hash>,
+}
+
 /// Try to mine a block: signal the ChainManager to check if it can produce a new block
 #[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TryMineBlock;


### PR DESCRIPTION
Close #1278 

Add synchronization progress to nodeStats command

```
Block mining stats:
- Proposed blocks: 0
- Blocks included in the block chain: 0
Data Request mining stats:
- Times with eligibility to mine a data request: 0
- Proposed commits: 0
- Accepted commits: 0
- Slashed commits: 0
Synchronization progress: 99.99% (186960/186964)
```

```
Block mining stats:
- Proposed blocks: 1
- Blocks included in the block chain: 0
Data Request mining stats:
- Times with eligibility to mine a data request: 0
- Proposed commits: 0
- Accepted commits: 0
- Slashed commits: 0
The node is synchronized and the current epoch is 186966
```