### PR TITLE
Include entire ReportContext in RadonReport

### DIFF
--- a/data_structures/src/data_request.rs
+++ b/data_structures/src/data_request.rs
@@ -423,7 +423,7 @@ pub fn create_tally<RT, S: ::std::hash::BuildHasher>(
 where
     RT: TypeLike,
 {
-    if let Stage::Tally(tally_metadata) = &report.metadata {
+    if let Stage::Tally(tally_metadata) = &report.context.stage {
         let commits_count = committers.len();
         let reveals_count = revealers.len();
         let mut out_of_consensus = committers;

--- a/data_structures/src/radon_report.rs
+++ b/data_structures/src/radon_report.rs
@@ -17,8 +17,8 @@ pub struct RadonReport<RT>
 where
     RT: TypeLike,
 {
-    /// Stage-specific metadata.
-    pub metadata: Stage<RT>,
+    /// Execution details, including stage-specific metadata.
+    pub context: ReportContext<RT>,
     /// Vector of partial results (the results in between each of the operators in a script)
     pub partial_results: Option<Vec<RT>>,
     /// This the intercepted result of the script execution: any `IE` raised in runtime has already
@@ -38,7 +38,7 @@ where
     pub fn from_result(result: Result<RT, RT::Error>, context: &ReportContext<RT>) -> Self {
         let intercepted = RT::intercept(result);
         RadonReport {
-            metadata: context.stage.clone(),
+            context: context.clone(),
             partial_results: None,
             result: intercepted,
             running_time: context.duration(),
@@ -58,7 +58,7 @@ where
         .clone();
 
         RadonReport {
-            metadata: context.stage.clone(),
+            context: context.clone(),
             partial_results: Some(intercepted),
             result,
             running_time: context.duration(),

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -601,7 +601,7 @@ mod tests {
         let expected_result = RadonTypes::Integer(RadonInteger::from(0));
         let expected_liars = vec![false];
         assert_eq!(consensus.result, expected_result);
-        let tally_metadata = if let Stage::Tally(tm) = consensus.metadata {
+        let tally_metadata = if let Stage::Tally(tm) = consensus.context.stage {
             tm
         } else {
             panic!("No tally stage");
@@ -633,7 +633,7 @@ mod tests {
         let expected_result = RadonTypes::Integer(RadonInteger::from(0));
         let expected_liars = vec![false, false];
         assert_eq!(consensus.result, expected_result);
-        let tally_metadata = if let Stage::Tally(tm) = consensus.metadata {
+        let tally_metadata = if let Stage::Tally(tm) = consensus.context.stage {
             tm
         } else {
             panic!("No tally stage");
@@ -666,7 +666,7 @@ mod tests {
         let expected_result = RadonTypes::Integer(RadonInteger::from(0));
         let expected_liars = vec![false, false, false];
         assert_eq!(consensus.result, expected_result);
-        let tally_metadata = if let Stage::Tally(tm) = consensus.metadata {
+        let tally_metadata = if let Stage::Tally(tm) = consensus.context.stage {
             tm
         } else {
             panic!("No tally stage");
@@ -703,7 +703,7 @@ mod tests {
         assert_eq!(output_tally, expected);
 
         let expected_liars = vec![false, false, true];
-        let tally_metadata = if let Stage::Tally(tm) = report.metadata {
+        let tally_metadata = if let Stage::Tally(tm) = report.context.stage {
             tm
         } else {
             panic!("No tally stage");
@@ -747,7 +747,7 @@ mod tests {
         assert_eq!(output_tally, expected);
 
         let expected_liars = vec![true, false, false, true];
-        let tally_metadata = if let Stage::Tally(tm) = report.metadata {
+        let tally_metadata = if let Stage::Tally(tm) = report.context.stage {
             tm
         } else {
             panic!("No tally stage");
@@ -782,7 +782,7 @@ mod tests {
         assert_eq!(output_tally, expected);
 
         let expected_liars = vec![false, false, false, false];
-        let tally_metadata = if let Stage::Tally(tm) = report.metadata {
+        let tally_metadata = if let Stage::Tally(tm) = report.context.stage {
             tm
         } else {
             panic!("No tally stage");


### PR DESCRIPTION
This enables clients like Sheikah to get all the available details for tracing execution of scripts and subscripts. 