### PR TITLE
Fix p2p small bugs

### DIFF
--- a/p2p/src/peers/mod.rs
+++ b/p2p/src/peers/mod.rs
@@ -234,7 +234,7 @@ impl Peers {
 
         // Run n experiments with probability of success 50% to obtain
         // the peers number required from the new bucket
-        let index_new_peers = (0..n_peers).fold(0, |acc, _| acc + rng.gen_range(0, 1));
+        let index_new_peers = (0..n_peers).fold(0, |acc, _| acc + rng.gen_range(0, 2));
         // Apply upper and lower limits to index_new_peers
         let index_new_peers = match index_new_peers {
             x if x < min_new_required => min_new_required,


### PR DESCRIPTION
Bug 1:
The peer selection strategy used before had a high probability of yielding 0 peers when asked for 1. Example: the node has 7 out of 8 peers, only 1 peer is missing:
Before: choose 1 random peer, filter out the already connected ones, connect to all that remain.
Now: choose 8 random peers, filter out the already connected ones, take 1 peer from those.

Bug 2:
When selecting a random peer, it is supposed to be 50% of being from tried bucket and 50% of being from new bucket. There was a bug where they were always selected from tried, and only selected from new if there are not enough tried.