### PR TITLE
feat (p2p): melt addresses inserted through addPeers

### DIFF
--- a/node/src/actors/peers_manager/handlers.rs
+++ b/node/src/actors/peers_manager/handlers.rs
@@ -18,7 +18,7 @@ impl Handler<AddPeers> for PeersManager {
         // The easiest way to check if a peer was added manually is by using msg.src_address,
         // which is set to None when using the addPeers JSON-RPC method and also when reading peers from config
         if msg.src_address.is_none() {
-            self.peers.ice_peer_addresses_remove(&msg.addresses);
+            self.peers.remove_many_from_ice(&msg.addresses);
         }
         self.peers.add_to_new(msg.addresses, msg.src_address)
     }

--- a/node/src/actors/peers_manager/handlers.rs
+++ b/node/src/actors/peers_manager/handlers.rs
@@ -14,6 +14,12 @@ impl Handler<AddPeers> for PeersManager {
     fn handle(&mut self, msg: AddPeers, _: &mut Context<Self>) -> Self::Result {
         // Insert address
         log::trace!("Adding the following peer addresses: {:?}", msg.addresses);
+        // Remove peers added manually from the ice bucket to ensure that they are always added
+        // The easiest way to check if a peer was added manually is by using msg.src_address,
+        // which is set to None when using the addPeers JSON-RPC method and also when reading peers from config
+        if msg.src_address.is_none() {
+            self.peers.ice_peer_addresses_remove(&msg.addresses);
+        }
         self.peers.add_to_new(msg.addresses, msg.src_address)
     }
 }

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -119,6 +119,7 @@ impl StreamHandler<BytesMut, Error> for Session {
     /// This is main event loop for client requests
     fn handle(&mut self, bytes: BytesMut, ctx: &mut Self::Context) {
         let result = WitnetMessage::from_pb_bytes(&bytes);
+
         match result {
             Err(err) => log::error!("Error decoding message: {:?}", err),
             Ok(msg) => {

--- a/p2p/src/peers/mod.rs
+++ b/p2p/src/peers/mod.rs
@@ -256,6 +256,11 @@ impl Peers {
         addrs
             .iter()
             .filter_map(|address| {
+                // Remove from iced
+                if ice {
+                    self.ice_peer_address(address);
+                }
+
                 let bucket_index = self.tried_bucket_index(&address);
                 let bucket_entry = self.tried_bucket.get(&bucket_index);
 
@@ -265,13 +270,7 @@ impl Peers {
                 {
                     log::trace!("Removed a tried peer address: \n{}", self);
 
-                    self.tried_bucket.remove(&bucket_index).map(|entry| {
-                        if ice {
-                            self.ice_peer_address(&entry.address);
-                        }
-
-                        entry
-                    })
+                    self.tried_b    ucket.remove(&bucket_index)
                 } else {
                     None
                 }
@@ -388,6 +387,21 @@ impl Peers {
         self.ice_bucket.insert(*address, timestamp);
 
         true
+    }
+
+    /// Remove address from the ice bucket, ignoring the ice period
+    pub fn remove_from_ice(&mut self, address: &SocketAddr) {
+        log::trace!("Removing peer address {} from the ice bucket", address);
+
+        self.ice_bucket.remove(address);
+    }
+
+    /// Remove a list of addresses from the ice bucket, ignoring the ice_period
+    pub fn remove_many_from_ice(&mut self, addresses: &[SocketAddr]) {
+        log::trace!("Removing peer address {:?} from the ice bucket", addresses);
+        for address in addresses {
+            self.remove_from_ice(address)
+        }
     }
 }
 

--- a/p2p/src/peers/mod.rs
+++ b/p2p/src/peers/mod.rs
@@ -256,7 +256,7 @@ impl Peers {
         addrs
             .iter()
             .filter_map(|address| {
-                // Remove from iced
+                // Add to iced
                 if ice {
                     self.ice_peer_address(address);
                 }
@@ -270,7 +270,7 @@ impl Peers {
                 {
                     log::trace!("Removed a tried peer address: \n{}", self);
 
-                    self.tried_b    ucket.remove(&bucket_index)
+                    self.tried_bucket.remove(&bucket_index)
                 } else {
                     None
                 }
@@ -398,7 +398,10 @@ impl Peers {
 
     /// Remove a list of addresses from the ice bucket, ignoring the ice_period
     pub fn remove_many_from_ice(&mut self, addresses: &[SocketAddr]) {
-        log::trace!("Removing peer address {:?} from the ice bucket", addresses);
+        log::trace!(
+            "Removing the following peer addresses from the ice bucket: {:?}",
+            addresses
+        );
         for address in addresses {
             self.remove_from_ice(address)
         }

--- a/p2p/tests/buckets.rs
+++ b/p2p/tests/buckets.rs
@@ -73,6 +73,61 @@ mod ice {
         assert!(is_still_iced_just_when_ice_period_is_over);
         assert!(!is_iced_right_after_ice_period_is_over);
     }
+
+    #[test]
+    fn test_remove_iced_address() {
+        let ice_period = Duration::from_secs(1000);
+        let mut peers = Peers {
+            ice_period,
+            ..Default::default()
+        };
+        let address = ip("192.168.1.1:21337");
+        let can_ice = peers.ice_peer_address(&address);
+
+        assert!(can_ice);
+
+        let mut is_iced = peers.ice_bucket_contains(&address);
+
+        assert!(is_iced);
+
+        peers.remove_from_ice(&address);
+
+        is_iced = peers.ice_bucket_contains(&address);
+
+        assert!(!is_iced);
+    }
+
+    #[test]
+    fn test_remove_iced_addresses() {
+        let ice_period = Duration::from_secs(1000);
+        let mut peers = Peers {
+            ice_period,
+            ..Default::default()
+        };
+        let address_1 = ip("192.168.1.1:21337");
+        let address_2 = ip("192.168.2.2:21337");
+
+        peers.ice_peer_address(&address_1);
+        peers.ice_peer_address(&address_2);
+
+        let mut is_iced = peers.ice_bucket_contains(&address_1);
+
+        assert!(is_iced);
+
+        is_iced = peers.ice_bucket_contains(&address_2);
+
+        assert!(is_iced);
+
+        peers.remove_many_from_ice(&[address_1, address_2]);
+
+        is_iced = peers.ice_bucket_contains(&address_1);
+
+        assert!(!is_iced);
+
+        is_iced = peers.ice_bucket_contains(&address_2);
+
+        assert!(!is_iced);
+    }
 }
 
 /// Tests for the business logic of inserting peer addresses into the `new` buckets.

--- a/p2p/tests/buckets.rs
+++ b/p2p/tests/buckets.rs
@@ -128,6 +128,39 @@ mod ice {
 
         assert!(!is_iced);
     }
+
+    #[test]
+    fn test_ice_address_non_existent_in_tried() {
+        let ice_period = Duration::from_secs(1000);
+        let mut peers = Peers {
+            ice_period,
+            ..Default::default()
+        };
+        let address = ip("192.168.1.1:21337");
+
+        peers.clear_tried_bucket();
+        peers.remove_from_tried(&[address], true);
+
+        let is_iced = peers.ice_bucket_contains(&address);
+
+        assert!(is_iced);
+    }
+    #[test]
+    fn test_not_ice_address_non_existent_in_tried() {
+        let ice_period = Duration::from_secs(1000);
+        let mut peers = Peers {
+            ice_period,
+            ..Default::default()
+        };
+        let address = ip("192.168.1.1:21337");
+
+        peers.clear_tried_bucket();
+        peers.remove_from_tried(&[address], false);
+
+        let is_iced = peers.ice_bucket_contains(&address);
+
+        assert!(!is_iced);
+    }
 }
 
 /// Tests for the business logic of inserting peer addresses into the `new` buckets.


### PR DESCRIPTION
This PR adds methods to remove addresses from the ice bucket, and removes those addresses added manually thtough addPeers method