### PR TITLE
fix(rad): serialize RadonIntegers as strings

### DIFF
--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -177,7 +177,8 @@ impl Serialize for RadonTypes {
                 state.serialize_field(radon_type_name, &radon_type.value())?
             }
             RadonTypes::Integer(radon_type) => {
-                state.serialize_field(radon_type_name, &radon_type.value())?
+                // Serialize integers as strings, as a workaround to issue #1302
+                state.serialize_field(radon_type_name, &radon_type.value().to_string())?
             }
             RadonTypes::Map(radon_type) => {
                 state.serialize_field(radon_type_name, &radon_type.value())?

--- a/wallet/tests/data_requests.rs
+++ b/wallet/tests/data_requests.rs
@@ -32,7 +32,7 @@ fn test_radon_types_json_serialization() {
     assert_eq!(serde_json::to_string(&radon_type).unwrap(), expected_json);
 
     let radon_type = RadonTypes::from(RadonInteger::from(42));
-    let expected_json = r#"{"RadonInteger":42}"#;
+    let expected_json = r#"{"RadonInteger":"42"}"#;
     assert_eq!(serde_json::to_string(&radon_type).unwrap(), expected_json);
 
     let radon_type = RadonTypes::from(RadonMap::from(


### PR DESCRIPTION
Fix #1302 

For some strange reason, the wallet fails to serialize `i128` values. It's strange because there is a test where that works, but the same code fails if executed in the wallet. Since the only `i128` we use seems to be the one from `RadonInteger`, as a workaround we can simply serialize it as a string.

This serialization is only used by sheikah to display the result of a data request, so let's make sure this doesn't break that.

Before:

    {"RadonInteger":42}

Now:

    {"RadonInteger":"42"}