### PR TITLE
Split blocks at batch function

### DIFF
--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -135,6 +135,18 @@ impl Default for StateMachine {
     }
 }
 
+/// Synchronization target determined by the beacons received from outbound peers
+#[derive(Clone, Debug)]
+pub struct SyncTarget {
+    // TODO: the target block must be set, but the node will not assume that it is valid
+    block: CheckpointBeacon,
+    // The target superblock must always be set. Here we only know the superblock index and hash,
+    // we do not know the block hash. The block index can be derived from the superblock index.
+    // This must be a superblock beacon consolidated with more than 2/3 of the votes, and it must be
+    // irreversibly consolidated when reached.
+    superblock: CheckpointBeacon,
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // ACTOR BASIC STRUCTURE
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -112,6 +112,19 @@ pub enum ChainManagerError {
     /// The node is trying to mine a block so commits are not allowed
     #[fail(display = "Commit received while node is trying to mine a block")]
     TooLateToCommit,
+    /// The node received a batch of blocks that is inconsistent with the current index
+    #[fail(
+        display = "Wrong number of blocks provided {:?} for superblock index {:?} and epoch {:?})",
+        wrong_index, consolidated_superblock_index, current_superblock_index
+    )]
+    WrongBlocksForSuperblock {
+        /// Tells what the wrong index was
+        wrong_index: u32,
+        /// Tells what the current superblock index was
+        consolidated_superblock_index: u32,
+        /// Tells what the current epoch was
+        current_superblock_index: u32,
+    },
 }
 
 /// State Machine


### PR DESCRIPTION
This PR provides functionality for split_blocks_batch function which splits a block batch in:

- Blocks needed to construct a consolidated superblock
- Blocks needed to potentially construct an intermediate superblock