### PR TITLE
Check beacon during handshake

### DIFF
--- a/data_structures/src/builders.rs
+++ b/data_structures/src/builders.rs
@@ -59,7 +59,7 @@ impl Message {
         magic: u16,
         sender_addr: Option<SocketAddr>,
         receiver_addr: SocketAddr,
-        last_epoch: u32,
+        beacon: LastBeacon,
     ) -> Message {
         let addr = sender_addr.map(to_address);
         Message::build_message(
@@ -71,8 +71,8 @@ impl Message {
                 sender_address: addr.unwrap_or_default(),
                 receiver_address: to_address(receiver_addr),
                 user_agent: USER_AGENT.to_string(),
-                last_epoch,
                 nonce: random_nonce(),
+                beacon,
             }),
         )
     }

--- a/data_structures/src/types.rs
+++ b/data_structures/src/types.rs
@@ -112,9 +112,8 @@ pub struct Version {
     pub sender_address: Address,
     pub receiver_address: Address,
     pub user_agent: String,
-    // TODO(#888): last_epoch assessment
-    pub last_epoch: u32,
     pub nonce: u64,
+    pub beacon: LastBeacon,
 }
 
 ///////////////////////////////////////////////////////////

--- a/data_structures/tests/builders.rs
+++ b/data_structures/tests/builders.rs
@@ -105,7 +105,12 @@ fn builders_build_peers() {
 #[test]
 fn builders_build_version() {
     // Expected message (except nonce which is random and timestamp which is the current one)
-    let hardcoded_last_epoch = 1234;
+    let hardcoded_beacon = LastBeacon {
+        highest_block_checkpoint: CheckpointBeacon {
+            hash_prev_block: Hash::SHA256([4; 32]),
+            checkpoint: 7,
+        },
+    };
     let sender_addr = Address {
         ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
         port: 8000,
@@ -121,8 +126,8 @@ fn builders_build_version() {
         sender_address: sender_addr,
         receiver_address: receiver_addr,
         user_agent: USER_AGENT.to_string(),
-        last_epoch: hardcoded_last_epoch,
         nonce: 1234,
+        beacon: hardcoded_beacon.clone(),
     });
     let msg = Message {
         kind: version_cmd,
@@ -136,7 +141,7 @@ fn builders_build_version() {
         0xABCD,
         Some(sender_sock_addr),
         receiver_sock_addr,
-        hardcoded_last_epoch,
+        hardcoded_beacon.clone(),
     );
 
     // Check that the build_version function builds the expected message
@@ -148,7 +153,7 @@ fn builders_build_version() {
             sender_address,
             receiver_address,
             user_agent,
-            last_epoch,
+            beacon,
             ..
         }) => assert!(
             *version == PROTOCOL_VERSION
@@ -156,7 +161,7 @@ fn builders_build_version() {
                 && *sender_address == sender_addr
                 && *receiver_address == receiver_addr
                 && user_agent == USER_AGENT
-                && *last_epoch == hardcoded_last_epoch
+                && *beacon == hardcoded_beacon
         ),
         _ => panic!("Some field/s do not match the expected value"),
     };

--- a/data_structures/tests/serializers.rs
+++ b/data_structures/tests/serializers.rs
@@ -207,6 +207,12 @@ fn message_verack_encode_decode() {
 
 #[test]
 fn message_version_to_bytes() {
+    let beacon = LastBeacon {
+        highest_block_checkpoint: CheckpointBeacon {
+            hash_prev_block: Hash::SHA256([4; 32]),
+            checkpoint: 7,
+        },
+    };
     let sender_address = Address {
         ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
         port: 8000,
@@ -223,15 +229,16 @@ fn message_version_to_bytes() {
             sender_address,
             receiver_address,
             user_agent: "asdf".to_string(),
-            last_epoch: 8,
             nonce: 1,
+            beacon,
         }),
         magic: 1,
     };
     let expected_buf: Vec<u8> = [
-        8, 1, 18, 55, 10, 53, 8, 2, 16, 123, 25, 4, 0, 0, 0, 0, 0, 0, 0, 34, 8, 10, 6, 192, 168, 1,
-        1, 31, 64, 42, 8, 10, 6, 192, 168, 1, 2, 31, 65, 50, 4, 97, 115, 100, 102, 61, 8, 0, 0, 0,
-        65, 1, 0, 0, 0, 0, 0, 0, 0,
+        8, 1, 18, 95, 10, 93, 8, 2, 16, 123, 25, 4, 0, 0, 0, 0, 0, 0, 0, 34, 8, 10, 6, 192, 168, 1,
+        1, 31, 64, 42, 8, 10, 6, 192, 168, 1, 2, 31, 65, 50, 4, 97, 115, 100, 102, 57, 1, 0, 0, 0,
+        0, 0, 0, 0, 66, 43, 10, 41, 13, 7, 0, 0, 0, 18, 34, 10, 32, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     ]
     .to_vec();
     let result: Vec<u8> = msg.to_pb_bytes().unwrap();
@@ -241,6 +248,12 @@ fn message_version_to_bytes() {
 
 #[test]
 fn message_version_from_bytes() {
+    let beacon = LastBeacon {
+        highest_block_checkpoint: CheckpointBeacon {
+            hash_prev_block: Hash::SHA256([4; 32]),
+            checkpoint: 7,
+        },
+    };
     let sender_address = Address {
         ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
         port: 8000,
@@ -257,16 +270,17 @@ fn message_version_from_bytes() {
             sender_address,
             receiver_address,
             user_agent: "asdf".to_string(),
-            last_epoch: 8,
             nonce: 1,
+            beacon,
         }),
         magic: 1,
     };
 
     let buf: Vec<u8> = [
-        8, 1, 18, 55, 10, 53, 8, 2, 16, 123, 25, 4, 0, 0, 0, 0, 0, 0, 0, 34, 8, 10, 6, 192, 168, 1,
-        1, 31, 64, 42, 8, 10, 6, 192, 168, 1, 2, 31, 65, 50, 4, 97, 115, 100, 102, 61, 8, 0, 0, 0,
-        65, 1, 0, 0, 0, 0, 0, 0, 0,
+        8, 1, 18, 95, 10, 93, 8, 2, 16, 123, 25, 4, 0, 0, 0, 0, 0, 0, 0, 34, 8, 10, 6, 192, 168, 1,
+        1, 31, 64, 42, 8, 10, 6, 192, 168, 1, 2, 31, 65, 50, 4, 97, 115, 100, 102, 57, 1, 0, 0, 0,
+        0, 0, 0, 0, 66, 43, 10, 41, 13, 7, 0, 0, 0, 18, 34, 10, 32, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
     ]
     .to_vec();
 
@@ -275,6 +289,12 @@ fn message_version_from_bytes() {
 
 #[test]
 fn message_version_encode_decode() {
+    let beacon = LastBeacon {
+        highest_block_checkpoint: CheckpointBeacon {
+            hash_prev_block: Hash::SHA256([4; 32]),
+            checkpoint: 7,
+        },
+    };
     let sender_address = Address {
         ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
         port: 8000,
@@ -291,8 +311,8 @@ fn message_version_encode_decode() {
             sender_address,
             receiver_address,
             user_agent: "asdf".to_string(),
-            last_epoch: 8,
             nonce: 1,
+            beacon,
         }),
         magic: 1,
     };

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -5,7 +5,8 @@ use super::{handlers::EveryEpochPayload, ChainManager};
 use crate::{
     actors::{
         epoch_manager::{EpochManager, EpochManagerError::CheckpointZeroInTheFuture},
-        messages::{AddBlocks, GetEpoch, GetEpochConstants, Subscribe},
+        messages::{AddBlocks, GetEpoch, GetEpochConstants, SetLastBeacon, Subscribe},
+        sessions_manager::SessionsManager,
         storage_keys,
     },
     config_mngr, signature_mngr, storage_mngr,
@@ -17,6 +18,7 @@ use witnet_data_structures::{
         OwnUnspentOutputsPool, PublicKeyHash, ReputationEngine,
     },
     data_request::DataRequestPool,
+    types::LastBeacon,
     vrf::VrfCtx,
 };
 use witnet_util::timestamp::pretty_print;
@@ -210,6 +212,12 @@ impl ChainManager {
                         });
                     }
                 }
+
+                SessionsManager::from_registry().do_send(SetLastBeacon {
+                    beacon: LastBeacon {
+                        highest_block_checkpoint: chain_info.highest_block_checkpoint,
+                    },
+                });
 
                 act.chain_state = chain_state;
                 act.last_chain_state = act.chain_state.clone();

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -53,8 +53,7 @@ use crate::{
         json_rpc::JsonRpcServer,
         messages::{
             AddItems, AddTransaction, Anycast, Broadcast, GetBlocksEpochRange, GetItemBlock,
-            NewBlock, SendInventoryItem, SendLastBeacon, SendSuperBlockVote, SetLastBeacon,
-            StoreInventoryItem,
+            NewBlock, SendInventoryItem, SendLastBeacon, SendSuperBlockVote, StoreInventoryItem,
         },
         sessions_manager::SessionsManager,
         storage_keys,
@@ -73,7 +72,6 @@ use witnet_data_structures::{
     radon_report::{RadonReport, ReportContext},
     superblock::AddSuperBlockVote,
     transaction::{TallyTransaction, Transaction},
-    types::LastBeacon,
     vrf::VrfCtx,
 };
 
@@ -495,12 +493,6 @@ impl ChainManager {
                 // Update beacon and vrf output
                 chain_info.highest_block_checkpoint = beacon;
                 chain_info.highest_vrf_output = vrf_input;
-
-                SessionsManager::from_registry().do_send(SetLastBeacon {
-                    beacon: LastBeacon {
-                        highest_block_checkpoint: chain_info.highest_block_checkpoint,
-                    },
-                });
 
                 // Store the ARS and the order of the keys
                 let trs = reputation_engine.trs();

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -53,7 +53,8 @@ use crate::{
         json_rpc::JsonRpcServer,
         messages::{
             AddItems, AddTransaction, Anycast, Broadcast, GetBlocksEpochRange, GetItemBlock,
-            NewBlock, SendInventoryItem, SendLastBeacon, SendSuperBlockVote, StoreInventoryItem,
+            NewBlock, SendInventoryItem, SendLastBeacon, SendSuperBlockVote, SetLastBeacon,
+            StoreInventoryItem,
         },
         sessions_manager::SessionsManager,
         storage_keys,
@@ -72,6 +73,7 @@ use witnet_data_structures::{
     radon_report::{RadonReport, ReportContext},
     superblock::AddSuperBlockVote,
     transaction::{TallyTransaction, Transaction},
+    types::LastBeacon,
     vrf::VrfCtx,
 };
 
@@ -493,6 +495,12 @@ impl ChainManager {
                 // Update beacon and vrf output
                 chain_info.highest_block_checkpoint = beacon;
                 chain_info.highest_vrf_output = vrf_input;
+
+                SessionsManager::from_registry().do_send(SetLastBeacon {
+                    beacon: LastBeacon {
+                        highest_block_checkpoint: chain_info.highest_block_checkpoint,
+                    },
+                });
 
                 // Store the ARS and the order of the keys
                 let trs = reputation_engine.trs();

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -23,6 +23,7 @@ use witnet_data_structures::{
     },
     radon_report::RadonReport,
     transaction::{CommitTransaction, RevealTransaction, Transaction},
+    types::LastBeacon,
 };
 use witnet_p2p::{
     error::SessionsError,
@@ -865,6 +866,17 @@ pub struct LogMessage {
 
 impl Message for LogMessage {
     type Result = SessionsUnitResult;
+}
+
+/// Set the LastBeacon
+#[derive(Clone, Debug)]
+pub struct SetLastBeacon {
+    /// Current tip of the chain
+    pub beacon: LastBeacon,
+}
+
+impl Message for SetLastBeacon {
+    type Result = ();
 }
 
 // JsonRpcServer messages (notifications)

--- a/node/src/actors/session/actor.rs
+++ b/node/src/actors/session/actor.rs
@@ -40,7 +40,7 @@ impl Actor for Session {
                 self.magic_number,
                 self.public_addr,
                 self.remote_addr,
-                self.current_epoch,
+                self.last_beacon.clone(),
             );
             self.send_message(version_msg);
             // Set HandshakeFlag of sent version message
@@ -84,7 +84,7 @@ impl Actor for Session {
                             act.magic_number,
                             act.public_addr,
                             act.remote_addr,
-                            act.current_epoch,
+                            act.last_beacon.clone(),
                         );
                         act.send_message(version_msg);
                         // Set HandshakeFlag of sent version message

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -601,7 +601,7 @@ fn handshake_version(session: &mut Session, sender_address: &Address) -> Vec<Wit
             session.magic_number,
             session.public_addr,
             session.remote_addr,
-            session.current_epoch,
+            session.last_beacon.clone(),
         );
         responses.push(version);
     }

--- a/node/src/actors/session/mod.rs
+++ b/node/src/actors/session/mod.rs
@@ -9,7 +9,7 @@ use tokio::{io::WriteHalf, net::TcpStream};
 use witnet_data_structures::{
     chain::{Block, Epoch, Hash},
     proto::ProtobufConvert,
-    types::{Command, Message as WitnetMessage},
+    types::{Command, LastBeacon, Message as WitnetMessage},
 };
 use witnet_p2p::sessions::{SessionStatus, SessionType};
 
@@ -72,6 +72,9 @@ pub struct Session {
     /// Current epoch
     current_epoch: Epoch,
 
+    /// Current top of the chain
+    last_beacon: LastBeacon,
+
     /// Requested block hashes vector
     requested_block_hashes: Vec<Hash>,
 
@@ -102,6 +105,7 @@ impl Session {
         blocks_timeout: i64,
         handshake_max_ts_diff: i64,
         current_epoch: Epoch,
+        last_beacon: LastBeacon,
     ) -> Session {
         Session {
             public_addr,
@@ -114,6 +118,7 @@ impl Session {
             remote_sender_addr: None,
             magic_number,
             current_epoch,
+            last_beacon,
             requested_block_hashes: vec![],
             requested_blocks: HashMap::new(),
             blocks_timeout,

--- a/node/src/actors/sessions_manager/mod.rs
+++ b/node/src/actors/sessions_manager/mod.rs
@@ -23,7 +23,10 @@ use crate::actors::{
 };
 use failure::Fail;
 use std::collections::HashSet;
-use witnet_data_structures::chain::{Epoch, EpochConstants};
+use witnet_data_structures::{
+    chain::{Epoch, EpochConstants},
+    types::LastBeacon,
+};
 
 mod actor;
 mod beacons;
@@ -40,6 +43,9 @@ pub struct SessionsManager {
     epoch_constants: Option<EpochConstants>,
     // Current epoch
     current_epoch: Epoch,
+    // Current tip of the chain, used to check if outbound peers are in consensus when connecting
+    // Note that the sessions manager will not be able to create any sessions if this field is None
+    last_beacon: Option<LastBeacon>,
     // Logging message hashset
     logging_messages: HashSet<String>,
 }

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -30,8 +30,8 @@ message Version {
     Address sender_address = 4;
     Address receiver_address = 5;
     string user_agent = 6;
-    fixed32 last_epoch = 7;
-    fixed64 nonce = 8;
+    fixed64 nonce = 7;
+    LastBeacon beacon = 8;
 }
 
 message Verack {


### PR DESCRIPTION
Close #1348

BREAKING CHANGE

This PR adds a `LastBeacon` field to the `Version` message. This field is used in the handshake to ensure that a node never connects to outbound peers whose beacon is behind its own, or whose beacon has a different block hash. This is also used by the feeler process to ensure that the peers that are added to tried are in consensus with the node.