### PR TITLE
feat(superblocks): create superblocks even if there are no blocks during superepoch

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -2769,10 +2769,6 @@ pub struct ChainState {
     pub node_stats: NodeStats,
     /// Alternative public key mapping
     pub alt_keys: AltKeys,
-    /// Last ARS pkhs
-    pub last_ars: Vec<PublicKeyHash>,
-    /// Last ARS keys vector ordered by reputation
-    pub last_ars_ordered_keys: Vec<Bn256PublicKey>,
     /// Current superblock state
     pub superblock_state: SuperBlockState,
 }

--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -383,13 +383,23 @@ mod tests {
         chain::{BlockMerkleRoots, Bn256SecretKey, CheckpointBeacon, PublicKey},
         vrf::BlockEligibilityClaim,
     };
-    use witnet_crypto::hash::calculate_sha256;
+    use witnet_crypto::hash::{calculate_sha256, EMPTY_SHA256};
 
     #[test]
     fn test_superblock_creation_no_blocks() {
         let default_hash = Hash::default();
         let superblock = mining_build_superblock(&[], &[], 0, default_hash);
-        assert_eq!(superblock, None);
+
+        let expected = SuperBlock {
+            ars_length: 0,
+            data_request_root: default_hash,
+            tally_root: default_hash,
+            ars_root: Hash::from(EMPTY_SHA256),
+            index: 0,
+            last_block: default_hash,
+            last_block_in_previous_superblock: default_hash,
+        };
+        assert_eq!(superblock, expected);
     }
 
     static DR_MERKLE_ROOT_1: &str =
@@ -434,8 +444,7 @@ mod tests {
             last_block_in_previous_superblock: default_hash,
         };
 
-        let superblock =
-            mining_build_superblock(&[block], &[default_hash], 0, default_hash).unwrap();
+        let superblock = mining_build_superblock(&[block], &[default_hash], 0, default_hash);
         assert_eq!(superblock, expected_superblock);
     }
 
@@ -500,7 +509,7 @@ mod tests {
         };
 
         let superblock =
-            mining_build_superblock(&[block_1, block_2], &[default_hash], 0, default_hash).unwrap();
+            mining_build_superblock(&[block_1, block_2], &[default_hash], 0, default_hash);
         assert_eq!(superblock, expected_superblock);
     }
 
@@ -535,9 +544,7 @@ mod tests {
         let ars2 = vec![p2.pkh()];
         let mut sbs = SuperBlockState::new(Hash::default(), ars1);
 
-        let sb1 = sbs
-            .build_superblock(&block_headers, &ars2, &ars2, &[], 100, 0, Hash::default())
-            .unwrap();
+        let sb1 = sbs.build_superblock(&block_headers, &ars2, &[], 100, 0, Hash::default());
         let mut v0 = SuperBlockVote::new_unsigned(sb1.hash(), 0);
 
         v0.secp256k1_signature.public_key = p1;
@@ -562,23 +569,20 @@ mod tests {
         let bls_pk =
             Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[1; 32]).unwrap())
                 .unwrap();
-        let sb1 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars_identities,
-                &ars_identities,
-                &[bls_pk],
-                100,
-                0,
-                genesis_hash,
-            )
-            .unwrap();
+        let sb1 = sbs.build_superblock(
+            &block_headers,
+            &ars_identities,
+            &[bls_pk],
+            100,
+            0,
+            genesis_hash,
+        );
         let v1 = SuperBlockVote::new_unsigned(sb1.hash(), 0);
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::NotInSigningCommittee);
     }
 
     #[test]
