### PR TITLE
Superblock signing committee

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -498,6 +498,10 @@ pub fn consensus_constants_from_partial(
             .extra_rounds
             .to_owned()
             .unwrap_or_else(|| defaults.consensus_constants_extra_rounds()),
+        superblock_signing_committee_size: config
+            .superblock_signing_committee_size
+            .to_owned()
+            .unwrap_or_else(|| defaults.consensus_constants_superblock_signing_committee_size()),
     }
 }
 

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -133,6 +133,11 @@ pub trait Defaults {
             .unwrap()
     }
 
+    /// Default period between superblocks
+    fn consensus_constants_superblock_signing_committee_size(&self) -> u32 {
+        100
+    }
+
     /// JSON-RPC server enabled by default
     fn jsonrpc_enabled(&self) -> bool {
         true

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -133,7 +133,7 @@ pub trait Defaults {
             .unwrap()
     }
 
-    /// Default period between superblocks
+    /// Default size of the superblock signing committee
     fn consensus_constants_superblock_signing_committee_size(&self) -> u32 {
         100
     }

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -190,6 +190,9 @@ pub struct ConsensusConstants {
 
     /// Superblock signing committee for the first superblocks
     pub bootstrapping_committee: Vec<String>,
+
+    /// Superblock signing committee for the first superblocks
+    pub superblock_signing_committee_size: u32,
 }
 
 impl ConsensusConstants {

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -2840,6 +2840,20 @@ impl AltKeys {
             .filter_map(|pkh| self.get_bn256(&pkh).cloned())
             .collect()
     }
+
+    /// Get keys ordered by reputation. If tie, order by pkh.
+    /// These keys will be used to order the ARS when forming a superblock
+    pub fn get_rep_ordered_pkh_list(
+        &self,
+        reputation_set: &TotalReputationSet<PublicKeyHash, Reputation, Alpha>,
+    ) -> Vec<PublicKeyHash> {
+        self.bn256
+            .iter()
+            .map(|(pkh, _)| *pkh)
+            .sorted_by_key(|&pkh| (reputation_set.get(&pkh), pkh))
+            .clone()
+            .collect()
+    }
 }
 
 impl ChainState {

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -191,7 +191,7 @@ pub struct ConsensusConstants {
     /// Superblock signing committee for the first superblocks
     pub bootstrapping_committee: Vec<String>,
 
-    /// Superblock signing committee for the first superblocks
+    /// Size of the superblock signing committee
     pub superblock_signing_committee_size: u32,
 }
 
@@ -2851,7 +2851,6 @@ impl AltKeys {
             .iter()
             .map(|(pkh, _)| *pkh)
             .sorted_by_key(|&pkh| (reputation_set.get(&pkh), pkh))
-            .clone()
             .collect()
     }
 }

--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -276,18 +276,13 @@ impl SuperBlockState {
             self.current_signing_committee.clone()
         } else {
             // Get the number of subsets of _signing_committee_size members
-            let n = ars_ordered.len() / usize::try_from(_signing_committee_size).unwrap();
-            println!("{}", n);
+            let n = ars_ordered.len() as u64 / u64::from(_signing_committee_size);
             // Start counting the members of the subset from the superblock_hash
-            let a = *self.current_superblock_hash.as_ref().get(0).unwrap() as u32;
-            let b = a % _signing_committee_size;
-            let first_member = b % n as u32;
+            let a = u64::from(*self.current_superblock_hash.as_ref().get(0).unwrap());
+            let b = a % u64::from(_signing_committee_size);
+            let first_member = b % n;
             // Get the subset
-            let subset = magic_partition(
-                &ars_ordered.to_vec(),
-                usize::try_from(first_member).unwrap(),
-                n,
-            );
+            let subset = magic_partition(&ars_ordered.to_vec(), first_member, n);
             let hs: HashSet<PublicKeyHash> = subset.iter().cloned().collect();
             self.current_signing_committee = Some(hs);
             self.current_signing_committee.clone()
@@ -295,13 +290,13 @@ impl SuperBlockState {
     }
 }
 
-fn magic_partition<T: Clone>(v: &[T], first: usize, each: usize) -> Vec<T> {
-    if first >= v.len() {
+fn magic_partition<T: Clone>(v: &[T], first: u64, each: u64) -> Vec<T> {
+    if usize::try_from(first).unwrap() >= v.len() {
         return vec![];
     }
 
-    v[first..]
-        .chunks(each)
+    v[usize::try_from(first).unwrap()..]
+        .chunks(usize::try_from(each).unwrap())
         .map(|chunk| chunk[0].clone())
         .collect()
 }

--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -260,7 +260,11 @@ impl SuperBlockState {
 
     /// Updates the current superblock signing committee for a given superblock index
     /// #FIXME This function should be update with issue 1395
-    pub fn update_superblock_signing_committee(&mut self, _singning_committee_size: u32, _current_index: u32) {
+    pub fn update_superblock_signing_committee(
+        &mut self,
+        _singning_committee_size: u32,
+        _current_index: u32,
+    ) {
         self.current_signing_committee = self.previous_ars_identities.clone();
     }
 }
@@ -470,7 +474,7 @@ mod tests {
         let mut sbs = SuperBlockState::new(Hash::default(), ars1);
 
         let sb1 = sbs
-            .build_superblock(&block_headers, &ars2, &[], 0, Hash::default())
+            .build_superblock(&block_headers, &ars2, &[], 100, 0, Hash::default())
             .unwrap();
         let mut v0 = SuperBlockVote::new_unsigned(sb1.hash(), 0);
 
@@ -497,7 +501,14 @@ mod tests {
             Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[1; 32]).unwrap())
                 .unwrap();
         let sb1 = sbs
-            .build_superblock(&block_headers, &ars_identities, &[bls_pk], 100, 0, genesis_hash)
+            .build_superblock(
+                &block_headers,
+                &ars_identities,
+                &[bls_pk],
+                100,
+                0,
+                genesis_hash,
+            )
             .unwrap();
         let v1 = SuperBlockVote::new_unsigned(sb1.hash(), 0);
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::NotInArs);
@@ -517,7 +528,14 @@ mod tests {
 
         let genesis_hash = Hash::default();
         assert_eq!(
-            sbs.build_superblock(&block_headers, &ars_identities, &[bls_pk], 100, 0, genesis_hash),
+            sbs.build_superblock(
+                &block_headers,
+                &ars_identities,
+                &[bls_pk],
+                100,
+                0,
+                genesis_hash
+            ),
             None
         );
 
@@ -592,7 +610,14 @@ mod tests {
         assert_eq!(sbs.add_vote(&v0), AddSuperBlockVote::AlreadySeen);
 
         let _sb2 = sbs
-            .build_superblock(&block_headers, &ars_identities, &[bls_pk], 100, 1, genesis_hash)
+            .build_superblock(
+                &block_headers,
+                &ars_identities,
+                &[bls_pk],
+                100,
+                1,
+                genesis_hash,
+            )
             .unwrap();
         let v1 = SuperBlockVote::new_unsigned(Hash::SHA256([2; 32]), 1);
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::NotInArs);
@@ -676,7 +701,7 @@ mod tests {
         // Superblock votes for index 0 cannot be validated because we do not know the ARS for index -1
         // (because it does not exist)
         let _sb0 = sbs
-            .build_superblock(&block_headers, &ars0, &ars0_ordered,  100, 0, genesis_hash)
+            .build_superblock(&block_headers, &ars0, &ars0_ordered, 100, 0, genesis_hash)
             .unwrap();
 
         // The ARS included in superblock 0 is empty, so none of the superblock votes for index 1

--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -212,7 +212,7 @@ impl SuperBlockState {
                     .extend(ars_pkh_keys.iter().cloned());
                 self.previous_ars_ordered_keys = ars_ordered_bn256_keys.to_vec();
                 // For the current index, update the signing committee
-                self.update_superblock_signing_committee(signing_committee_size, superblock_index);
+                self.update_superblock_signing_committee(signing_committee_size);
 
                 let superblock_hash = superblock.hash();
                 self.current_superblock_hash = superblock_hash;
@@ -268,7 +268,6 @@ impl SuperBlockState {
     pub fn update_superblock_signing_committee(
         &mut self,
         _signing_committee_size: u32,
-        _current_index: u32,
     ) -> Option<HashSet<PublicKeyHash>> {
         // If the number of identities is lower than committee_size all the members of the ARS sign the superblock
         let ars_ordered = &self.previous_ordered_ars_identities;
@@ -1037,8 +1036,7 @@ mod tests {
         sbs.previous_ordered_ars_identities = vec![p1.pkh(), p2.pkh(), p3.pkh()];
         sbs.previous_ars_identities = Some(ars_identities.iter().cloned().collect());
         let committee_size = 4;
-        let current_index = 2;
-        let subset = sbs.update_superblock_signing_committee(committee_size, current_index);
+        let subset = sbs.update_superblock_signing_committee(committee_size);
         assert_eq!(ars_identities.len(), subset.unwrap().len());
     }
 
@@ -1101,8 +1099,7 @@ mod tests {
         ];
         sbs.previous_ars_identities = Some(ars_identities.iter().cloned().collect());
         let committee_size = 4;
-        let current_index = 3;
-        let subset = sbs.update_superblock_signing_committee(committee_size, current_index);
+        let subset = sbs.update_superblock_signing_committee(committee_size);
         assert_eq!(
             usize::try_from(committee_size).unwrap(),
             subset.unwrap().len()

--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -214,8 +214,7 @@ impl SuperBlockState {
                 // For the current index, update the signing committee
                 self.update_superblock_signing_committee(signing_committee_size);
 
-                let superblock_hash = superblock.hash();
-                self.current_superblock_hash = superblock_hash;
+                self.current_superblock_hash = superblock.hash();
 
                 // This replace is needed because the for loop below needs unique access to self,
                 // but it cannot have unique access to self if it is iterating over
@@ -276,8 +275,8 @@ impl SuperBlockState {
             self.current_signing_committee.clone()
         } else {
             // Start counting the members of the subset from the superblock_hash
-            let a = u64::from(*self.current_superblock_hash.as_ref().get(0).unwrap());
-            let first = a % u64::from(_signing_committee_size);
+            let superblock_hash = u64::from(*self.current_superblock_hash.as_ref().get(0).unwrap());
+            let first = superblock_hash % u64::from(_signing_committee_size);
             // Get the subset
             let subset = magic_partition(
                 &ars_ordered.to_vec(),

--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -202,9 +202,6 @@ impl SuperBlockState {
                 None
             }
             Some(superblock) => {
-                let superblock_hash = superblock.hash();
-                self.current_superblock_hash = superblock_hash;
-
                 // Save ARS identities:
                 // previous = current
                 // current = ars_pkh_keys
@@ -216,6 +213,9 @@ impl SuperBlockState {
                 self.previous_ars_ordered_keys = ars_ordered_bn256_keys.to_vec();
                 // For the current index, update the signing committee
                 self.update_superblock_signing_committee(signing_committee_size, superblock_index);
+
+                let superblock_hash = superblock.hash();
+                self.current_superblock_hash = superblock_hash;
 
                 // This replace is needed because the for loop below needs unique access to self,
                 // but it cannot have unique access to self if it is iterating over
@@ -264,23 +264,25 @@ impl SuperBlockState {
         self.received_superblocks.contains(sbv)
     }
 
-    /// Updates the current superblock signing committee for a given superblock index
-    /// #FIXME This function should be update with issue 1395
+    /// Updates the current superblock signing committee for a given superblock hash
     pub fn update_superblock_signing_committee(
         &mut self,
         _signing_committee_size: u32,
         _current_index: u32,
     ) -> Option<HashSet<PublicKeyHash>> {
-        // If the number of identities is lower than 100, then all the members of the ARS sign the superblock
+        // If the number of identities is lower than committee_size all the members of the ARS sign the superblock
         let ars_ordered = &self.previous_ordered_ars_identities;
         if ars_ordered.len() < usize::try_from(_signing_committee_size).unwrap() {
             self.current_signing_committee = self.previous_ars_identities.clone();
             self.current_signing_committee.clone()
         } else {
-            // Get the number of subsets of 100 members
-            let n = ars_ordered.len() / 100;
-            // Start counting the members of the subset from the superblock_index
-            let first_member = self.current_superblock_index;
+            // Get the number of subsets of _signing_committee_size members
+            let n = ars_ordered.len() / usize::try_from(_signing_committee_size).unwrap();
+            println!("{}", n);
+            // Start counting the members of the subset from the superblock_hash
+            let a = *self.current_superblock_hash.as_ref().get(0).unwrap() as u32;
+            let b = a % _signing_committee_size;
+            let first_member = b % n as u32;
             // Get the subset
             let subset = magic_partition(
                 &ars_ordered.to_vec(),
@@ -996,6 +998,115 @@ mod tests {
         v3.secp256k1_signature.public_key = p3;
         assert_eq!(sbs.add_vote(&v3), AddSuperBlockVote::MaybeValid);
         assert_eq!(sbs.votes_on_each_superblock, HashMap::new());
+    }
+
+    #[test]
+    fn test_update_superblock_signing_committee() {
+        // When the ARS has less members than the committee size it should
+        // return the entire ARS as superblock signing committee.
+        let mut sbs = SuperBlockState::default();
+
+        let p1 = PublicKey::from_bytes([1; 33]);
+        let p2 = PublicKey::from_bytes([2; 33]);
+        let p3 = PublicKey::from_bytes([3; 33]);
+
+        let bls_pk1 =
+            Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[1; 32]).unwrap())
+                .unwrap();
+        let bls_pk2 =
+            Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[2; 32]).unwrap())
+                .unwrap();
+        let bls_pk3 =
+            Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[3; 32]).unwrap())
+                .unwrap();
+
+        let block_headers = vec![BlockHeader::default()];
+        let ars_identities = vec![p1.pkh(), p2.pkh(), p3.pkh()];
+        let ordered_ars = vec![bls_pk1, bls_pk2, bls_pk3];
+        let genesis_hash = Hash::default();
+        let _sb1 = sbs
+            .build_superblock(
+                &block_headers,
+                &ars_identities,
+                &ordered_ars,
+                100,
+                0,
+                genesis_hash,
+            )
+            .unwrap();
+        sbs.previous_ordered_ars_identities = vec![p1.pkh(), p2.pkh(), p3.pkh()];
+        sbs.previous_ars_identities = Some(ars_identities.iter().cloned().collect());
+        let committee_size = 4;
+        let current_index = 2;
+        let subset = sbs.update_superblock_signing_committee(committee_size, current_index);
+        assert_eq!(ars_identities.len(), subset.unwrap().len());
+    }
+
+    #[test]
+    fn test_update_superblock_signing_committee_2() {
+        // It shpuld return a subset of 4 members from an ARS having size 8
+        let mut sbs = SuperBlockState::default();
+
+        let p1 = PublicKey::from_bytes([1; 33]);
+        let p2 = PublicKey::from_bytes([2; 33]);
+        let p3 = PublicKey::from_bytes([3; 33]);
+        let p4 = PublicKey::from_bytes([4; 33]);
+        let p5 = PublicKey::from_bytes([5; 33]);
+        let p6 = PublicKey::from_bytes([6; 33]);
+        let p7 = PublicKey::from_bytes([7; 33]);
+        let p8 = PublicKey::from_bytes([8; 33]);
+
+        let bls_pk1 =
+            Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[1; 32]).unwrap())
+                .unwrap();
+        let bls_pk2 =
+            Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[2; 32]).unwrap())
+                .unwrap();
+        let bls_pk3 =
+            Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[3; 32]).unwrap())
+                .unwrap();
+
+        let block_headers = vec![BlockHeader::default()];
+        let ars_identities = vec![
+            p1.pkh(),
+            p2.pkh(),
+            p3.pkh(),
+            p4.pkh(),
+            p5.pkh(),
+            p6.pkh(),
+            p7.pkh(),
+            p8.pkh(),
+        ];
+        let ordered_ars = vec![bls_pk1, bls_pk2, bls_pk3];
+        let genesis_hash = Hash::default();
+        let _sb1 = sbs
+            .build_superblock(
+                &block_headers,
+                &ars_identities,
+                &ordered_ars,
+                4,
+                0,
+                genesis_hash,
+            )
+            .unwrap();
+        sbs.previous_ordered_ars_identities = vec![
+            p1.pkh(),
+            p2.pkh(),
+            p3.pkh(),
+            p4.pkh(),
+            p5.pkh(),
+            p6.pkh(),
+            p7.pkh(),
+            p8.pkh(),
+        ];
+        sbs.previous_ars_identities = Some(ars_identities.iter().cloned().collect());
+        let committee_size = 4;
+        let current_index = 3;
+        let subset = sbs.update_superblock_signing_committee(committee_size, current_index);
+        assert_eq!(
+            usize::try_from(committee_size).unwrap(),
+            subset.unwrap().len()
+        );
     }
 
     #[test]

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -12,6 +12,7 @@ use crate::{
     config_mngr, signature_mngr, storage_mngr,
 };
 use witnet_crypto::key::CryptoEngine;
+use witnet_data_structures::superblock::SuperBlockState;
 use witnet_data_structures::{
     chain::{
         ChainInfo, ChainState, CheckpointBeacon, CheckpointVRF, GenesisBlockInfo,

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -12,7 +12,6 @@ use crate::{
     config_mngr, signature_mngr, storage_mngr,
 };
 use witnet_crypto::key::CryptoEngine;
-use witnet_data_structures::superblock::SuperBlockState;
 use witnet_data_structures::{
     chain::{
         ChainInfo, ChainState, CheckpointBeacon, CheckpointVRF, GenesisBlockInfo,

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -900,6 +900,9 @@ impl ChainManager {
         let signing_committee_size =
             u32::from(consensus_constants.superblock_signing_committee_size);
 
+        let signing_committee_size =
+            u32::from(consensus_constants.superblock_signing_committee_size);
+
         let superblock_index = block_epoch / superblock_period;
         let inventory_manager = InventoryManager::from_registry();
 

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -725,7 +725,7 @@ impl ChainManager {
 
                     false
                 }
-                AddSuperBlockVote::NotInArs => {
+                AddSuperBlockVote::NotInSigningCommittee => {
                     log::debug!(
                         "Not forwarding superblock vote: identity not in ARS: {}",
                         superblock_vote.secp256k1_signature.public_key.pkh()

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -900,9 +900,6 @@ impl ChainManager {
         let signing_committee_size =
             u32::from(consensus_constants.superblock_signing_committee_size);
 
-        let signing_committee_size =
-            u32::from(consensus_constants.superblock_signing_committee_size);
-
         let superblock_index = block_epoch / superblock_period;
         let inventory_manager = InventoryManager::from_registry();
 

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -982,11 +982,13 @@ impl ChainManager {
                         .collect()
                 }
             };
+
             let ars_ordered_keys = &act.chain_state.last_ars_ordered_keys;
 
             let superblock = act.chain_state.superblock_state.build_superblock(
                 &block_headers,
                 &ars_members,
+                &act.chain_state.last_ars,
                 ars_ordered_keys,
                 consensus_constants.superblock_signing_committee_size,
                 superblock_index,

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -539,16 +539,12 @@ impl ChainManager {
 
                 // Store the ARS and the order of the keys
                 let trs = reputation_engine.trs();
-                let current_ars = reputation_engine
-                    .ars()
-                    .active_identities()
-                    .cloned()
-                    .collect();
                 let alt_keys = &self.chain_state.alt_keys;
 
                 let ordered_alts: Vec<Bn256PublicKey> = alt_keys.get_rep_ordered_bn256_list(trs);
+                let ordered_ars: Vec<PublicKeyHash> = alt_keys.get_rep_ordered_pkh_list(trs);
                 // last ars with previous block ars info
-                self.chain_state.last_ars = current_ars;
+                self.chain_state.last_ars = ordered_ars;
                 self.chain_state.last_ars_ordered_keys = ordered_alts;
 
                 let rep_info = update_pools(

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -897,6 +897,8 @@ impl ChainManager {
         let consensus_constants = self.consensus_constants();
 
         let superblock_period = u32::from(consensus_constants.superblock_period);
+        let signing_committee_size =
+            u32::from(consensus_constants.superblock_signing_committee_size);
 
         let superblock_index = block_epoch / superblock_period;
         let inventory_manager = InventoryManager::from_registry();
@@ -988,6 +990,7 @@ impl ChainManager {
                 &block_headers,
                 &ars_members,
                 ars_ordered_keys,
+                signing_committee_size,
                 superblock_index,
                 last_hash,
             );
@@ -1671,6 +1674,29 @@ mod tests {
             CheckpointBeacon {
                 checkpoint: 0,
                 hash_prev_block: Hash::SHA256([1; 32]),
+            }
+        );
+
+        // build a superblock
+        chain_manager.chain_state.superblock_state.build_superblock(
+            &[BlockHeader::default()],
+            &[],
+            &[],
+            100,
+            1,
+            genesis_hash,
+        );
+
+        let superblock_hash =
+            mining_build_superblock(&[BlockHeader::default()], &[], 1, genesis_hash)
+                .unwrap()
+                .hash();
+
+        assert_eq!(
+            chain_manager.get_superblock_beacon(),
+            CheckpointBeacon {
+                checkpoint: 1,
+                hash_prev_block: superblock_hash,
             }
         );
     }

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -897,8 +897,6 @@ impl ChainManager {
         let consensus_constants = self.consensus_constants();
 
         let superblock_period = u32::from(consensus_constants.superblock_period);
-        let signing_committee_size =
-            u32::from(consensus_constants.superblock_signing_committee_size);
 
         let superblock_index = block_epoch / superblock_period;
         let inventory_manager = InventoryManager::from_registry();
@@ -990,7 +988,7 @@ impl ChainManager {
                 &block_headers,
                 &ars_members,
                 ars_ordered_keys,
-                signing_committee_size,
+                consensus_constants.superblock_signing_committee_size,
                 superblock_index,
                 last_hash,
             );
@@ -1674,29 +1672,6 @@ mod tests {
             CheckpointBeacon {
                 checkpoint: 0,
                 hash_prev_block: Hash::SHA256([1; 32]),
-            }
-        );
-
-        // build a superblock
-        chain_manager.chain_state.superblock_state.build_superblock(
-            &[BlockHeader::default()],
-            &[],
-            &[],
-            100,
-            1,
-            genesis_hash,
-        );
-
-        let superblock_hash =
-            mining_build_superblock(&[BlockHeader::default()], &[], 1, genesis_hash)
-                .unwrap()
-                .hash();
-
-        assert_eq!(
-            chain_manager.get_superblock_beacon(),
-            CheckpointBeacon {
-                checkpoint: 1,
-                hash_prev_block: superblock_hash,
             }
         );
     }

--- a/node/tests/serialization.rs
+++ b/node/tests/serialization.rs
@@ -39,6 +39,7 @@ fn chain_state() {
             extra_rounds: 0,
             initial_difficulty: 0,
             epochs_with_initial_difficulty: 0,
+            superblock_signing_committee_size: 100,
         },
         highest_block_checkpoint: CheckpointBeacon {
             checkpoint: 0,

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -304,6 +304,7 @@ message ConsensusConstants {
     uint32 initial_difficulty = 18;
     uint32 epochs_with_initial_difficulty = 19;
     repeated string bootstrapping_committee = 20;
+    uint32 superblock_signing_committee_size = 21;
 }
 
 message VrfProof {

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -5246,6 +5246,7 @@ fn test_block_with_drpool_and_utxo_set<F: FnMut(&mut Block) -> bool>(
         extra_rounds: 0,
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
+        superblock_signing_committee_size: 100,
     };
 
     // Insert output to utxo
@@ -5506,6 +5507,7 @@ fn block_difficult_proof() {
         extra_rounds: 0,
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
+        superblock_signing_committee_size: 100,
     };
 
     // Insert output to utxo
@@ -6099,6 +6101,7 @@ fn test_blocks_with_limits(
         extra_rounds: 0,
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
+        superblock_signing_committee_size: 100,
     };
 
     // Insert output to utxo
@@ -6661,6 +6664,7 @@ fn genesis_block_after_not_bootstrap_hash() {
         extra_rounds: 0,
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
+        superblock_signing_committee_size: 100,
     };
     let mut signatures_to_verify = vec![];
 
@@ -6734,6 +6738,7 @@ fn genesis_block_value_overflow() {
         extra_rounds: 0,
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
+        superblock_signing_committee_size: 100,
     };
     let vrf_input = CheckpointVRF::default();
     let mut signatures_to_verify = vec![];
@@ -6812,6 +6817,7 @@ fn genesis_block_full_validate() {
         extra_rounds: 0,
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
+        superblock_signing_committee_size: 100,
     };
 
     // Validate block
@@ -6871,6 +6877,7 @@ fn validate_block_transactions_uses_block_number_in_utxo_diff() {
             extra_rounds: 0,
             initial_difficulty: 0,
             epochs_with_initial_difficulty: 0,
+            superblock_signing_committee_size: 100,
         };
         let dr_pool = DataRequestPool::default();
         let vrf = &mut VrfCtx::secp256k1().unwrap();
@@ -7052,6 +7059,7 @@ fn validate_commit_transactions_included_in_utxo_diff() {
             extra_rounds: 0,
             initial_difficulty: 0,
             epochs_with_initial_difficulty: 0,
+            superblock_signing_committee_size: 100,
         };
 
         let (inputs, outputs) = (vec![vti], vec![change_vto.clone()]);


### PR DESCRIPTION
This PR creates the method `update_superblock_signing_committee` that returns the subset of the ARS in charge of signing a specific superblock. In particular:
- Orders the ARS with the method `get_rep_ordered_pkh_list` and stores it in the `chain_state.last_ars`
- Adds the size of the superblock signing committee in the consensus constants, and sets it to 100 as default. 
- Creates the function `update_superblock_signing_committee`, this function is called when building the superblock using the previous superblock_hash.
- Adds previous_ordered_ars_identities and current_ordered_ars_identities in the superblockState

Close #1395 
Close #1391 
Close #1393