### PR TITLE
feat(session manager): Signal superblock beacon

### DIFF
--- a/data_structures/src/builders.rs
+++ b/data_structures/src/builders.rs
@@ -143,11 +143,16 @@ impl Message {
     }
 
     /// Function to build LastBeacon messages
-    pub fn build_last_beacon(magic: u16, highest_block_checkpoint: CheckpointBeacon) -> Message {
+    pub fn build_last_beacon(
+        magic: u16,
+        highest_block_checkpoint: CheckpointBeacon,
+        highest_superblock_checkpoint: CheckpointBeacon,
+    ) -> Message {
         Message::build_message(
             magic,
             Command::LastBeacon(LastBeacon {
                 highest_block_checkpoint,
+                highest_superblock_checkpoint,
             }),
         )
     }

--- a/data_structures/src/builders.rs
+++ b/data_structures/src/builders.rs
@@ -6,8 +6,7 @@ use witnet_util::timestamp::get_timestamp;
 
 use crate::{
     chain::{
-        Block, BlockHeader, BlockTransactions, CheckpointBeacon, InventoryEntry, KeyedSignature,
-        SuperBlockVote,
+        Block, BlockHeader, BlockTransactions, InventoryEntry, KeyedSignature, SuperBlockVote,
     },
     error::BuildersError,
     transaction::Transaction,
@@ -143,18 +142,8 @@ impl Message {
     }
 
     /// Function to build LastBeacon messages
-    pub fn build_last_beacon(
-        magic: u16,
-        highest_block_checkpoint: CheckpointBeacon,
-        highest_superblock_checkpoint: CheckpointBeacon,
-    ) -> Message {
-        Message::build_message(
-            magic,
-            Command::LastBeacon(LastBeacon {
-                highest_block_checkpoint,
-                highest_superblock_checkpoint,
-            }),
-        )
+    pub fn build_last_beacon(magic: u16, last_beacon: LastBeacon) -> Message {
+        Message::build_message(magic, Command::LastBeacon(last_beacon))
     }
 
     /// Function to build SuperBlockVote messages

--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -734,15 +734,9 @@ mod tests {
             current_ars_identities: Some(HashSet::default()),
             current_superblock_hash: Some(Hash::default()),
             current_superblock_index: None,
-            // Set of ARS identities that can currently send superblock votes
             previous_ars_identities: Some(HashSet::default()),
-            // Set of received superblock votes
-            // This is cleared when we try to create a new superblock
             received_superblocks: HashSet::default(),
-            // Set of votes that agree with current_superblock_hash
-            // This is cleared when we try to create a new superblock
             votes_on_local_superlock: HashSet::default(),
-            // The last ARS ordered keys
             previous_ars_ordered_keys: vec![],
         };
         let beacon = superblock_state.get_beacon();
@@ -756,15 +750,9 @@ mod tests {
             current_ars_identities: Some(HashSet::default()),
             current_superblock_hash: Some(Hash::default()),
             current_superblock_index: Some(1),
-            // Set of ARS identities that can currently send superblock votes
             previous_ars_identities: Some(HashSet::default()),
-            // Set of received superblock votes
-            // This is cleared when we try to create a new superblock
             received_superblocks: HashSet::default(),
-            // Set of votes that agree with current_superblock_hash
-            // This is cleared when we try to create a new superblock
             votes_on_local_superlock: HashSet::default(),
-            // The last ARS ordered keys
             previous_ars_ordered_keys: vec![],
         };
         let beacon = superblock_state.get_beacon();

--- a/data_structures/src/types.rs
+++ b/data_structures/src/types.rs
@@ -56,7 +56,12 @@ impl fmt::Display for Command {
             Command::InventoryRequest(_) => f.write_str(&"INVENTORY_REQUEST".to_string()),
             Command::LastBeacon(LastBeacon {
                 highest_block_checkpoint: h,
-            }) => write!(f, "LAST_BEACON: #{}: {}", h.checkpoint, h.hash_prev_block),
+                highest_superblock_checkpoint: s,
+            }) => write!(
+                f,
+                "LAST_BEACON: Block: #{}: {} Superblock: #{}: {}",
+                h.checkpoint, h.hash_prev_block, s.checkpoint, s.hash_prev_block
+            ),
             Command::Transaction(tx) => {
                 match tx {
                     Transaction::Commit(_) => f.write_str(&"COMMIT_TRANSACTION".to_string())?,
@@ -135,6 +140,7 @@ pub struct InventoryRequest {
 #[protobuf_convert(pb = "witnet::LastBeacon")]
 pub struct LastBeacon {
     pub highest_block_checkpoint: CheckpointBeacon,
+    pub highest_superblock_checkpoint: CheckpointBeacon,
 }
 
 ///////////////////////////////////////////////////////////

--- a/data_structures/tests/builders.rs
+++ b/data_structures/tests/builders.rs
@@ -9,22 +9,16 @@ fn builders_build_last_beacon() {
         checkpoint: 1,
         hash_prev_block: Hash::SHA256([1; 32]),
     };
+    let last_beacon = LastBeacon {
+        highest_block_checkpoint,
+        highest_superblock_checkpoint,
+    };
 
     let msg = Message {
-        kind: Command::LastBeacon(LastBeacon {
-            highest_block_checkpoint,
-            highest_superblock_checkpoint,
-        }),
+        kind: Command::LastBeacon(last_beacon.clone()),
         magic: 0xABCD,
     };
-    assert_eq!(
-        msg,
-        Message::build_last_beacon(
-            0xABCD,
-            highest_block_checkpoint,
-            highest_superblock_checkpoint
-        )
-    );
+    assert_eq!(msg, Message::build_last_beacon(0xABCD, last_beacon,));
 }
 
 #[test]

--- a/data_structures/tests/builders.rs
+++ b/data_structures/tests/builders.rs
@@ -120,6 +120,10 @@ fn builders_build_version() {
             hash_prev_block: Hash::SHA256([4; 32]),
             checkpoint: 7,
         },
+        highest_superblock_checkpoint: CheckpointBeacon {
+            hash_prev_block: Hash::SHA256([5; 32]),
+            checkpoint: 1,
+        },
     };
     let sender_addr = Address {
         ip: IpAddress::Ipv4 { ip: 3_232_235_777 },

--- a/data_structures/tests/builders.rs
+++ b/data_structures/tests/builders.rs
@@ -5,15 +5,25 @@ use witnet_data_structures::{builders::*, chain::*, transaction::Transaction, ty
 #[test]
 fn builders_build_last_beacon() {
     let highest_block_checkpoint = CheckpointBeacon::default();
+    let highest_superblock_checkpoint = CheckpointBeacon {
+        checkpoint: 1,
+        hash_prev_block: Hash::SHA256([1; 32]),
+    };
+
     let msg = Message {
         kind: Command::LastBeacon(LastBeacon {
             highest_block_checkpoint,
+            highest_superblock_checkpoint,
         }),
         magic: 0xABCD,
     };
     assert_eq!(
         msg,
-        Message::build_last_beacon(0xABCD, highest_block_checkpoint)
+        Message::build_last_beacon(
+            0xABCD,
+            highest_block_checkpoint,
+            highest_superblock_checkpoint
+        )
     );
 }
 

--- a/data_structures/tests/serializers.rs
+++ b/data_structures/tests/serializers.rs
@@ -34,15 +34,21 @@ const EXAMPLE_BLOCK_VECTOR: &[u8] = &[
 
 #[test]
 fn message_last_beacon_from_bytes() {
+    let highest_superblock_checkpoint = CheckpointBeacon {
+        checkpoint: 1,
+        hash_prev_block: Hash::SHA256([1; 32]),
+    };
     let buff: Vec<u8> = [
-        18, 40, 66, 38, 10, 36, 18, 34, 10, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        18, 83, 66, 81, 10, 36, 18, 34, 10, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 41, 13, 1, 0, 0, 0, 18, 34, 10, 32, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     ]
     .to_vec();
 
     let expected_msg = Message {
         kind: Command::LastBeacon(LastBeacon {
             highest_block_checkpoint: CheckpointBeacon::default(),
+            highest_superblock_checkpoint,
         }),
         magic: 0,
     };
@@ -52,15 +58,22 @@ fn message_last_beacon_from_bytes() {
 
 #[test]
 fn message_last_beacon_to_bytes() {
+    let highest_superblock_checkpoint = CheckpointBeacon {
+        checkpoint: 1,
+        hash_prev_block: Hash::SHA256([1; 32]),
+    };
+
     let msg = Message {
         kind: Command::LastBeacon(LastBeacon {
             highest_block_checkpoint: CheckpointBeacon::default(),
+            highest_superblock_checkpoint,
         }),
         magic: 0,
     };
     let expected_buf: Vec<u8> = [
-        18, 40, 66, 38, 10, 36, 18, 34, 10, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        18, 83, 66, 81, 10, 36, 18, 34, 10, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 18, 41, 13, 1, 0, 0, 0, 18, 34, 10, 32, 1, 1,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     ]
     .to_vec();
     let result: Vec<u8> = msg.to_pb_bytes().unwrap();

--- a/data_structures/tests/serializers.rs
+++ b/data_structures/tests/serializers.rs
@@ -225,6 +225,10 @@ fn message_version_to_bytes() {
             hash_prev_block: Hash::SHA256([4; 32]),
             checkpoint: 7,
         },
+        highest_superblock_checkpoint: CheckpointBeacon {
+            hash_prev_block: Hash::SHA256([5; 32]),
+            checkpoint: 1,
+        },
     };
     let sender_address = Address {
         ip: IpAddress::Ipv4 { ip: 3_232_235_777 },
@@ -248,10 +252,12 @@ fn message_version_to_bytes() {
         magic: 1,
     };
     let expected_buf: Vec<u8> = [
-        8, 1, 18, 95, 10, 93, 8, 2, 16, 123, 25, 4, 0, 0, 0, 0, 0, 0, 0, 34, 8, 10, 6, 192, 168, 1,
-        1, 31, 64, 42, 8, 10, 6, 192, 168, 1, 2, 31, 65, 50, 4, 97, 115, 100, 102, 57, 1, 0, 0, 0,
-        0, 0, 0, 0, 66, 43, 10, 41, 13, 7, 0, 0, 0, 18, 34, 10, 32, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        8, 1, 18, 139, 1, 10, 136, 1, 8, 2, 16, 123, 25, 4, 0, 0, 0, 0, 0, 0, 0, 34, 8, 10, 6, 192,
+        168, 1, 1, 31, 64, 42, 8, 10, 6, 192, 168, 1, 2, 31, 65, 50, 4, 97, 115, 100, 102, 57, 1,
+        0, 0, 0, 0, 0, 0, 0, 66, 86, 10, 41, 13, 7, 0, 0, 0, 18, 34, 10, 32, 4, 4, 4, 4, 4, 4, 4,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 18, 41, 13, 1,
+        0, 0, 0, 18, 34, 10, 32, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
     ]
     .to_vec();
     let result: Vec<u8> = msg.to_pb_bytes().unwrap();
@@ -265,6 +271,10 @@ fn message_version_from_bytes() {
         highest_block_checkpoint: CheckpointBeacon {
             hash_prev_block: Hash::SHA256([4; 32]),
             checkpoint: 7,
+        },
+        highest_superblock_checkpoint: CheckpointBeacon {
+            hash_prev_block: Hash::SHA256([5; 32]),
+            checkpoint: 1,
         },
     };
     let sender_address = Address {
@@ -290,10 +300,12 @@ fn message_version_from_bytes() {
     };
 
     let buf: Vec<u8> = [
-        8, 1, 18, 95, 10, 93, 8, 2, 16, 123, 25, 4, 0, 0, 0, 0, 0, 0, 0, 34, 8, 10, 6, 192, 168, 1,
-        1, 31, 64, 42, 8, 10, 6, 192, 168, 1, 2, 31, 65, 50, 4, 97, 115, 100, 102, 57, 1, 0, 0, 0,
-        0, 0, 0, 0, 66, 43, 10, 41, 13, 7, 0, 0, 0, 18, 34, 10, 32, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+        8, 1, 18, 139, 1, 10, 136, 1, 8, 2, 16, 123, 25, 4, 0, 0, 0, 0, 0, 0, 0, 34, 8, 10, 6, 192,
+        168, 1, 1, 31, 64, 42, 8, 10, 6, 192, 168, 1, 2, 31, 65, 50, 4, 97, 115, 100, 102, 57, 1,
+        0, 0, 0, 0, 0, 0, 0, 66, 86, 10, 41, 13, 7, 0, 0, 0, 18, 34, 10, 32, 4, 4, 4, 4, 4, 4, 4,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 18, 41, 13, 1,
+        0, 0, 0, 18, 34, 10, 32, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
     ]
     .to_vec();
 
@@ -306,6 +318,10 @@ fn message_version_encode_decode() {
         highest_block_checkpoint: CheckpointBeacon {
             hash_prev_block: Hash::SHA256([4; 32]),
             checkpoint: 7,
+        },
+        highest_superblock_checkpoint: CheckpointBeacon {
+            hash_prev_block: Hash::SHA256([5; 32]),
+            checkpoint: 1,
         },
     };
     let sender_address = Address {

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -216,6 +216,7 @@ impl ChainManager {
                 SessionsManager::from_registry().do_send(SetLastBeacon {
                     beacon: LastBeacon {
                         highest_block_checkpoint: chain_info.highest_block_checkpoint,
+                        highest_superblock_checkpoint: act.get_superblock_beacon(),
                     },
                 });
 

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -123,11 +123,13 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                     sessions_manager.do_send(SetLastBeacon {
                         beacon: LastBeacon {
                             highest_block_checkpoint: chain_info.highest_block_checkpoint,
+                            highest_superblock_checkpoint: self.get_superblock_beacon(),
                         },
                     });
                     sessions_manager.do_send(Broadcast {
                         command: SendLastBeacon {
                             beacon: chain_info.highest_block_checkpoint,
+                            superblock_beacon: self.get_superblock_beacon(),
                         },
                         only_inbound: true,
                     });
@@ -190,13 +192,18 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                             .as_ref()
                             .unwrap()
                             .highest_block_checkpoint;
+                        let superblock_beacon = self.get_superblock_beacon();
                         sessions_manager.do_send(SetLastBeacon {
                             beacon: LastBeacon {
                                 highest_block_checkpoint: beacon,
+                                highest_superblock_checkpoint: superblock_beacon,
                             },
                         });
                         sessions_manager.do_send(Broadcast {
-                            command: SendLastBeacon { beacon },
+                            command: SendLastBeacon {
+                                beacon,
+                                superblock_beacon: self.get_superblock_beacon(),
+                            },
                             only_inbound: true,
                         });
 

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -120,17 +120,15 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                 if let Some(chain_info) = &self.chain_state.chain_info {
                     // Send last beacon because otherwise the network cannot bootstrap
                     let sessions_manager = SessionsManager::from_registry();
+                    let last_beacon = LastBeacon {
+                        highest_block_checkpoint: chain_info.highest_block_checkpoint,
+                        highest_superblock_checkpoint: self.get_superblock_beacon(),
+                    };
                     sessions_manager.do_send(SetLastBeacon {
-                        beacon: LastBeacon {
-                            highest_block_checkpoint: chain_info.highest_block_checkpoint,
-                            highest_superblock_checkpoint: self.get_superblock_beacon(),
-                        },
+                        beacon: last_beacon.clone(),
                     });
                     sessions_manager.do_send(Broadcast {
-                        command: SendLastBeacon {
-                            beacon: chain_info.highest_block_checkpoint,
-                            superblock_beacon: self.get_superblock_beacon(),
-                        },
+                        command: SendLastBeacon { last_beacon },
                         only_inbound: true,
                     });
                 }
@@ -193,17 +191,15 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                             .unwrap()
                             .highest_block_checkpoint;
                         let superblock_beacon = self.get_superblock_beacon();
+                        let last_beacon = LastBeacon {
+                            highest_block_checkpoint: beacon,
+                            highest_superblock_checkpoint: superblock_beacon,
+                        };
                         sessions_manager.do_send(SetLastBeacon {
-                            beacon: LastBeacon {
-                                highest_block_checkpoint: beacon,
-                                highest_superblock_checkpoint: superblock_beacon,
-                            },
+                            beacon: last_beacon.clone(),
                         });
                         sessions_manager.do_send(Broadcast {
-                            command: SendLastBeacon {
-                                beacon,
-                                superblock_beacon: self.get_superblock_beacon(),
-                            },
+                            command: SendLastBeacon { last_beacon },
                             only_inbound: true,
                         });
 

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -661,6 +661,17 @@ impl ChainManager {
             .highest_block_checkpoint
     }
 
+    fn get_superblock_beacon(&self) -> CheckpointBeacon {
+        match self.chain_state.superblock_state.get_beacon() {
+            Some(superblock_beacon) => superblock_beacon,
+            // FIXME(#1367): this should be modified with the appropriate superblock bootstrap state.
+            None => CheckpointBeacon {
+                checkpoint: 0,
+                hash_prev_block: self.consensus_constants().genesis_hash,
+            },
+        }
+    }
+
     fn consensus_constants(&self) -> ConsensusConstants {
         self.chain_state
             .chain_info
@@ -1001,6 +1012,7 @@ impl ChainManager {
             .send(Anycast {
                 command: SendLastBeacon {
                     beacon: self.get_chain_beacon(),
+                    superblock_beacon: self.get_superblock_beacon(),
                 },
                 safu: true,
             })

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -53,6 +53,7 @@ use witnet_data_structures::{
     radon_report::{RadonReport, ReportContext},
     superblock::AddSuperBlockVote,
     transaction::{TallyTransaction, Transaction},
+    types::LastBeacon,
     vrf::VrfCtx,
 };
 use witnet_rad::types::RadonTypes;
@@ -661,6 +662,7 @@ impl ChainManager {
             .highest_block_checkpoint
     }
 
+    /// Retrieves the latest superblock hash an index, if it exists. Else, returns the genesis beacon.
     fn get_superblock_beacon(&self) -> CheckpointBeacon {
         match self.chain_state.superblock_state.get_beacon() {
             Some(superblock_beacon) => superblock_beacon,
@@ -1011,8 +1013,10 @@ impl ChainManager {
         SessionsManager::from_registry()
             .send(Anycast {
                 command: SendLastBeacon {
-                    beacon: self.get_chain_beacon(),
-                    superblock_beacon: self.get_superblock_beacon(),
+                    last_beacon: LastBeacon {
+                        highest_block_checkpoint: self.get_chain_beacon(),
+                        highest_superblock_checkpoint: self.get_superblock_beacon(),
+                    },
                 },
                 safu: true,
             })

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -692,10 +692,8 @@ impl fmt::Display for SendInventoryItem {
 /// Message to send beacon through the network
 #[derive(Clone, Debug, Message)]
 pub struct SendLastBeacon {
-    /// The highest block checkpoint
-    pub beacon: CheckpointBeacon,
-    /// The highest superblock checkpoint
-    pub superblock_beacon: CheckpointBeacon,
+    /// Last block and superblock checkpoints
+    pub last_beacon: LastBeacon,
 }
 
 impl fmt::Display for SendLastBeacon {

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -694,6 +694,8 @@ impl fmt::Display for SendInventoryItem {
 pub struct SendLastBeacon {
     /// The highest block checkpoint
     pub beacon: CheckpointBeacon,
+    /// The highest superblock checkpoint
+    pub superblock_beacon: CheckpointBeacon,
 }
 
 impl fmt::Display for SendLastBeacon {

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -89,6 +89,7 @@ message InventoryRequest {
 
 message LastBeacon {
     CheckpointBeacon highest_block_checkpoint = 1;
+    CheckpointBeacon highest_superblock_checkpoint = 2;
 }
 
 message OutputPointer {


### PR DESCRIPTION
This PR adds the superblock beacon to the lastbeacon message. In particular:

- Adds a new 'highest_superblock_checkpoint' to LastBeacon structure.
- If there exists some superblock state, adds the superblock checkpoint to the lastbeacon message.
- Else, signals the genesis hash and the 0 index.

The latter point should be modified when a decision is taken about how to bootstrap the network with an appropriate state #1367.

Currently upon reception of the superblock checkpoint the node does nothing. Once the consensus has been decided, we should implement how to handle that superblock state #1366.
 