-    fn superblock_state_first_superblock_none() {
+    fn superblock_state_first_superblock_empty() {
         // If the first superblock is None, the state is not updated except for the superblock_index
         let mut sbs = SuperBlockState::default();
 
@@ -590,20 +594,45 @@ mod tests {
                 .unwrap();
 
         let genesis_hash = Hash::default();
-        assert_eq!(
-            sbs.build_superblock(
-                &block_headers,
-                &ars_identities,
-                &ars_identities,
-                &[bls_pk],
-                100,
-                0,
-                genesis_hash
-            ),
-            None
+
+        let first_superblock = sbs.build_superblock(
+            &block_headers,
+            &ars_identities,
+            &[bls_pk.clone()],
+            100,
+            0,
+            genesis_hash,
         );
 
-        let mut expected_sbs = SuperBlockState::default();
+        let expected_superblock = SuperBlock {
+            ars_length: 1,
+            data_request_root: Hash::default(),
+            tally_root: Hash::default(),
+            ars_root: hash_merkle_tree_root(&hash_key_leaves(&[bls_pk.clone()])),
+            index: 0,
+            last_block: genesis_hash,
+            last_block_in_previous_superblock: genesis_hash,
+        };
+        assert_eq!(first_superblock, expected_superblock);
+
+        let expected_superblock_hash =
+            "bcbead467194d639bc8162725db72495056b65c4ff8caf033f86f76c118874c9"
+                .parse()
+                .unwrap();
+
+        let mut expected_sbs = SuperBlockState {
+            current_ars_identities: ars_identities.iter().cloned().collect(),
+            current_ordered_ars_identities: ars_identities.iter().cloned().collect(),
+            current_signing_committee: Some(HashSet::new()),
+            current_superblock_hash: expected_superblock_hash,
+            current_superblock_index: 0,
+            identities_that_voted_more_than_once: Default::default(),
+            previous_ars_identities: Some(HashSet::new()),
+            previous_ars_ordered_keys: vec![bls_pk],
+            received_superblocks: Default::default(),
+            votes_of_each_identity: Default::default(),
+            votes_on_each_superblock: Default::default(),
+        };
         expected_sbs.current_superblock_index = 0;
         assert_eq!(sbs, expected_sbs);
     }
@@ -618,36 +647,38 @@ mod tests {
             Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[1; 32]).unwrap())
                 .unwrap();
         let genesis_hash = Hash::default();
-        let sb1 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars_identities,
-                &ars_identities,
-                &[bls_pk.clone()],
-                100,
-                0,
-                genesis_hash,
-            )
-            .unwrap();
 
+        sbs.build_superblock(
+            &block_headers,
+            &ars_identities,
+            &[bls_pk.clone()],
+            100,
+            0,
+            genesis_hash,
+        );
+
+        let expected_second_superblock = SuperBlock {
+            ars_length: 1,
+            data_request_root: Hash::default(),
+            tally_root: Hash::default(),
+            ars_root: hash_merkle_tree_root(&hash_key_leaves(&[bls_pk.clone()])),
+            index: 1,
+            last_block: genesis_hash,
+            last_block_in_previous_superblock: genesis_hash,
+        };
         let mut expected_sbs = sbs.clone();
         assert_eq!(
-            sbs.build_superblock(
-                &[],
-                &ars_identities,
-                &ars_identities,
-                &[bls_pk],
-                100,
-                1,
-                genesis_hash
-            ),
-            None
+            sbs.build_superblock(&[], &ars_identities, &[bls_pk], 100, 1, genesis_hash),
+            expected_second_superblock
         );
 
         // The only think that should change is the superblock_index
         expected_sbs.current_superblock_index = 1;
         // And the superblock_hash, which will be set to the previous superblock
-        expected_sbs.current_superblock_hash = sb1.hash();
+        expected_sbs.current_superblock_hash = expected_second_superblock.hash();
+        expected_sbs.current_signing_committee = Some(ars_identities.iter().cloned().collect());
+        expected_sbs.previous_ars_identities = Some(ars_identities.iter().cloned().collect());
+        expected_sbs.previous_ordered_ars_identities = ars_identities;
         assert_eq!(sbs, expected_sbs);
     }
 
@@ -668,32 +699,26 @@ mod tests {
             Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[1; 32]).unwrap())
                 .unwrap();
         let genesis_hash = Hash::default();
-        let _sb1 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars_identities,
-                &ars_identities,
-                &[bls_pk.clone()],
-                100,
-                0,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb1 = sbs.build_superblock(
+            &block_headers,
+            &ars_identities,
+            &[bls_pk.clone()],
+            100,
+            0,
+            genesis_hash,
+        );
         // After building a new superblock the cache is invalidated but the previous ARS is still empty
         assert_eq!(sbs.add_vote(&v0), AddSuperBlockVote::NotInSigningCommittee);
         assert_eq!(sbs.add_vote(&v0), AddSuperBlockVote::AlreadySeen);
 
