### PR TITLE
Several fixes to p2p / bucketing

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -222,6 +222,10 @@ pub struct Connections {
 
     /// Period that indicate the validity of a checked peer
     pub bucketing_update_period: i64,
+
+    /// Reject (tarpit) inbound connections coming from addresses in the same /16 IP range, so as
+    /// to prevent sybil peers from monopolizing our inbound capacity (128 by default).
+    pub reject_sybil_inbounds: bool,
 }
 
 fn from_millis<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
@@ -538,6 +542,10 @@ impl Connections {
                 .bucketing_update_period
                 .to_owned()
                 .unwrap_or_else(|| defaults.connections_bucketing_update_period()),
+            reject_sybil_inbounds: config
+                .reject_sybil_inbounds
+                .to_owned()
+                .unwrap_or_else(|| defaults.connections_reject_sybil_inbounds()),
         }
     }
 }
@@ -855,6 +863,7 @@ mod tests {
             blocks_timeout: Some(5),
             consensus_c: Some(51),
             bucketing_update_period: Some(200),
+            reject_sybil_inbounds: Some(false),
         };
         let config = Connections::from_partial(&partial_config, &Testnet);
 
@@ -872,6 +881,7 @@ mod tests {
         assert_eq!(config.handshake_max_ts_diff, 17);
         assert_eq!(config.consensus_c, 51);
         assert_eq!(config.bucketing_update_period, 200);
+        assert_eq!(config.reject_sybil_inbounds, false);
     }
 
     #[test]

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -81,6 +81,12 @@ pub trait Defaults {
         300
     }
 
+    /// Reject (tarpit) inbound connections coming from addresses in the same /16 IP range, so as
+    /// to prevent sybil peers from monopolizing our inbound capacity (128 by default).
+    fn connections_reject_sybil_inbounds(&self) -> bool {
+        true
+    }
+
     /// Timestamp at the start of epoch 0
     fn consensus_constants_checkpoint_zero_timestamp(&self) -> i64;
 

--- a/node/src/actors/connections_manager/handlers.rs
+++ b/node/src/actors/connections_manager/handlers.rs
@@ -32,7 +32,11 @@ impl Handler<OutboundTcpConnect> for ConnectionsManager {
             .send(ConnectAddr(msg.address))
             .into_actor(self)
             .then(move |res, _act, _ctx| {
-                ConnectionsManager::process_connect_addr_response(res, msg.session_type)
+                ConnectionsManager::process_connect_addr_response(
+                    res,
+                    msg.session_type,
+                    &msg.address,
+                )
             })
             .wait(ctx);
     }

--- a/node/src/actors/connections_manager/mod.rs
+++ b/node/src/actors/connections_manager/mod.rs
@@ -1,17 +1,19 @@
+use std::net::SocketAddr;
+
 use actix::prelude::*;
 use futures::Stream;
 use tokio::net::{TcpListener, TcpStream};
 
-use crate::actors::{
-    messages::{Create, InboundTcpConnect, ResolverResult},
-    sessions_manager::SessionsManager,
-};
-
-use crate::config_mngr;
-
-use crate::actors::peers_manager::PeersManager;
-use std::net::SocketAddr;
 use witnet_p2p::sessions::SessionType;
+
+use crate::{
+    actors::{
+        messages::{Create, InboundTcpConnect, ResolverResult},
+        sessions_manager::SessionsManager,
+    },
+    config_mngr,
+    peers_manager::PeersManager,
+};
 
 mod actor;
 mod handlers;

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -547,12 +547,12 @@ impl Message for AddConsolidatedPeer {
 }
 
 /// Message to remove one or more peer addresses from the list
