### PR TITLE
feat(jsonrpc): implement addPeers method

### DIFF
--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -1190,12 +1190,9 @@ pub fn add_peers(params: Result<Vec<SocketAddr>, jsonrpc_core::Error>) -> JsonRp
         Ok(x) => x,
         Err(e) => return Box::new(futures::failed(e)),
     };
-    // Bucketing implementation needs to know the source address that sent us the peers
-    // Use localhost:21337, this way all the peers added using JSON-RPC will go to the same range
-    // of buckets
-    // TODO: do we want that all the peers added using JSON-RPC will go to the same range of buckets?
-    // Currently this means that it is impossible to add two ips with same address but different port, but that may be a bug
-    let src_address = "127.0.0.1:21337".parse().unwrap();
+    // Use None as the source address: this will make adding peers using this method be exactly the
+    // same as adding peers using the configuration file
+    let src_address = None;
     let peers_manager_addr = PeersManager::from_registry();
 
     let fut = peers_manager_addr

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -528,8 +528,9 @@ pub struct AddPeers {
     /// Addresses of the peer
     pub addresses: Vec<SocketAddr>,
 
-    /// Source address of the peer
-    pub src_address: SocketAddr,
+    /// Address of the peer that sent us this peers using the Peers protocol message, or None if
+    /// the peers were added from config or from command line
+    pub src_address: Option<SocketAddr>,
 }
 
 impl Message for AddPeers {

--- a/node/src/actors/peers_manager/actor.rs
+++ b/node/src/actors/peers_manager/actor.rs
@@ -40,7 +40,7 @@ impl Actor for PeersManager {
                     "Adding the following peer addresses from config: {:?}",
                     known_peers
                 );
-                match act.peers.add_to_new(known_peers.clone(), server_addr) {
+                match act.peers.add_to_new(known_peers.clone(), None) {
                     Ok(_duplicated_peers) => {}
                     Err(e) => log::error!("Error when adding peer addresses from config: {}", e),
                 }
@@ -57,7 +57,7 @@ impl Actor for PeersManager {
                         if let Some(peers_from_storage) = peers_from_storage {
                             // Add all the peers from storage
                             // The add method handles duplicates by overwriting the old values
-                            act.import_peers(peers_from_storage, known_peers, server_addr);
+                            act.import_peers(peers_from_storage, known_peers);
                         }
 
                         fut::ok(())

--- a/node/src/actors/peers_manager/mod.rs
+++ b/node/src/actors/peers_manager/mod.rs
@@ -66,15 +66,10 @@ impl PeersManager {
         });
     }
 
-    fn import_peers(
-        &mut self,
-        peers: Peers,
-        known_peers: Vec<SocketAddr>,
-        server_addr: SocketAddr,
-    ) {
+    fn import_peers(&mut self, peers: Peers, known_peers: Vec<SocketAddr>) {
         self.peers = peers;
 
-        match self.peers.add_to_new(known_peers, server_addr) {
+        match self.peers.add_to_new(known_peers, None) {
             Ok(_duplicated_peers) => {}
             Err(e) => log::error!("Error when adding peer addresses from config: {}", e),
         }

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -468,7 +468,7 @@ fn peer_discovery_peers(peers: &[Address], src_address: SocketAddr) {
     // Send AddPeers message to the peers manager
     peers_manager_addr.do_send(AddPeers {
         addresses,
-        src_address,
+        src_address: Some(src_address),
     });
 }
 

--- a/node/src/actors/sessions_manager/handlers.rs
+++ b/node/src/actors/sessions_manager/handlers.rs
@@ -208,7 +208,7 @@ impl Handler<Consolidate> for SessionsManager {
         if let Some(potential_new_peer) = msg.potential_new_peer {
             peers_manager_addr.do_send(AddPeers {
                 addresses: vec![potential_new_peer],
-                src_address: msg.address,
+                src_address: Some(msg.address),
             });
         }
 

--- a/p2p/src/peers/mod.rs
+++ b/p2p/src/peers/mod.rs
@@ -2,7 +2,12 @@
 
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
-use std::{cmp, collections::HashMap, fmt, net::SocketAddr};
+use std::{
+    cmp,
+    collections::HashMap,
+    fmt,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
 
 use rand::seq::IteratorRandom;
 use witnet_crypto::hash::calculate_sha256;
@@ -104,8 +109,14 @@ impl Peers {
     pub fn add_to_new(
         &mut self,
         addrs: Vec<SocketAddr>,
-        src_address: SocketAddr,
+        src_address: Option<SocketAddr>,
     ) -> Result<Vec<SocketAddr>, failure::Error> {
+        // If the source address that sent us this peer addresses is None, use the invalid address
+        // "0.0.0.0:0". This will make all the peer addresses that were added using manual methods
+        // go to the same buckets.
+        let src_address = src_address
+            .unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0));
+
         // Insert address
         // Note: if the peer address exists, the peer info will be overwritten
         let result = addrs

--- a/p2p/tests/peers.rs
+++ b/p2p/tests/peers.rs
@@ -11,7 +11,10 @@ fn p2p_peers_add_to_new() {
 
     // Add address
     let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-    let src_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 8080);
+    let src_address = Some(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+        8080,
+    ));
 
     assert_eq!(
         peers.add_to_new(vec![address], src_address).unwrap(),
@@ -64,7 +67,10 @@ fn p2p_peers_random() {
 
     // Add addresses
     let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-    let src_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 8080);
+    let src_address = Some(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+        8080,
+    ));
     let address2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3)), 8080);
 
     peers.add_to_new(vec![address], src_address).unwrap();
@@ -130,10 +136,13 @@ fn p2p_peers_remove_from_new_with_index() {
 
     // Add address
     let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-    let src_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(168, 0, 0, 12)), 8080);
+    let src_address = Some(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(168, 0, 0, 12)),
+        8080,
+    ));
     peers.add_to_new(vec![address], src_address).unwrap();
 