-        let _sb2 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars_identities,
-                &ars_identities,
-                &[bls_pk],
-                100,
-                1,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb2 = sbs.build_superblock(
+            &block_headers,
+            &ars_identities,
+            &[bls_pk],
+            100,
+            1,
+            genesis_hash,
+        );
         let v1 = SuperBlockVote::new_unsigned(Hash::SHA256([2; 32]), 1);
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::NotInSigningCommittee);
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::AlreadySeen);
@@ -729,45 +754,15 @@ mod tests {
 
         // Superblock votes for index 0 cannot be validated because we do not know the ARS for index -1
         // (because it does not exist)
-        let _sb0 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars0,
-                &ars0,
-                &ars0_ordered,
-                100,
-                0,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb0 = sbs.build_superblock(&block_headers, &ars0, &ars0_ordered, 100, 0, genesis_hash);
 
         // The ARS included in superblock 0 is empty, so none of the superblock votes for index 1
         // can be valid, they all return `NotInSigningCommittee`
-        let _sb1 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars1,
-                &ars1,
-                &ars1_ordered,
-                100,
-                1,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb1 = sbs.build_superblock(&block_headers, &ars1, &ars1_ordered, 100, 1, genesis_hash);
 
         // The ARS included in superblock 1 contains only identity p1, so only its vote will be
         // valid in superblock votes for index 2
-        let sb2 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars2,
-                &ars2,
-                &ars2_ordered,
-                100,
-                2,
-                genesis_hash,
-            )
-            .unwrap();
+        let sb2 = sbs.build_superblock(&block_headers, &ars2, &ars2_ordered, 100, 2, genesis_hash);
         let mut v1 = SuperBlockVote::new_unsigned(sb2.hash(), 2);
         v1.secp256k1_signature.public_key = p1.clone();
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::ValidWithSameHash);
@@ -799,31 +794,11 @@ mod tests {
 
         // Superblock votes for index 0 cannot be validated because we do not know the ARS for index -1
         // (because it does not exist)
-        let _sb0 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars0,
-                &ars0,
-                &ars0_ordered,
-                100,
-                0,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb0 = sbs.build_superblock(&block_headers, &ars0, &ars0_ordered, 100, 0, genesis_hash);
 
         // The ARS included in superblock 0 is empty, so none of the superblock votes for index 1
         // can be valid, they all return `NotInSigningCommittee`
-        let _sb1 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars1,
-                &ars1,
-                &ars1_ordered,
-                100,
-                1,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb1 = sbs.build_superblock(&block_headers, &ars1, &ars1_ordered, 100, 1, genesis_hash);
 
         let mut v2 = SuperBlockVote::new_unsigned(Hash::SHA256([2; 32]), 2);
         v2.secp256k1_signature.public_key = p1.clone();
@@ -831,17 +806,7 @@ mod tests {
 
         // The ARS included in superblock 1 contains only identity p1, so only its vote will be
         // valid in superblock votes for index 2
-        let sb2 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars2,
-                &ars2,
-                &ars2_ordered,
-                100,
-                2,
-                genesis_hash,
-            )
-            .unwrap();
+        let sb2 = sbs.build_superblock(&block_headers, &ars2, &ars2_ordered, 100, 2, genesis_hash);
         let mut v1 = SuperBlockVote::new_unsigned(sb2.hash(), 2);
         v1.secp256k1_signature.public_key = p1;
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::DoubleVote);
@@ -870,45 +835,15 @@ mod tests {
 
         // Superblock votes for index 0 cannot be validated because we do not know the ARS for index -1
         // (because it does not exist)
-        let _sb0 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars0,
-                &ars0,
-                &ars0_ordered,
-                100,
-                0,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb0 = sbs.build_superblock(&block_headers, &ars0, &ars0_ordered, 100, 0, genesis_hash);
 
         // The ARS included in superblock 0 is empty, so none of the superblock votes for index 1
         // can be valid, they all return `NotInSigningCommittee`
-        let _sb1 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars1,
-                &ars1,
-                &ars1_ordered,
-                100,
-                1,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb1 = sbs.build_superblock(&block_headers, &ars1, &ars1_ordered, 100, 1, genesis_hash);
 
         // The ARS included in superblock 1 contains only identity p1, so only its vote will be
         // valid in superblock votes for index 2
-        let sb2 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars2,
-                &ars2,
-                &ars2_ordered,
-                100,
-                2,
-                genesis_hash,
-            )
-            .unwrap();
+        let sb2 = sbs.build_superblock(&block_headers, &ars2, &ars2_ordered, 100, 2, genesis_hash);
         let mut v1 = SuperBlockVote::new_unsigned(sb2.hash(), 2);
         v1.secp256k1_signature.public_key = p1.clone();
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::ValidWithSameHash);
@@ -965,35 +900,15 @@ mod tests {
 
         // Superblock votes for index 0 cannot be validated because we do not know the ARS for index -1
         // (because it does not exist)
-        let sb0 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars0,
-                &ars0,
-                &ars0_ordered,
-                100,
-                0,
-                genesis_hash,
-            )
-            .unwrap();
+        let sb0 = sbs.build_superblock(&block_headers, &ars0, &ars0_ordered, 100, 0, genesis_hash);
         let (v1, v2, v3) = create_votes(sb0.hash(), 0);
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::NotInSigningCommittee);
         assert_eq!(sbs.add_vote(&v2), AddSuperBlockVote::NotInSigningCommittee);
         assert_eq!(sbs.add_vote(&v3), AddSuperBlockVote::NotInSigningCommittee);
 
         // The ARS included in superblock 0 is empty, so none of the superblock votes for index 1
-        // can be valid, they all return `NotInSigningCommittee`
-        let sb1 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars1,
-                &ars1,
-                &ars1_ordered,
-                100,
-                1,
-                genesis_hash,
-            )
-            .unwrap();
+        // can be valid, they all return `NotInArs`
+        let sb1 = sbs.build_superblock(&block_headers, &ars1, &ars1_ordered, 100, 1, genesis_hash);
         let (v1, v2, v3) = create_votes(sb1.hash(), 1);
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::NotInSigningCommittee);
         assert_eq!(sbs.add_vote(&v2), AddSuperBlockVote::NotInSigningCommittee);
@@ -1001,17 +916,7 @@ mod tests {
 
         // The ARS included in superblock 1 contains only identity p1, so only the vote v1 will be
         // valid in superblock votes for index 2
-        let sb2 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars2,
-                &ars2,
-                &ars2_ordered,
-                100,
-                2,
-                genesis_hash,
-            )
-            .unwrap();
+        let sb2 = sbs.build_superblock(&block_headers, &ars2, &ars2_ordered, 100, 2, genesis_hash);
         let (v1, v2, v3) = create_votes(sb2.hash(), 2);
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::ValidWithSameHash);
         assert_eq!(sbs.add_vote(&v2), AddSuperBlockVote::NotInSigningCommittee);
