### PR TITLE
Reenable and improve NTP support

### DIFF
--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -318,7 +318,7 @@ pub trait Defaults {
     }
 
     fn ntp_update_period(&self) -> Duration {
-        Duration::from_secs(600)
+        Duration::from_secs(1024)
     }
 
     fn ntp_server(&self) -> Vec<String> {

--- a/node/src/actors/epoch_manager/mod.rs
+++ b/node/src/actors/epoch_manager/mod.rs
@@ -1,9 +1,8 @@
-use actix::prelude::*;
-// use actix::{Actor, AsyncContext, Context, Recipient, SystemService};
-
-use ansi_term::Color::Purple;
-
 use std::{collections::BTreeMap, time::Duration};
+
+use actix::prelude::*;
+use ansi_term::Color::Purple;
+use rand::Rng;
 
 use witnet_data_structures::{
     chain::{Epoch, EpochConstants},

--- a/util/src/timestamp.rs
+++ b/util/src/timestamp.rs
@@ -49,12 +49,20 @@ pub fn update_global_timestamp(addr: &str) {
 
             if let Some(diff) = duration_between_timestamps(utc, ntp) {
                 ntp_diff.ntp_diff = diff;
-                log::debug!("Update NTP -> Our UTC is {} seconds before", diff.as_secs());
+                log::debug!(
+                    "Update NTP -> System time was {}.{:03} seconds ahead",
+                    diff.as_secs(),
+                    diff.subsec_millis()
+                );
                 ntp_diff.bigger = true;
             } else {
                 let diff = duration_between_timestamps(ntp, utc).unwrap();
                 ntp_diff.ntp_diff = diff;
-                log::debug!("Update NTP -> Our UTC is {} seconds after", diff.as_secs());
+                log::debug!(
+                    "Update NTP -> System time was {}.{:03} seconds behind",
+                    diff.as_secs(),
+                    diff.subsec_millis()
+                );
                 ntp_diff.bigger = false;
             }
         }

--- a/witnet.toml
+++ b/witnet.toml
@@ -68,7 +68,7 @@ server_address = "127.0.0.1:21338"
 
 [ntp]
 # Period for checking the local system clock drift against a public NTP server.
-update_period_seconds = 8000000
+update_period_seconds = 1024
 
 [mining]
 # Enable or disable mining and participation in resolving data requests.


### PR DESCRIPTION
This reenables NTP, adds a ±5s variance on its polling period and prints drift with milliseconds.

Fix #1193 
Fix #1189 