### PR TITLE
refactor: remove some unnecessary clones

### DIFF
--- a/rad/src/reducers/mode.rs
+++ b/rad/src/reducers/mode.rs
@@ -36,7 +36,7 @@ pub fn mode(input: &RadonArray) -> Result<RadonTypes, RadError> {
             max_count: u16::try_from(*max_count).unwrap(),
         })
     } else {
-        Ok(mode_vector[0].clone())
+        Ok(mode_vector.into_iter().next().unwrap())
     }
 }
 

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -1797,7 +1797,7 @@ pub fn validate_candidate(
 /// Validate a standalone transaction received from the network
 #[allow(clippy::too_many_arguments)]
 pub fn validate_new_transaction(
-    transaction: Transaction,
+    transaction: &Transaction,
     (reputation_engine, unspent_outputs_pool, data_request_pool): (
         &ReputationEngine,
         &UnspentOutputsPool,


### PR DESCRIPTION
Change some functions in ChainManager to accept references to blocks and transactions, and change other functions that used to clone a reference into accept an owned value, removing the clone in some cases.

Also, replace

    x[0].clone()

with

    x.into_iter().next().unwrap()