@@ -1019,17 +924,7 @@ mod tests {
 
         // The ARS included in superblock 2 contains only identity p2, so only the vote v2 will be
         // valid in superblock votes for index 3
-        let sb3 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars3,
-                &ars3,
-                &ars3_ordered,
-                100,
-                3,
-                genesis_hash,
-            )
-            .unwrap();
+        let sb3 = sbs.build_superblock(&block_headers, &ars3, &ars3_ordered, 100, 3, genesis_hash);
         let (v1, v2, v3) = create_votes(sb3.hash(), 3);
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::NotInSigningCommittee);
         assert_eq!(sbs.add_vote(&v2), AddSuperBlockVote::ValidWithSameHash);
@@ -1037,17 +932,7 @@ mod tests {
 
         // The ARS included in superblock 3 contains only identity p3, so only the vote v3 will be
         // valid in superblock votes for index 4
-        let sb4 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars4,
-                &ars4,
-                &ars4_ordered,
-                100,
-                4,
-                genesis_hash,
-            )
-            .unwrap();
+        let sb4 = sbs.build_superblock(&block_headers, &ars4, &ars4_ordered, 100, 4, genesis_hash);
         let (v1, v2, v3) = create_votes(sb4.hash(), 4);
         assert_eq!(sbs.add_vote(&v1), AddSuperBlockVote::NotInSigningCommittee);
         assert_eq!(sbs.add_vote(&v2), AddSuperBlockVote::NotInSigningCommittee);
@@ -1078,25 +963,21 @@ mod tests {
         let ars_identities = vec![p1.pkh(), p2.pkh(), p3.pkh()];
         let ordered_ars = vec![bls_pk1, bls_pk2, bls_pk3];
         let genesis_hash = Hash::default();
-        let _sb1 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars_identities,
-                &ars_identities,
-                &ordered_ars,
-                100,
-                0,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb1 = sbs.build_superblock(
+            &block_headers,
+            &ars_identities,
+            &ordered_ars,
+            100,
+            0,
+            genesis_hash,
+        );
 
         let expected_sb2 = mining_build_superblock(
             &block_headers,
             &hash_key_leaves(&ordered_ars),
             1,
             genesis_hash,
-        )
-        .unwrap();
+        );
         let sb2_hash = expected_sb2.hash();
 
         // Receive a superblock vote for index 1 when we are in index 0
@@ -1107,17 +988,14 @@ mod tests {
         // still the one with index 0, while the vote has index 1
         assert_eq!(sbs.votes_on_each_superblock, HashMap::new());
         // Create the second superblock afterwards
-        let sb2 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars_identities,
-                &ars_identities,
-                &ordered_ars,
-                100,
-                1,
-                genesis_hash,
-            )
-            .unwrap();
+        let sb2 = sbs.build_superblock(
+            &block_headers,
+            &ars_identities,
+            &ordered_ars,
+            100,
+            1,
+            genesis_hash,
+        );
         assert_eq!(sb2, expected_sb2);
         let mut hh: HashMap<_, Vec<_>> = HashMap::new();
         hh.entry(sb2_hash).or_default().push(v1);
