### PR TITLE
feat(chain manager): update superblock while synchronizing

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -36,6 +36,7 @@ use crate::{
     },
     get_environment,
     proto::{schema::witnet, ProtobufConvert},
+    superblock::SuperBlockState,
     transaction::{
         CommitTransaction, DRTransaction, DRTransactionBody, MintTransaction, RevealTransaction,
         TallyTransaction, Transaction, VTTransaction,
@@ -596,7 +597,7 @@ impl SuperBlock {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Hash, ProtobufConvert)]
+#[derive(Debug, Eq, PartialEq, Clone, Hash, ProtobufConvert, Serialize, Deserialize)]
 #[protobuf_convert(pb = "witnet::SuperBlockVote")]
 pub struct SuperBlockVote {
     pub bn256_signature: Bn256Signature,
@@ -2681,6 +2682,8 @@ pub struct ChainState {
     pub last_ars: Vec<PublicKeyHash>,
     /// Last ARS keys vector ordered by reputation
     pub last_ars_ordered_keys: Vec<Bn256PublicKey>,
+    /// Current superblock state
+    pub superblock_state: SuperBlockState,
 }
 
 /// Alternative public key mapping: maps each secp256k1 public key hash to

--- a/data_structures/src/lib.rs
+++ b/data_structures/src/lib.rs
@@ -26,6 +26,10 @@ pub mod error;
 /// Module containing data_request structures
 pub mod data_request;
 
+// Module containing superblock
+
+pub mod superblock;
+
 /// Module containing transaction structures
 pub mod transaction;
 

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -386,6 +386,8 @@ impl Handler<AddBlocks> for ChainManager {
                             let block_epoch = block.block_header.beacon.checkpoint;
 
                             if self.create_superblocks && block_epoch % superblock_period == 0 {
+                                // Create superblocks while synchronizing but do not broadcast them
+                                // This is needed to ensure that we can validate the received superblocks later on
                                 self.construct_superblock(ctx, block_epoch)
                                     .and_then(move |_, _act, _ctx| actix::fut::ok(()))
                                     .wait(ctx);


### PR DESCRIPTION
This PR adds the functionality of building the superblock state while synchronizing to a new tip. This prevents a freshly synchronized node to forward a vote that it is not supposed to forward