-    let index = peers.new_bucket_index(&address, &src_address);
+    let index = peers.new_bucket_index(&address, &src_address.unwrap());
 
     // Remove address
     assert_eq!(peers.remove_from_new_with_index(&[index]), vec![address]);
@@ -159,7 +168,10 @@ fn p2p_peers_get_all_from_new() {
     let many_peers: Vec<_> = (0..100)
         .map(|i| SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, i)), 8080))
         .collect();
-    let src_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(168, 0, 0, 12)), 8080);
+    let src_address = Some(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(168, 0, 0, 12)),
+        8080,
+    ));
     peers.add_to_new(many_peers, src_address).unwrap();
 
     assert!(!peers.get_all_from_new().unwrap().is_empty());

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -196,6 +196,9 @@ pub fn exec_cmd(
         Command::GetNodeStats { node } => {
             rpc::get_node_stats(node.unwrap_or(config.jsonrpc.server_address))
         }
+        Command::AddPeers { node, peers } => {
+            rpc::add_peers(node.unwrap_or(config.jsonrpc.server_address), peers)
+        }
     }
 }
 
@@ -513,6 +516,24 @@ pub enum Command {
         /// Socket address of the Witnet node to query
         #[structopt(short = "n", long = "node")]
         node: Option<SocketAddr>,
+    },
+    #[structopt(
+        name = "addPeers",
+        about = "Add new peer addresses for the node to try to connect to"
+    )]
+    AddPeers {
+        /// Socket address of the Witnet node to query
+        #[structopt(short = "n", long = "node")]
+        node: Option<SocketAddr>,
+        /// List of peer addresses for the node to try to connect to.
+        ///
+        /// Expected format: list of "address:port" separated by spaces:
+        ///
+        /// addPeers 52.166.178.145:21337 52.166.178.145:22337
+        ///
+        /// If no addresses are provided, read the addresses from stdin.
+        #[structopt(name = "peers")]
+        peers: Vec<SocketAddr>,
     },
 }
 


### PR DESCRIPTION
Implement addPeers JSON-RPC and CLI methods

CLI usage:

```
$ witnet node addPeers 52.166.178.145:21337 52.166.178.145:22337
Loading config from: witnet.toml
Setting log level to: DEBUG, source: Config
[2020-06-25T11:31:18Z DEBUG witnet_data_structures] Set environment to testnet
[2020-06-25T11:31:18Z INFO  witnet::cli::node::json_rpc_client] Connecting to JSON-RPC server at 127.0.0.1:21338
Successfully added peers: ["52.166.178.145:21337", "52.166.178.145:22337"]
```

If the command is called without any arguments, it will read the peers from standard input, so you can paste peer lists found online [like this one](https://gist.github.com/harsh-98/607c2f4ad94d7fdc95c0badb2731b36c)

The addPeers JSON-RPC method is considered "sensitive", so it will not work on public nodes. This is to prevent an attacker from flooding the node with its own peers.