### PR TITLE
Almost synched if no consensus

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -790,7 +790,7 @@ impl Handler<PeersBeacons> for ChainManager {
                 // we need to rewind one epoch
                 if pb_len == 0 {
                     log::warn!("[CONSENSUS]: We have not received any beacons for this epoch");
-                    self.sm_state = StateMachine::WaitingConsensus;
+                    self.sm_state = StateMachine::AlmostSynced;
                 }
 
                 let our_beacon = self.get_chain_beacon();
@@ -809,7 +809,7 @@ impl Handler<PeersBeacons> for ChainManager {
                         self.initialize_from_storage(ctx);
                         log::info!("Restored chain state from storage");
 
-                        self.sm_state = StateMachine::WaitingConsensus;
+                        self.sm_state = StateMachine::AlmostSynced;
 
                         Ok(peers_to_unregister)
                     }
@@ -821,7 +821,7 @@ impl Handler<PeersBeacons> for ChainManager {
                             our_beacon
                         );
 
-                        self.sm_state = StateMachine::WaitingConsensus;
+                        self.sm_state = StateMachine::AlmostSynced;
 
                         // Unregister all peers to try to obtain a new set of trustworthy peers
                         Ok(peers_to_unregister)


### PR DESCRIPTION
This PR:

- Goes to almost synced state if while synched we lost consensus on our peers.
- While in almost synced state, if drops only peers whose beacons are different from ours.

Close #1351 
Close #1349 