-pub struct RemovePeers {
+pub struct RemoveAddressesFromTried {
     /// Address of the peer
     pub addresses: Vec<SocketAddr>,
 }
 
-impl Message for RemovePeers {
+impl Message for RemoveAddressesFromTried {
     type Result = PeersSocketAddrsResult;
 }
 

--- a/node/src/actors/peers_manager/handlers.rs
+++ b/node/src/actors/peers_manager/handlers.rs
@@ -3,7 +3,7 @@ use actix::{Context, Handler};
 use super::PeersManager;
 use crate::actors::messages::{
     AddConsolidatedPeer, AddPeers, GetKnownPeers, GetRandomPeers, PeersNewTried,
-    PeersSocketAddrResult, PeersSocketAddrsResult, RemovePeers, RequestPeers,
+    PeersSocketAddrResult, PeersSocketAddrsResult, RemoveAddressesFromTried, RequestPeers,
 };
 use witnet_util::timestamp::get_timestamp;
 
@@ -42,12 +42,14 @@ impl Handler<AddConsolidatedPeer> for PeersManager {
 }
 
 /// Handler for RemovePeers message
-impl Handler<RemovePeers> for PeersManager {
+impl Handler<RemoveAddressesFromTried> for PeersManager {
     type Result = PeersSocketAddrsResult;
 
-    fn handle(&mut self, msg: RemovePeers, _: &mut Context<Self>) -> Self::Result {
-        // Find index of element with address
-        log::debug!("Removing the following addresses: {:?}", msg.addresses);
+    fn handle(&mut self, msg: RemoveAddressesFromTried, _: &mut Context<Self>) -> Self::Result {
+        log::debug!(
+            "Removing the following addresses from `tried` buckets (if present): {:?}",
+            msg.addresses
+        );
         Ok(self.peers.remove_from_tried(&msg.addresses))
     }
 }

--- a/node/src/actors/peers_manager/mod.rs
+++ b/node/src/actors/peers_manager/mod.rs
@@ -5,6 +5,7 @@ use actix::{
     SystemService, WrapFuture,
 };
 
+use crate::actors::messages::RemoveAddressesFromTried;
 use crate::{
     actors::{connections_manager::ConnectionsManager, messages::OutboundTcpConnect, storage_keys},
     storage_mngr,
@@ -108,6 +109,15 @@ impl PeersManager {
             // Case peer updated recently ( do nothing )
             _ => {}
         }
+    }
+
+    /// Remove a peer address from the `tried` buckets if present.
+    pub fn remove_address_from_tried(address: &SocketAddr) {
+        let peers_manager_addr = PeersManager::from_registry();
+
+        peers_manager_addr.do_send(RemoveAddressesFromTried {
+            addresses: vec![*address],
+        });
     }
 
     /// Method to try peers periodically to move peers from new to tried

--- a/node/src/actors/peers_manager/mod.rs
+++ b/node/src/actors/peers_manager/mod.rs
@@ -5,13 +5,17 @@ use actix::{
     SystemService, WrapFuture,
 };
 
-use crate::actors::messages::RemoveAddressesFromTried;
-use crate::{
-    actors::{connections_manager::ConnectionsManager, messages::OutboundTcpConnect, storage_keys},
-    storage_mngr,
-};
 use witnet_p2p::{peers::Peers, sessions::SessionType};
 use witnet_util::timestamp::get_timestamp;
+
+use crate::{
+    actors::{
+        connections_manager::ConnectionsManager,
+        messages::{OutboundTcpConnect, RemoveAddressesFromTried},
+        storage_keys,
+    },
+    storage_mngr,
+};
 
 // Internal Actor implementation for PeersManager
 mod actor;

--- a/node/src/actors/sessions_manager/actor.rs
+++ b/node/src/actors/sessions_manager/actor.rs
@@ -22,7 +22,7 @@ impl Actor for SessionsManager {
                 let discovery_peers_period = config.connections.discovery_peers_period;
                 let consensus_constants = config.consensus_constants.clone();
 
-                // Set server address, connections limits and handshake timeout
+                // Set server address, connections limits, handshake timeout and optional features
                 act.sessions
                     .set_public_address(config.connections.public_addr);
                 act.sessions.set_limits(
@@ -35,6 +35,7 @@ impl Actor for SessionsManager {
                     .set_handshake_max_ts_diff(config.connections.handshake_max_ts_diff);
                 act.sessions
                     .set_blocks_timeout(config.connections.blocks_timeout);
+                act.sessions.reject_sybil_inbounds = config.connections.reject_sybil_inbounds;
 
                 // Initialized epoch from config
                 let mut checkpoints_period = config.consensus_constants.checkpoints_period;

--- a/node/src/actors/sessions_manager/handlers.rs
+++ b/node/src/actors/sessions_manager/handlers.rs
@@ -68,7 +68,7 @@ impl Handler<Create> for SessionsManager {
         // Refuse creating multiple inbound sessions for similar IP ranges
         // This is guarded once here and again when consolidating, just to mitigate a possible race
         // condition
-        if msg.session_type == SessionType::Inbound {
+        if self.sessions.reject_sybil_inbounds && msg.session_type == SessionType::Inbound {
             if let Some(range) = self.sessions.is_similar_to_inbound_session(&remote_addr) {
                 log::debug!("Refusing to accept {} as inbound peer because there is already an inbound session with another peer in IP range {}", remote_addr, ip_range_string(range));
                 return;

--- a/p2p/src/error.rs
+++ b/p2p/src/error.rs
@@ -11,6 +11,15 @@ pub enum SessionsError {
     /// Errors when registering sessions. Address already registered in sessions
     #[fail(display = "Register failed. Address already registered in sessions")]
     AddressAlreadyRegistered,
+    /// Errors when registering sessions. Address in same IP range already registered in sessions
+    #[fail(
+        display = "Register failed. Address in same IP range ({}) already registered in sessions",
+        range
+    )]
+    AddressInSameRangeAlreadyRegistered {
+        /// A string representing the IP range for which a session already existed
+        range: String,
+    },
     /// Errors when unregistering sessions.
     #[fail(display = "Address could not be unregistered (not found in sessions)")]
     AddressNotFound,

--- a/p2p/src/peers/mod.rs
+++ b/p2p/src/peers/mod.rs
@@ -118,7 +118,7 @@ impl Peers {
                     let index = self.tried_bucket_index(&address);
                     let elem = self.tried_bucket.get(&index);
 
-                    // If the index point to the same address that it is already
+                    // If the index points to the same address that it is already
                     // in tried, we don't include in new bucket
                     if elem.is_none() || (elem.unwrap().address != address) {
                         let index = self.new_bucket_index(&address, &src_address);
@@ -181,11 +181,14 @@ impl Peers {
         let v = addrs
             .iter()
             .filter_map(|address| {
-                let index = self.tried_bucket_index(&address);
-                let elem = self.tried_bucket.get(&index);
+                let bucket_index = self.tried_bucket_index(&address);
+                let bucket_entry = self.tried_bucket.get(&bucket_index);
 
-                if elem.is_some() && (elem.unwrap().address == *address) {
-                    self.tried_bucket.remove(&index)
+                if bucket_entry
+                    .filter(|entry| entry.address == *address)
+                    .is_some()
+                {
+                    self.tried_bucket.remove(&bucket_index)
                 } else {
                     None
                 }

--- a/p2p/src/peers/mod.rs
+++ b/p2p/src/peers/mod.rs
@@ -178,7 +178,7 @@ impl Peers {
     /// Remove a peer given an address from tried addresses bucket
     /// Returns the removed addresses
     pub fn remove_from_tried(&mut self, addrs: &[SocketAddr]) -> Vec<SocketAddr> {
-        let v = addrs
+        addrs
             .iter()
             .filter_map(|address| {
                 let bucket_index = self.tried_bucket_index(&address);
@@ -188,17 +188,15 @@ impl Peers {
                     .filter(|entry| entry.address == *address)
                     .is_some()
                 {
+                    log::trace!("Removed a tried peer address: \n{}", self);
+
                     self.tried_bucket.remove(&bucket_index)
                 } else {
                     None
                 }
             })
             .map(|info| info.address)
-            .collect();
-
-        log::trace!("Removed a tried peer: \n{}", self);
-
-        v
+            .collect()
     }
 
     /// Remove a peer given an index from new addresses bucket

--- a/p2p/src/peers/mod.rs
+++ b/p2p/src/peers/mod.rs
@@ -316,7 +316,7 @@ impl fmt::Display for Peers {
 }
 
 /// Returns the ip and ip split
-fn split_socket_addresses(socket_addr: &SocketAddr) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+pub fn split_socket_addresses(socket_addr: &SocketAddr) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
     match socket_addr {
         SocketAddr::V4(addr) => {
             let ip = addr.ip().octets();
@@ -346,7 +346,7 @@ fn split_socket_addresses(socket_addr: &SocketAddr) -> (Vec<u8>, Vec<u8>, Vec<u8
 /// Slot = Hash( SK, Host_ID, i ) % 64
 ///
 /// Index = Bucket * Slot
-fn calculate_index_for_tried(sk: u64, ip: &[u8], group: &[u8], host_id: &[u8]) -> u16 {
+pub fn calculate_index_for_tried(sk: u64, ip: &[u8], group: &[u8], host_id: &[u8]) -> u16 {
     let sk = sk.to_be_bytes();
 
     let data = [&sk, ip].concat();
@@ -375,7 +375,7 @@ fn calculate_index_for_tried(sk: u64, ip: &[u8], group: &[u8], host_id: &[u8]) -
 /// Slot = Hash( SK, Host_ID, i ) % 64
 ///
 /// Index = Bucket * Slot
-fn calculate_index_for_new(sk: u64, src_group: &[u8], group: &[u8], host_id: &[u8]) -> u16 {
+pub fn calculate_index_for_new(sk: u64, src_group: &[u8], group: &[u8], host_id: &[u8]) -> u16 {
     let sk = sk.to_be_bytes();
 
     let data = [&sk, src_group, group].concat();

--- a/p2p/src/sessions/mod.rs
+++ b/p2p/src/sessions/mod.rs
@@ -137,24 +137,35 @@ where
     }
     /// Method to check if a socket address is eligible as outbound peer
     pub fn is_outbound_address_eligible(&self, candidate_addr: SocketAddr) -> bool {
-        // Check if address is already used as outbound session (consolidated or unconsolidated)
-        let is_outbound_consolidated = self
+        // Check if address is already used as consolidated outbound session
+        if self
             .outbound_consolidated
             .collection
-            .contains_key(&candidate_addr);
-        let is_outbound_unconsolidated = self
+            .contains_key(&candidate_addr)
+        {
+            return false;
+        }
+
+        // Check if address is already used as unconsolidated outbound session
+        if self
             .outbound_unconsolidated
             .collection
-            .contains_key(&candidate_addr);
+            .contains_key(&candidate_addr)
+        {
+            return false;
+        }
 
         // Check if address is the server address
-        let is_server = self
+        if self
             .public_address
             .map(|address| address == candidate_addr)
-            .unwrap_or(false);
+            .unwrap_or(false)
+        {
+            return false;
+        }
 
         // Return true if the address has not been used as outbound session or server address
-        !is_outbound_consolidated && !is_outbound_unconsolidated && !is_server
+        true
     }
     /// Method to get total number of outbound peers
     pub fn get_num_outbound_sessions(&self) -> usize {

--- a/p2p/src/sessions/mod.rs
+++ b/p2p/src/sessions/mod.rs
@@ -67,6 +67,9 @@ where
     pub outbound_unconsolidated: BoundedSessions<T>,
     /// Server public address listening to incoming connections
     pub public_address: Option<SocketAddr>,
+    /// Reject (tarpit) inbound connections coming from addresses in the same /16 IP range, so as
+    /// to prevent sybil peers from monopolizing our inbound capacity (128 by default).
+    pub reject_sybil_inbounds: bool,
 }
 
 /// Default trait implementation
@@ -87,6 +90,7 @@ where
             outbound_consolidated_consensus: BoundedSessions::default(),
             outbound_unconsolidated: BoundedSessions::default(),
             public_address: None,
+            reject_sybil_inbounds: true,
         }
     }
 }

--- a/p2p/tests/buckets.rs
+++ b/p2p/tests/buckets.rs
@@ -1,0 +1,176 @@
+use std::net::SocketAddr;
+
+use witnet_p2p::peers::{
+    calculate_index_for_new, calculate_index_for_tried, split_socket_addresses,
+};
+
+/// Tests for the business logic of inserting peer addresses into the `new` buckets.
+mod new {
+    use super::{ip, new_bucket_index};
+
+    #[test]
+    fn test_same_peer_ip_different_peer_port_same_new_bucket_index() {
+        let sk = 0;
+        let src_addr = ip("127.0.0.1:21337");
+        let peer_addr_21337 = ip("192.168.1.1:21337");
+        let peer_addr_21338 = ip("192.168.1.1:21338");
+
+        let new_index_21337 = new_bucket_index(sk, &peer_addr_21337, &src_addr);
+        let new_index_21338 = new_bucket_index(sk, &peer_addr_21338, &src_addr);
+
+        assert_eq!(new_index_21337, new_index_21338);
+    }
+
+    #[test]
+    fn test_close_peer_ip_same_new_bucket_different_index() {
+        let sk = 0;
+        let src_addr = ip("127.0.0.1:21337");
+        let peer_addr_1_1 = ip("192.168.1.1:21337");
+        let peer_addr_2_1 = ip("192.168.2.1:21337");
+
+        let new_index_1_1 = new_bucket_index(sk, &peer_addr_1_1, &src_addr);
+        let new_index_2_1 = new_bucket_index(sk, &peer_addr_2_1, &src_addr);
+
+        assert_ne!(new_index_1_1, new_index_2_1);
+        assert!((f64::from(new_index_1_1) - f64::from(new_index_2_1)).abs() < 64.0);
+    }
+
+    #[test]
+    fn test_same_peer_address_same_source_ip_different_source_port_same_new_index() {
+        let sk = 0;
+        let src_addr_21337 = ip("127.0.0.1:21337");
+        let src_addr_21338 = ip("127.0.0.1:21338");
+        let peer_addr = ip("192.168.1.1:21337");
+
+        let new_index_1_1 = new_bucket_index(sk, &peer_addr, &src_addr_21337);
+        let new_index_2_1 = new_bucket_index(sk, &peer_addr, &src_addr_21338);
+
+        assert_eq!(new_index_1_1, new_index_2_1);
+    }
+
+    #[test]
+    fn test_same_peer_address_close_source_ip_same_source_port_same_new_bucket_same_index() {
+        let sk = 0;
+        let src_addr_0_1 = ip("127.0.0.1:21337");
+        let src_addr_1_1 = ip("127.0.1.1:21337");
+        let peer_addr = ip("192.168.1.1:21337");
+
+        let new_index_0_1 = new_bucket_index(sk, &peer_addr, &src_addr_0_1);
+        let new_index_1_1 = new_bucket_index(sk, &peer_addr, &src_addr_1_1);
+
+        assert_eq!(new_index_0_1, new_index_1_1);
+    }
+
+    #[test]
+    fn test_same_peer_address_different_source_ip_same_source_port_different_new_bucket() {
+        let sk = 0;
+        let src_addr_0_0_1 = ip("127.0.0.1:21337");
+        let src_addr_1_0_1 = ip("127.1.0.1:21337");
+        let peer_addr = ip("192.168.1.1:21337");
+
+        let new_index_0_0_1 = new_bucket_index(sk, &peer_addr, &src_addr_0_0_1);
+        let new_index_1_0_1 = new_bucket_index(sk, &peer_addr, &src_addr_1_0_1);
+
+        assert_ne!(new_index_0_0_1, new_index_1_0_1);
+    }
+
+    #[test]
+    fn test_different_sk_different_bucket() {
+        let sk_1 = 1;
+        let sk_2 = 2;
+        let src_addr = ip("127.0.0.1:21337");
+        let peer_addr = ip("192.168.1.1:21337");
+
+        let new_index_sk_1 = new_bucket_index(sk_1, &peer_addr, &src_addr);
+        let new_index_sk_2 = new_bucket_index(sk_2, &peer_addr, &src_addr);
+
+        assert_ne!(new_index_sk_1, new_index_sk_2);
+    }
+}
+
+/// Tests for the business logic of inserting peer addresses into the `tried` buckets.
+mod tried {
+    use super::{ip, tried_bucket_index};
+
+    #[test]
+    fn test_same_peer_ip_different_peer_port_same_tried_bucket_different_index() {
+        let sk = 0;
+        let peer_addr_21337 = ip("192.168.1.1:21337");
+        let peer_addr_21338 = ip("192.168.1.1:21338");
+
+        let new_index_21337 = tried_bucket_index(sk, &peer_addr_21337);
+        let new_index_21338 = tried_bucket_index(sk, &peer_addr_21338);
+
+        assert_ne!(new_index_21337, new_index_21338);
+        assert!((f64::from(new_index_21337) - f64::from(new_index_21338)).abs() < 64.0);
+    }
+
+    #[test]
+    fn test_close_peer_ip_same_tried_bucket_different_index() {
+        let sk = 0;
+        let peer_addr_1_1 = ip("192.168.1.1:21337");
+        let peer_addr_1_2 = ip("192.168.1.2:21337");
+
+        let new_index_1_1 = tried_bucket_index(sk, &peer_addr_1_1);
+        let new_index_1_2 = tried_bucket_index(sk, &peer_addr_1_2);
+
+        assert_ne!(new_index_1_1, new_index_1_2);
+        assert!((f64::from(new_index_1_1) - f64::from(new_index_1_2)).abs() < 64.0);
+    }
+
+    #[test]
+    fn test_slightly_far_peer_ip_different_tried_bucket_different_index() {
+        let sk = 0;
+        let peer_addr_1_1 = ip("192.168.1.1:21337");
+        let peer_addr_2_1 = ip("192.168.2.1:21337");
+
+        let new_index_1_1 = tried_bucket_index(sk, &peer_addr_1_1);
+        let new_index_2_1 = tried_bucket_index(sk, &peer_addr_2_1);
+
+        assert_ne!(new_index_1_1, new_index_2_1);
+        assert!((f64::from(new_index_1_1) - f64::from(new_index_2_1)).abs() < 1024.0);
+    }
+
+    #[test]
+    fn test_much_far_peer_ip_different_tried_bucket_different_index() {
+        let sk = 0;
+        let peer_addr_168 = ip("192.168.1.1:21337");
+        let peer_addr_169 = ip("192.169.1.1:21337");
+
+        let new_index_168 = tried_bucket_index(sk, &peer_addr_168);
+        let new_index_169 = tried_bucket_index(sk, &peer_addr_169);
+
+        assert_ne!(new_index_168, new_index_169);
+    }
+
+    #[test]
+    fn test_different_sk_different_bucket() {
+        let sk_1 = 1;
+        let sk_2 = 2;
+        let peer_addr = ip("192.168.1.1:21337");
+
+        let new_index_sk_1 = tried_bucket_index(sk_1, &peer_addr);
+        let new_index_sk_2 = tried_bucket_index(sk_2, &peer_addr);
+
+        assert_ne!(new_index_sk_1, new_index_sk_2);
+    }
+}
+
+fn new_bucket_index(sk: u64, socket_addr: &SocketAddr, src_socket_addr: &SocketAddr) -> u16 {
+    let (_, group, host_id) = split_socket_addresses(socket_addr);
+    let (_, src_group, _) = split_socket_addresses(src_socket_addr);
+
+    calculate_index_for_new(sk, &src_group, &group, &host_id)
+}
+
+fn tried_bucket_index(sk: u64, socket_addr: &SocketAddr) -> u16 {
+    let (ip, group, host_id) = split_socket_addresses(socket_addr);
+
+    calculate_index_for_tried(sk, &ip, &group, &host_id)
+}
+
+fn ip(string: &str) -> SocketAddr {
+    use std::str::FromStr;
+
+    SocketAddr::from_str(string).unwrap()
+}

--- a/p2p/tests/lib.rs
+++ b/p2p/tests/lib.rs
@@ -1,3 +1,6 @@
+/// Buckets tests
+pub mod buckets;
+
 /// Peers library tests
 pub mod peers;
 

--- a/witnet.toml
+++ b/witnet.toml
@@ -77,6 +77,9 @@ known_peers = [
 outbound_limit = 16
 # Period for opening new peer connections while the current number of peers is lower than `outbound_limit`.
 bootstrap_peers_period_seconds = 1
+# Reject (tarpit) inbound connections coming from addresses in the same /16 IP range, so as to prevent sybil peers from
+# monopolizing our inbound capacity (128 by default).
+reject_sybil_inbounds = true
 
 [storage]
 # Path of the folder where RocksDB storage files will be written to.


### PR DESCRIPTION
Namely:
- fix(p2p): evict peer addresses from `tried` buckets upon connection failure
- refactor(p2p): improve readability of `remove_from_tried`
- tests(p2p): add tests for new and tried buckets
- refactor(p2p): avoid redundant hashmap lookups
- feat(node): refuse creating multiple inbound sessions for similar IP ranges