### PR TITLE
docs(wallet): update README

### DIFF
--- a/wallet/README.md
+++ b/wallet/README.md
@@ -8,7 +8,6 @@ The Wallet executable is self-documented, so you can just start with:
 > cargo run -- wallet --help
 ```
 
-## Wallet documentation
+## Wallet API
 
-The Wallet documentation is being written in the [Wiki](https://github.com/witnet/witnet-rust/wiki/Wallet) section of this repository.
-
+The Wallet server API is described in the [Developer Docs](https://docs.witnet.io/developer/wallet-api/) section of the [Witnet documentation](https://docs.witnet.io).


### PR DESCRIPTION
This PR just updates the README file from the wallet module.

Once merged, we could also remove the old Wallet Wiki GitHub section as it has been moved (and improved) to a [section](https://docs.witnet.io/developer/wallet-api/) in the Witnet documentation website.

This PR should close #1201 and #1202