### PR TITLE
fix(node): never add unverified addresses to tried bucket

### DIFF
--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -775,7 +775,7 @@ pub struct Consolidate {
     /// Potential peer to be added
     /// In their `Version` messages the nodes communicate the address of their server and that
     /// is a potential peer that should try to be added
-    pub potential_new_peer: SocketAddr,
+    pub potential_new_peer: Option<SocketAddr>,
 
     /// Session type
     pub session_type: SessionType,

--- a/node/src/actors/sessions_manager/handlers.rs
+++ b/node/src/actors/sessions_manager/handlers.rs
@@ -186,13 +186,15 @@ impl Handler<Consolidate> for SessionsManager {
             // Send AddConsolidatedPeer message to the peers manager
             // Try to add this potential peer in the tried addresses bucket
             peers_manager_addr.do_send(AddConsolidatedPeer {
-                address: msg.potential_new_peer,
+                address: msg.address,
             });
-        } else if msg.session_type == SessionType::Inbound {
-            // Send AddPeers message to the peers manager
-            // Try to add this potential peer in the new addresses bucket
+        }
+
+        // Send AddPeers message to the peers manager
+        // Try to add this potential peer in the new addresses bucket
+        if let Some(potential_new_peer) = msg.potential_new_peer {
             peers_manager_addr.do_send(AddPeers {
-                addresses: vec![msg.potential_new_peer],
+                addresses: vec![potential_new_peer],
                 src_address: msg.address,
             });
         }


### PR DESCRIPTION
Fix #1334 

It turns out this was not only an issue with the feeler, outbound connections had the same problem.