### PR TITLE
Send consolidated last superblock beacon

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -60,6 +60,9 @@ pub struct ChainInfo {
     /// Checkpoint of the last block in the blockchain
     pub highest_block_checkpoint: CheckpointBeacon,
 
+    /// Checkpoint hash of the highest superblock in the blockchain
+    pub highest_superblock_checkpoint: CheckpointBeacon,
+
     /// Checkpoint and VRF hash of the highest block in the blockchain
     pub highest_vrf_output: CheckpointVRF,
 }

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -173,6 +173,10 @@ impl ChainManager {
                                 checkpoint: 0,
                                 hash_prev_block,
                             },
+                            highest_superblock_checkpoint: CheckpointBeacon {
+                                checkpoint: 0,
+                                hash_prev_block,
+                            },
                             highest_vrf_output: CheckpointVRF {
                                 checkpoint: 0,
                                 hash_prev_vrf: hash_prev_block,

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -97,7 +97,7 @@ impl ChainManager {
 
         let current_epoch = self.current_epoch.unwrap();
 
-        let chain_info = self.chain_state.chain_info.as_ref().unwrap();
+        let chain_info = self.chain_state.chain_info.as_mut().unwrap();
         let max_vt_weight = chain_info.consensus_constants.max_vt_weight;
         let max_dr_weight = chain_info.consensus_constants.max_dr_weight;
         let mining_bf = chain_info.consensus_constants.mining_backup_factor;
@@ -134,6 +134,9 @@ impl ChainManager {
         let superblock_period = u32::from(chain_info.consensus_constants.superblock_period);
         // Everyone creates superblocks, but only ARS members sign and broadcast them
         if current_epoch % superblock_period == 0 {
+            // TODO: replace this to a proper consolidation when 2/3 of votes are achieved
+            chain_info.highest_superblock_checkpoint =
+                self.chain_state.superblock_state.get_beacon();
             self.superblock_creating_and_broadcasting(ctx, current_epoch);
         }
 

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -664,7 +664,11 @@ impl ChainManager {
 
     /// Retrieves the latest superblock hash an index.
     fn get_superblock_beacon(&self) -> CheckpointBeacon {
-        self.chain_state.superblock_state.get_beacon()
+        self.chain_state
+            .chain_info
+            .as_ref()
+            .expect("ChainInfo is None")
+            .highest_superblock_checkpoint
     }
 
     fn consensus_constants(&self) -> ConsensusConstants {
@@ -1540,13 +1544,11 @@ mod tests {
             ChainInfo, Environment, KeyedSignature, PartialConsensusConstants, PublicKey,
             ValueTransferOutput,
         },
-        superblock::mining_build_superblock,
         transaction::{CommitTransaction, DRTransaction, RevealTransaction},
     };
 
     pub use super::*;
     use witnet_config::{config::consensus_constants_from_partial, defaults::Testnet};
-    use witnet_data_structures::superblock::SuperBlockState;
 
     #[test]
     fn test_rep_info_update() {
@@ -1661,39 +1663,18 @@ mod tests {
                 &Testnet,
             ),
             highest_block_checkpoint: CheckpointBeacon::default(),
+            highest_superblock_checkpoint: CheckpointBeacon {
+                checkpoint: 0,
+                hash_prev_block: Hash::SHA256([1; 32]),
+            },
             highest_vrf_output: CheckpointVRF::default(),
         });
-        chain_manager.chain_state.superblock_state =
-            SuperBlockState::new(Hash::SHA256([1; 32]), vec![]);
-        let genesis_hash = chain_manager.consensus_constants().genesis_hash;
 
         assert_eq!(
             chain_manager.get_superblock_beacon(),
             CheckpointBeacon {
                 checkpoint: 0,
                 hash_prev_block: Hash::SHA256([1; 32]),
-            }
-        );
-
-        // build a superblock
-        chain_manager.chain_state.superblock_state.build_superblock(
-            &[BlockHeader::default()],
-            &[],
-            &[],
-            1,
-            genesis_hash,
-        );
-
-        let superblock_hash =
-            mining_build_superblock(&[BlockHeader::default()], &[], 1, genesis_hash)
-                .unwrap()
-                .hash();
-
-        assert_eq!(
-            chain_manager.get_superblock_beacon(),
-            CheckpointBeacon {
-                checkpoint: 1,
-                hash_prev_block: superblock_hash,
             }
         );
     }

--- a/node/tests/serialization.rs
+++ b/node/tests/serialization.rs
@@ -44,6 +44,10 @@ fn chain_state() {
             checkpoint: 0,
             hash_prev_block: bootstrap_hash,
         },
+        highest_superblock_checkpoint: CheckpointBeacon {
+            checkpoint: 0,
+            hash_prev_block: bootstrap_hash,
+        },
         highest_vrf_output: CheckpointVRF {
             checkpoint: 0,
             hash_prev_vrf: bootstrap_hash,


### PR DESCRIPTION
This PR modifies where the last superblock beacon is taken from to the chain info structure. The superblock hash is copied from the superblock state to chain info when a new superblock will be constructed