@@ -1133,17 +1011,14 @@ mod tests {
 
         // But if we are in index 2 and receive a vote for index 1, the votes are simply marked as
         // "MaybeValid", they are not included in votes_on_local_superlock
-        let _sb3 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars_identities,
-                &ars_identities,
-                &ordered_ars,
-                100,
-                2,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb3 = sbs.build_superblock(
+            &block_headers,
+            &ars_identities,
+            &ordered_ars,
+            100,
+            2,
+            genesis_hash,
+        );
         // votes_on_each_superblock are cleared when the local superblock changes
         assert_eq!(sbs.votes_on_each_superblock, HashMap::new());
         let mut v3 = SuperBlockVote::new_unsigned(sb2_hash, 1);
@@ -1177,29 +1052,23 @@ mod tests {
         let ordered_ars = vec![bls_pk1, bls_pk2, bls_pk3];
         let genesis_hash = Hash::default();
         // superblock with index 0.
-        let _sb1 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars_identities,
-                &ars_identities,
-                &ordered_ars,
-                2,
-                0,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb1 = sbs.build_superblock(
+            &block_headers,
+            &ars_identities,
+            &ordered_ars,
+            2,
+            0,
+            genesis_hash,
+        );
         // superblock with index 1
-        let _sb2 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars_identities,
-                &ars_identities,
-                &ordered_ars,
-                2,
-                1,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb2 = sbs.build_superblock(
+            &block_headers,
+            &ars_identities,
+            &ordered_ars,
+            2,
+            1,
+            genesis_hash,
+        );
 
         let expected_sb2 = mining_build_superblock(
             &block_headers,
@@ -1247,17 +1116,14 @@ mod tests {
         let ars_identities = vec![p1.pkh(), p2.pkh(), p3.pkh()];
         let ordered_ars = vec![bls_pk1, bls_pk2, bls_pk3];
         let genesis_hash = Hash::default();
-        let _sb1 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars_identities,
-                &ars_identities,
-                &ordered_ars,
-                100,
-                0,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb1 = sbs.build_superblock(
+            &block_headers,
+            &ars_identities,
+            &ordered_ars,
+            100,
+            0,
+            genesis_hash,
+        );
         sbs.previous_ordered_ars_identities = ars_identities.clone();
         sbs.previous_ars_identities = Some(ars_identities.iter().cloned().collect());
         let committee_size = 4;
@@ -1307,17 +1173,14 @@ mod tests {
         ];
         let ordered_ars = vec![bls_pk1, bls_pk2, bls_pk3];
         let genesis_hash = Hash::default();
-        let _sb1 = sbs
-            .build_superblock(
-                &block_headers,
-                &ars_identities,
-                &ars_identities,
-                &ordered_ars,
-                4,
-                0,
-                genesis_hash,
-            )
-            .unwrap();
+        let _sb1 = sbs.build_superblock(
+            &block_headers,
+            &ars_identities,
+            &ordered_ars,
+            4,
+            0,
+            genesis_hash,
+        );
         sbs.previous_ordered_ars_identities = ars_identities.clone();
         sbs.previous_ars_identities = Some(ars_identities.iter().cloned().collect());
         let committee_size = 4;
@@ -1423,6 +1286,7 @@ mod tests {
         assert_ne!(hashes, compressed_hashes);
         assert_eq!(hashes, expected_hashes);
     }
+
     #[test]
     fn test_get_beacon_1() {
         let superblock_state = SuperBlockState::default();
@@ -1432,7 +1296,7 @@ mod tests {
             beacon,
             CheckpointBeacon {
                 checkpoint: 0,
-                hash_prev_block: Hash::default()
+                hash_prev_block: Hash::default(),
             }
         );
     }
@@ -1451,7 +1315,7 @@ mod tests {
             beacon,
             CheckpointBeacon {
                 checkpoint: 0,
-                hash_prev_block: Hash::SHA256([1; 32])
+                hash_prev_block: Hash::SHA256([1; 32]),
             }
         );
     }
@@ -1471,7 +1335,7 @@ mod tests {
             beacon,
             CheckpointBeacon {
                 checkpoint: 1,
-                hash_prev_block: Hash::default()
+                hash_prev_block: Hash::default(),
             }
         );
     }

--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -186,69 +186,60 @@ impl SuperBlockState {
         signing_committee_size: u32,
         superblock_index: u32,
         last_block_in_previous_superblock: Hash,
-    ) -> Option<SuperBlock> {
+    ) -> SuperBlock {
         self.current_superblock_index = superblock_index;
         self.votes_on_each_superblock.clear();
         self.votes_of_each_identity.clear();
         let key_leaves = hash_key_leaves(ars_ordered_bn256_keys);
 
-        match mining_build_superblock(
+        let superblock = mining_build_superblock(
             block_headers,
             &key_leaves,
             superblock_index,
             last_block_in_previous_superblock,
-        ) {
-            None => {
-                // Clear state when there is no superblock
-                // Note that the ARS members list is not updated in this case
-                self.received_superblocks.clear();
+        );
 
-                None
-            }
-            Some(superblock) => {
-                // Save ARS identities:
-                // previous = current
-                // current = ars_pkh_keys
+        // Save ARS identities:
+        // previous = current
+        // current = ars_pkh_keys
 
-                self.previous_ars_identities =
-                    Some(std::mem::take(&mut self.current_ars_identities));
-                self.current_ars_identities
-                    .extend(ars_pkh_keys.iter().cloned());
-                self.previous_ars_ordered_keys = ars_ordered_bn256_keys.to_vec();
-                self.previous_ordered_ars_identities = self.current_ordered_ars_identities.to_vec();
-                self.current_ordered_ars_identities = ars_pkh_keys_ordered.to_vec();
-                // For the current superblock hash, calculate the signing committee
-                self.current_signing_committee = calculate_superblock_signing_committee(
-                    self.previous_ars_identities.clone(),
-                    self.previous_ordered_ars_identities.clone(),
-                    signing_committee_size,
-                    self.current_superblock_hash,
-                );
+        self.previous_ars_identities = Some(std::mem::take(&mut self.current_ars_identities));
+        self.current_ars_identities
+            .extend(ars_pkh_keys.iter().cloned());
+        self.previous_ars_ordered_keys = ars_ordered_bn256_keys.to_vec();
+        self.previous_ordered_ars_identities = self.current_ordered_ars_identities.to_vec();
+        self.current_ordered_ars_identities = ars_pkh_keys_ordered.to_vec();
 
-                self.current_superblock_hash = superblock.hash();
+        // For the current superblock hash, calculate the signing committee
+        self.current_signing_committee = calculate_superblock_signing_committee(
+            self.previous_ars_identities.clone(),
+            self.previous_ordered_ars_identities.clone(),
+            signing_committee_size,
+            self.current_superblock_hash,
+        );
 
-                // This replace is needed because the for loop below needs unique access to self,
-                // but it cannot have unique access to self if it is iterating over
-                // self.received_superblocks.drain()
-                let mut old_superblock_votes =
-                    std::mem::replace(&mut self.received_superblocks, HashSet::new());
-                // Process old superblock votes
-                for sbv in old_superblock_votes.drain() {
-                    // Validate again, check if they are valid now
-                    let valid = self.is_valid(&sbv);
+        self.current_superblock_hash = superblock.hash();
 
-                    // If the superblock vote is valid, store it
-                    if valid == Some(true) {
-                        self.insert_vote(sbv);
-                    }
-                }
-                // old_superblock_votes should be empty, as we have drained it
-                // But swap it back to reuse allocated memory
-                self.received_superblocks = old_superblock_votes;
+        // This replace is needed because the for loop below needs unique access to self,
+        // but it cannot have unique access to self if it is iterating over
+        // self.received_superblocks.drain()
+        let mut old_superblock_votes =
+            std::mem::replace(&mut self.received_superblocks, HashSet::new());
+        // Process old superblock votes
+        for sbv in old_superblock_votes.drain() {
+            // Validate again, check if they are valid now
+            let valid = self.is_valid(&sbv);
 
-                Some(superblock)
+            // If the superblock vote is valid, store it
+            if valid == Some(true) {
+                self.insert_vote(sbv);
             }
         }
+        // old_superblock_votes should be empty, as we have drained it
+        // But swap it back to reuse allocated memory
+        self.received_superblocks = old_superblock_votes;
+
+        superblock
     }
 
     /// Returns the last superblock hash and index.
@@ -322,31 +313,50 @@ fn magic_partition<T: Clone>(v: &[T], first: usize, size: usize) -> Vec<T> {
 }
 
 /// Produces a `SuperBlock` that includes the blocks in `block_headers` if there is at least one of them.
+/// // remove return Option
 pub fn mining_build_superblock(
     block_headers: &[BlockHeader],
     ars_ordered_hash_leaves: &[Hash],
     index: u32,
     last_block_in_previous_superblock: Hash,
-) -> Option<SuperBlock> {
-    let last_block = block_headers.last()?.hash();
-    let merkle_drs: Vec<Hash> = block_headers
-        .iter()
-        .map(|b| b.merkle_roots.dr_hash_merkle_root)
-        .collect();
-    let merkle_tallies: Vec<Hash> = block_headers
-        .iter()
-        .map(|b| b.merkle_roots.tally_hash_merkle_root)
-        .collect();
+) -> SuperBlock {
+    let last_block = block_headers.last();
+    match last_block {
+        None =>
+        // Build "empty" Superblock (there were no blocks during super-epoch)
+        {
+            SuperBlock {
+                ars_length: ars_ordered_hash_leaves.len() as u64,
+                ars_root: hash_merkle_tree_root(ars_ordered_hash_leaves),
+                data_request_root: Hash::default(),
+                tally_root: Hash::default(),
+                index,
+                last_block: last_block_in_previous_superblock,
+                last_block_in_previous_superblock,
+            }
+        }
+        Some(last_block_header) => {
+            let last_block_hash = last_block_header.hash();
+            let merkle_drs: Vec<Hash> = block_headers
+                .iter()
+                .map(|b| b.merkle_roots.dr_hash_merkle_root)
+                .collect();
+            let merkle_tallies: Vec<Hash> = block_headers
+                .iter()
+                .map(|b| b.merkle_roots.tally_hash_merkle_root)
+                .collect();
 
-    Some(SuperBlock {
-        ars_length: ars_ordered_hash_leaves.len() as u64,
-        data_request_root: hash_merkle_tree_root(&merkle_drs),
-        tally_root: hash_merkle_tree_root(&merkle_tallies),
-        ars_root: hash_merkle_tree_root(ars_ordered_hash_leaves),
-        index,
-        last_block,
-        last_block_in_previous_superblock,
-    })
+            SuperBlock {
+                ars_length: ars_ordered_hash_leaves.len() as u64,
+                data_request_root: hash_merkle_tree_root(&merkle_drs),
+                tally_root: hash_merkle_tree_root(&merkle_tallies),
+                ars_root: hash_merkle_tree_root(ars_ordered_hash_leaves),
+                index,
+                last_block: last_block_hash,
+                last_block_in_previous_superblock,
+            }
+        }
+    }
 }
 
 /// Takes a set of keys and calculates their hashes roots to be used as leaves.

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -4,8 +4,8 @@ use std::{collections::BTreeMap, collections::HashMap, convert::TryFrom, net::So
 
 use witnet_data_structures::{
     chain::{
-        get_utxo_info, Bn256PublicKey, ChainState, CheckpointBeacon, DataRequestInfo,
-        DataRequestReport, Epoch, Hash, Hashable, NodeStats, PublicKeyHash, Reputation, UtxoInfo,
+        get_utxo_info, ChainState, CheckpointBeacon, DataRequestInfo, DataRequestReport, Epoch,
+        Hash, Hashable, NodeStats, PublicKeyHash, Reputation, UtxoInfo,
     },
     error::{ChainInfoError, TransactionError::DataRequestNotFound},
     transaction::{DRTransaction, Transaction, VTTransaction},
@@ -346,18 +346,6 @@ impl Handler<AddBlocks> for ChainManager {
                             if block.hash() != consensus_constants.genesis_hash {
                                 if let Some(ref mut rep_engine) = self.chain_state.reputation_engine
                                 {
-                                    // Store the ARS and the order of the keys
-                                    let trs = rep_engine.trs();
-                                    let current_ars =
-                                        rep_engine.ars().active_identities().cloned().collect();
-                                    let alt_keys = &self.chain_state.alt_keys;
-
-                                    let ordered_alts: Vec<Bn256PublicKey> =
-                                        alt_keys.get_rep_ordered_bn256_list(trs);
-                                    // last ars with previous block ars info
-                                    self.chain_state.last_ars = current_ars;
-                                    self.chain_state.last_ars_ordered_keys = ordered_alts;
-
                                     if let Err(e) = rep_engine.ars_mut().update_empty(block_epoch) {
                                         log::error!(
                                             "Error updating reputation before processing block: {}",

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -423,7 +423,6 @@ impl ChainManager {
                         );
 
                         actix::fut::err(())
-
                     } else {
                         // Update `current_retrieval_count` thanks to interior mutability of the
                         // `cloned_retrieval_count` reference. This is a recursive operation so as
@@ -456,7 +455,7 @@ impl ChainManager {
                         None => {
                             log::error!("ChainInfo is None");
                             return actix::fut::err(());
-                        },
+                        }
                     };
 
                     let block_number_limit = act.chain_state.block_number().saturating_sub(collateral_age);
@@ -473,12 +472,12 @@ impl ChainManager {
                         // the next epoch or at least in two epochs
                         u64::from(checkpoint_period),
                         // The block number must be lower than this limit
-                        block_number_limit
+                        block_number_limit,
                     ) {
                         Ok(collateral) => actix::fut::ok((vrf_proof, collateral)),
                         Err(TransactionError::NoMoney {
                                 available_balance, transaction_value, ..
-                        }) => {
+                            }) => {
                             let required_collateral = transaction_value;
                             log::warn!("Not enough mature UTXOs for collateral for data request {}: Available balance: {}, Required collateral: {}",
                                 Yellow.bold().paint(dr_pointer.to_string()),
@@ -534,7 +533,7 @@ impl ChainManager {
                         Err(e) => {
                             log::error!("Couldn't decode tally value from bytes: {}", e);
                             actix::fut::err(())
-                        },
+                        }
                     }
                 })
                 .and_then(move |(reveal_bytes, vrf_proof_dr, collateral), act, _| {
@@ -591,65 +590,52 @@ impl ChainManager {
     ) {
         self.construct_superblock(ctx, current_epoch)
             .and_then(move |superblock, act, _ctx| {
-                match superblock {
-                    Some(superblock) => {
-                        let superblock_hash = superblock.hash();
-                        log::debug!(
-                            "SUPERBLOCK #{} {}: {:?}",
-                            superblock.index,
-                            superblock_hash,
-                            superblock
-                        );
+                let superblock_hash = superblock.hash();
+                log::debug!(
+                    "SUPERBLOCK #{} {}: {:?}",
+                    superblock.index,
+                    superblock_hash,
+                    superblock
+                );
 
-                        let mut superblock_vote =
-                            SuperBlockVote::new_unsigned(superblock_hash, superblock.index);
-                        let bn256_message = superblock_vote.bn256_signature_message();
-                        let fut = signature_mngr::bn256_sign(bn256_message)
+                let mut superblock_vote =
+                    SuperBlockVote::new_unsigned(superblock_hash, superblock.index);
+                let bn256_message = superblock_vote.bn256_signature_message();
+
+                signature_mngr::bn256_sign(bn256_message)
+                    .map_err(|e| {
+                        log::error!("Failed to sign superblock with bn256 key: {}", e);
+                    })
+                    .and_then(move |bn256_keyed_signature| {
+                        // Actually, we don't need to include the BN256 public key because
+                        // it is stored in the `alt_keys` mapping, indexed by the
+                        // secp256k1 public key hash
+                        let bn256_signature = bn256_keyed_signature.signature;
+                        superblock_vote.set_bn256_signature(bn256_signature);
+                        let secp256k1_message = superblock_vote.secp256k1_signature_message();
+                        let sign_bytes = calculate_sha256(&secp256k1_message).0;
+                        signature_mngr::sign_data(sign_bytes)
+                            .map(move |secp256k1_signature| {
+                                superblock_vote.set_secp256k1_signature(secp256k1_signature);
+
+                                superblock_vote
+                            })
                             .map_err(|e| {
-                                log::error!("Failed to sign superblock with bn256 key: {}", e);
+                                log::error!("Failed to sign superblock with secp256k1 key: {}", e);
                             })
-                            .and_then(move |bn256_keyed_signature| {
-                                // Actually, we don't need to include the BN256 public key because
-                                // it is stored in the `alt_keys` mapping, indexed by the
-                                // secp256k1 public key hash
-                                let bn256_signature = bn256_keyed_signature.signature;
-                                superblock_vote.set_bn256_signature(bn256_signature);
-                                let secp256k1_message =
-                                    superblock_vote.secp256k1_signature_message();
-                                let sign_bytes = calculate_sha256(&secp256k1_message).0;
-                                signature_mngr::sign_data(sign_bytes)
-                                    .map(move |secp256k1_signature| {
-                                        superblock_vote
-                                            .set_secp256k1_signature(secp256k1_signature);
+                    })
+                    .into_actor(act)
+                    .and_then(|res, act, ctx| match act.add_superblock_vote(res, ctx) {
+                        Ok(()) => actix::fut::ok(()),
+                        Err(e) => {
+                            log::error!(
+                                "Error when broadcasting recently created superblock: {}",
+                                e
+                            );
 
-                                        superblock_vote
-                                    })
-                                    .map_err(|e| {
-                                        log::error!(
-                                            "Failed to sign superblock with secp256k1 key: {}",
-                                            e
-                                        );
-                                    })
-                            })
-                            .into_actor(act)
-                            .and_then(|res, act, ctx| match act.add_superblock_vote(res, ctx) {
-                                Ok(()) => actix::fut::ok(()),
-                                Err(e) => {
-                                    log::error!(
-                                        "Error when broadcasting recently created superblock: {}",
-                                        e
-                                    );
-
-                                    actix::fut::err(())
-                                }
-                            });
-                        actix::fut::Either::A(fut)
-                    }
-                    None => {
-                        log::warn!("No blocks to build a superblock");
-                        actix::fut::Either::B(actix::fut::ok(()))
-                    }
-                }
+                            actix::fut::err(())
+                        }
+                    })
             })
             .wait(ctx)
     }
@@ -1133,6 +1119,7 @@ mod tests {
 
     static LAST_VRF_INPUT: &str =
         "4da71b67e7e50ae4ad06a71e505244f8b490da55fc58c50386c908f7146d2239";
+
     #[test]
     fn build_signed_empty_block() {
         // Initialize transaction_pool with 1 transaction

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -592,7 +592,7 @@ impl ChainManager {
             .and_then(move |superblock, act, _ctx| {
                 let superblock_hash = superblock.hash();
                 log::debug!(
-                    "SUPERBLOCK #{} {}: {:?}",
+                    "Local SUPERBLOCK #{} {}: {:?}",
                     superblock.index,
                     superblock_hash,
                     superblock

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -893,7 +893,7 @@ impl ChainManager {
         &mut self,
         ctx: &mut Context<Self>,
         block_epoch: u32,
-    ) -> ResponseActFuture<Self, Option<SuperBlock>, ()> {
+    ) -> ResponseActFuture<Self, SuperBlock, ()> {
         let consensus_constants = self.consensus_constants();
 
         let superblock_period = u32::from(consensus_constants.superblock_period);

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -537,16 +537,6 @@ impl ChainManager {
                 chain_info.highest_block_checkpoint = beacon;
                 chain_info.highest_vrf_output = vrf_input;
 
-                // Store the ARS and the order of the keys
-                let trs = reputation_engine.trs();
-                let alt_keys = &self.chain_state.alt_keys;
-
-                let ordered_alts: Vec<Bn256PublicKey> = alt_keys.get_rep_ordered_bn256_list(trs);
-                let ordered_ars: Vec<PublicKeyHash> = alt_keys.get_rep_ordered_pkh_list(trs);
-                // last ars with previous block ars info
-                self.chain_state.last_ars = ordered_ars;
-                self.chain_state.last_ars_ordered_keys = ordered_alts;
-
                 let rep_info = update_pools(
                     &block,
                     &mut self.chain_state.unspent_outputs_pool,
@@ -580,6 +570,20 @@ impl ChainManager {
 
                 // Insert candidate block into `block_chain` state
                 self.chain_state.block_chain.insert(block_epoch, block_hash);
+
+                // Store the ARS and the order of the keys
+                let trs = reputation_engine.trs();
+                let current_ars = reputation_engine
+                    .ars()
+                    .active_identities()
+                    .cloned()
+                    .collect();
+                let alt_keys = &self.chain_state.alt_keys;
+
+                let ordered_alts: Vec<Bn256PublicKey> = alt_keys.get_rep_ordered_bn256_list(trs);
+                // last ars with previous block ars info
+                self.chain_state.last_ars = current_ars;
+                self.chain_state.last_ars_ordered_keys = ordered_alts;
 
                 match self.sm_state {
                     StateMachine::WaitingConsensus => {


### PR DESCRIPTION
This PR creates superblocks even when no blocks have been proposed during a superblock period.
It also stores the last ARS instead of the prior to last ARS

Closes #1415 
