### PR TITLE
fix(session): close TCP socket if error msg

### DIFF
--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -121,7 +121,11 @@ impl StreamHandler<BytesMut, Error> for Session {
         let result = WitnetMessage::from_pb_bytes(&bytes);
 
         match result {
-            Err(err) => log::error!("Error decoding message: {:?}", err),
+            Err(err) => {
+                log::error!("Error decoding message: {:?}", err);
+
+                ctx.stop();
+            }
             Ok(msg) => {
                 self.log_received_message(&msg, &bytes);
 


### PR DESCRIPTION
This PR partially mitigates a DoS attack in which a malicious user sends a huge amount of messages to the node by dropping the TCP socket.