### PR TITLE
feat(jsonrpc): Add sum of the utxo amounts to getUtxoInfo and format it as a table

### DIFF
--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -178,7 +178,7 @@ impl ChainManager {
                         ChainState {
                             chain_info: Some(chain_info),
                             reputation_engine: Some(reputation_engine),
-                            own_utxos: OwnUnspentOutputsPool::new(consensus_constants.collateral_minimum),
+                            own_utxos: OwnUnspentOutputsPool::new(),
                             data_request_pool: DataRequestPool::new(consensus_constants.extra_rounds),
                             ..ChainState::default()
                         }

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -1239,16 +1239,12 @@ fn update_pools(
             |own_utxos, output_pointer, output| {
                 // Insert new outputs
                 if output.pkh == own_pkh {
-                    own_utxos.insert(output_pointer.clone(), 0, output.value);
+                    own_utxos.insert(output_pointer.clone(), 0);
                 }
             },
             |own_utxos, output_pointer| {
                 // Remove spent inputs
-                let value = unspent_outputs_pool
-                    .get(output_pointer)
-                    .map(|vto| vto.value)
-                    .unwrap_or(0);
-                own_utxos.remove(&output_pointer, value);
+                own_utxos.remove(&output_pointer);
             },
         );
     }

--- a/node/src/actors/chain_manager/transaction_factory.rs
+++ b/node/src/actors/chain_manager/transaction_factory.rs
@@ -410,7 +410,7 @@ mod tests {
                 Transaction::ValueTransfer(vt_tx) => {
                     // Remove spent inputs
                     for input in &vt_tx.body.inputs {
-                        own_utxos.remove(&input.output_pointer(), 0);
+                        own_utxos.remove(&input.output_pointer());
                     }
                     // Insert new outputs
                     for (i, output) in vt_tx.body.outputs.iter().enumerate() {
@@ -421,7 +421,6 @@ mod tests {
                                     output_index: u32::try_from(i).unwrap(),
                                 },
                                 0,
-                                0,
                             );
                         }
                     }
@@ -430,7 +429,7 @@ mod tests {
                 Transaction::DataRequest(dr_tx) => {
                     // Remove spent inputs
                     for input in &dr_tx.body.inputs {
-                        own_utxos.remove(&input.output_pointer(), 0);
+                        own_utxos.remove(&input.output_pointer());
                     }
                     // Insert new outputs
                     for (i, output) in dr_tx.body.outputs.iter().enumerate() {
@@ -440,7 +439,6 @@ mod tests {
                                     transaction_id: transaction.hash(),
                                     output_index: u32::try_from(i).unwrap(),
                                 },
-                                0,
                                 0,
                             );
                         }


### PR DESCRIPTION
This pull request solves #1258. I took the liberty to add some extra categories (and rephrase others) for ease of use. I also formatted the output as a table similar to the output of `getUtxoInfo --long`. 

The categories I added are "Utxos smaller than collateral minimum", which I think is useful to indicate if you should do joinTransactions (previously you'd have to calculate that yourself). I also added "Utxos bigger than and not ready for collateral" for completeness.

If some of these changes are unwanted, I can obviously change them.

PS: I don't know why the formatting check requires me to put the utxos_table columns names on one line (comparing line 155 to 160 and line 215), but I did it anyway.