### PR TITLE
feat(node): disable superblock creation

### DIFF
--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -137,7 +137,7 @@ impl ChainManager {
 
         let superblock_period = u32::from(chain_info.consensus_constants.superblock_period);
         // Everyone creates superblocks, but only ARS members sign and broadcast them
-        if current_epoch % superblock_period == 0 {
+        if self.create_superblocks && current_epoch % superblock_period == 0 {
             // FIXME(#1236): ARS Members have to include the BLS signature instead of PublicKeyHash
             // FIXME: After Reputation Merkelitation, only the ARS Members from the previous consolidated
             // Superblock will be added, to avoid include addresses that could be wrong later by

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -190,6 +190,8 @@ pub struct ChainManager {
     external_percentage: u8,
     /// State related to SuperBlocks
     superblock_state: SuperBlockState,
+    /// Enable superblock creation
+    create_superblocks: bool,
 }
 
 /// Required trait for being able to retrieve ChainManager address from registry


### PR DESCRIPTION
This is a temporal workaround to reduce the message overhead in testnet 0.9.0c