### PR TITLE
Reduced committee size

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -495,7 +495,7 @@ pub fn consensus_constants_from_partial(
         bootstrapping_committee: config
             .bootstrapping_committee
             .to_owned()
-            .unwrap_or_else(|| defaults.consensus_constants_bootsrapping_committee()),
+            .unwrap_or_else(|| defaults.consensus_constants_bootstrapping_committee()),
         collateral_age: config
             .collateral_age
             .to_owned()

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -430,12 +430,6 @@ pub fn consensus_constants_from_partial(
             .superblock_period
             .to_owned()
             .unwrap_or_else(|| defaults.consensus_constants_superblock_period()),
-        superblock_agreement_decreasing_period: config
-            .superblock_agreement_decreasing_period
-            .to_owned()
-            .unwrap_or_else(|| {
-                defaults.consensus_constants_superblock_agreement_decreasing_period()
-            }),
         bootstrap_hash: config
             .bootstrap_hash
             .to_owned()
@@ -508,6 +502,16 @@ pub fn consensus_constants_from_partial(
             .superblock_signing_committee_size
             .to_owned()
             .unwrap_or_else(|| defaults.consensus_constants_superblock_signing_committee_size()),
+        superblock_committee_decreasing_period: config
+            .superblock_committee_decreasing_period
+            .to_owned()
+            .unwrap_or_else(|| {
+                defaults.consensus_constants_superblock_committee_decreasing_period()
+            }),
+        superblock_committee_decreasing_step: config
+            .superblock_committee_decreasing_step
+            .to_owned()
+            .unwrap_or_else(|| defaults.consensus_constants_superblock_committee_decreasing_step()),
     }
 }
 

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -430,6 +430,12 @@ pub fn consensus_constants_from_partial(
             .superblock_period
             .to_owned()
             .unwrap_or_else(|| defaults.consensus_constants_superblock_period()),
+        superblock_agreement_decreasing_period: config
+            .superblock_agreement_decreasing_period
+            .to_owned()
+            .unwrap_or_else(|| {
+                defaults.consensus_constants_superblock_agreement_decreasing_period()
+            }),
         bootstrap_hash: config
             .bootstrap_hash
             .to_owned()

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -111,9 +111,14 @@ pub trait Defaults {
         10
     }
 
-    /// Default period between superblocks
-    fn consensus_constants_superblock_agreement_decreasing_period(&self) -> u32 {
-        100
+    /// Default period (in superblock periods) after which the committee should be reduced
+    fn consensus_constants_superblock_committee_decreasing_period(&self) -> u32 {
+        5
+    }
+
+    /// Default committee reduction step
+    fn consensus_constants_superblock_committee_decreasing_step(&self) -> u32 {
+        5
     }
 
     /// Default Hash value for the auxiliary bootstrap block

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -111,6 +111,11 @@ pub trait Defaults {
         10
     }
 
+    /// Default period between superblocks
+    fn consensus_constants_superblock_agreement_decreasing_period(&self) -> u32 {
+        100
+    }
+
     /// Default Hash value for the auxiliary bootstrap block
     // TODO Decide an appropriate default value
     fn consensus_constants_bootstrap_hash(&self) -> Hash {

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -274,7 +274,7 @@ pub trait Defaults {
     }
 
     /// First superblocks signing committee
-    fn consensus_constants_bootsrapping_committee(&self) -> Vec<String> {
+    fn consensus_constants_bootstrapping_committee(&self) -> Vec<String> {
         // FIXME(#1114): Choose a proper value for the committee
         // [] pkhs
 

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -194,8 +194,11 @@ pub struct ConsensusConstants {
     /// Size of the superblock signing committee
     pub superblock_signing_committee_size: u32,
 
-    /// Period after which the agreement requirement should decrease by one member/vote (in superblock periods)
-    pub superblock_agreement_decreasing_period: u32,
+    /// Period after which the committee size should decrease (in superblock periods)
+    pub superblock_committee_decreasing_period: u32,
+
+    /// Step by which the committee should be reduced after superblock_agreement_decreasing_period
+    pub superblock_committee_decreasing_step: u32,
 }
 
 impl ConsensusConstants {

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -193,6 +193,9 @@ pub struct ConsensusConstants {
 
     /// Size of the superblock signing committee
     pub superblock_signing_committee_size: u32,
+
+    /// Period after which the agreement requirement should decrease by one member/vote (in superblock periods)
+    pub superblock_agreement_decreasing_period: u32,
 }
 
 impl ConsensusConstants {

--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -422,7 +422,8 @@ pub fn calculate_superblock_signing_committee(
         ars_identities.identities
     } else {
         // Start counting the members of the subset from the superblock_hash
-        let mut first = u32::from(*superblock_hash.as_ref().get(0).unwrap()) + current_superblock_index;
+        let mut first =
+            u32::from(*superblock_hash.as_ref().get(0).unwrap()) + current_superblock_index;
         first %= signing_committee_size;
         // Get the subset
         let subset = magic_partition(

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -26,7 +26,7 @@
 //!     - Removing the UTXOs that the transaction spends as inputs.
 //!     - Adding a new UTXO for every output in the transaction.
 use std::{
-    cmp::Ordering,
+    cmp::{Ordering,max},
     collections::{HashMap, HashSet},
     convert::TryFrom,
     time::Duration,
@@ -40,7 +40,7 @@ use ansi_term::Color::{Purple, White, Yellow};
 use failure::Fail;
 use futures::future::{join_all, Future};
 use itertools::Itertools;
-use witnet_crypto::key::CryptoEngine;
+use witnet_crypto::{key::CryptoEngine, hash::calculate_sha256};
 use witnet_data_structures::{
     chain::{
         penalize_factor, reputation_issuance, Alpha, AltKeys, Block, BlockHeader, Bn256PublicKey,
@@ -76,7 +76,6 @@ use crate::{
     },
     signature_mngr, storage_mngr,
 };
-use witnet_crypto::hash::calculate_sha256;
 
 mod actor;
 mod handlers;
@@ -1195,10 +1194,22 @@ impl ChainManager {
                         // Store the ARS and the order of the keys
                         let ars_identities = ARSIdentities::new(ars_members);
 
+                        // Committee size should decrease if sufficient epochs have elapsed since last confirmed superblock
+                        // Committee_size = expected_size - ((current_index-last_consolidated_index)/decrease_period))
+
+                        let committee_size = calculate_committee_size(
+                            consensus_constants
+                                .superblock_signing_committee_size,
+                            consensus_constants.superblock_agreement_decreasing_period,
+                            chain_info.highest_superblock_checkpoint.checkpoint,
+                                superblock_index
+                        );
+                        log::debug!("The current signing committee size is {}", committee_size);
+
                         let superblock = act.chain_state.superblock_state.build_superblock(
                             &block_headers,
                             ars_identities,
-                            consensus_constants.superblock_signing_committee_size,
+                            committee_size,
                             superblock_index,
                             last_hash,
                             &act.chain_state.alt_keys,
@@ -1834,6 +1845,32 @@ fn show_sync_progress(
     );
 }
 
+// TODO: handle recovery cases after reduction
+fn calculate_committee_size(
+    default_committee_size: u32,
+    decreasing_period: u32,
+    last_consolidated_checkpoint: u32,
+    current_checkpoint: u32
+) -> u32 {
+    // If the last consolidated superblock is 0, we return the default committee size
+    if last_consolidated_checkpoint == 0 {
+        default_committee_size
+    } else {
+        // We calculate the difference between the last consolidated superblock checkpoint and the current one
+        // If this difference exceeds the decreasing_period, we reduce the committee size
+        // The minimum committee size is 1
+        max(
+            default_committee_size
+                .saturating_sub(
+                    current_checkpoint
+                        .saturating_sub(last_consolidated_checkpoint)
+                        / decreasing_period,
+                ),
+            1,
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use witnet_data_structures::{
@@ -1973,6 +2010,82 @@ mod tests {
                 checkpoint: 0,
                 hash_prev_block: Hash::SHA256([1; 32]),
             }
+        );
+    }
+
+    #[test]
+    fn test_calculate_committee_size() {
+
+        let mut size = calculate_committee_size(
+            5,
+            4,
+            0,
+            1
+        );
+
+        assert_eq!(
+            size,
+            5
+        );
+
+        size = calculate_committee_size(
+            5,
+            4,
+            0,
+            300
+        );
+
+        assert_eq!(
+            size,
+            5
+        );
+
+        size = calculate_committee_size(
+            5,
+            4,
+            3,
+            4
+        );
+
+        assert_eq!(
+            size,
+            5
+        );
+
+        size = calculate_committee_size(
+            5,
+            4,
+            3,
+            7
+        );
+
+        assert_eq!(
+            size,
+            4
+        );
+
+        size = calculate_committee_size(
+            5,
+            4,
+            3,
+            12
+        );
+
+        assert_eq!(
+            size,
+            3
+        );
+
+        size = calculate_committee_size(
+            5,
+            4,
+            3,
+            200
+        );
+
+        assert_eq!(
+            size,
+            1
         );
     }
 }

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -1195,12 +1195,11 @@ impl ChainManager {
                         let ars_identities = ARSIdentities::new(ars_members);
 
                         // Committee size should decrease if sufficient epochs have elapsed since last confirmed superblock
-                        // Committee_size = expected_size - ((current_index-last_consolidated_index)/decrease_period))
-
-                        let committee_size = calculate_committee_size(
+                        let committee_size = current_committee_size_requirement(
                             consensus_constants
                                 .superblock_signing_committee_size,
-                            consensus_constants.superblock_agreement_decreasing_period,
+                            consensus_constants.superblock_committee_decreasing_period,
+                            consensus_constants.superblock_committee_decreasing_step,
                             chain_info.highest_superblock_checkpoint.checkpoint,
                                 superblock_index
                         );
@@ -1846,22 +1845,27 @@ fn show_sync_progress(
 }
 
 // TODO: handle recovery cases after reduction
-fn calculate_committee_size(
+// Returns the committee size to be applied given the default committee size, decreasing period
+// and  step, last consolidated epoch and the current checkpoint
+fn current_committee_size_requirement(
     default_committee_size: u32,
     decreasing_period: u32,
+    decreasing_step: u32,
     last_consolidated_checkpoint: u32,
     current_checkpoint: u32,
 ) -> u32 {
-    // If the last consolidated superblock is 0, we return the default committee size
+    // If the last consolidated superblock is 0, return the default committee size
     if last_consolidated_checkpoint == 0 {
         default_committee_size
     } else {
-        // We calculate the difference between the last consolidated superblock checkpoint and the current one
-        // If this difference exceeds the decreasing_period, we reduce the committee size
+        // Calculate the difference between the last consolidated superblock checkpoint and the current one
+        // If this difference exceeds the decreasing_period, reduce the committee size by decreasing_step * difference
         // The minimum committee size is 1
         max(
             default_committee_size.saturating_sub(
-                current_checkpoint.saturating_sub(last_consolidated_checkpoint) / decreasing_period,
+                (current_checkpoint.saturating_sub(last_consolidated_checkpoint)
+                    / decreasing_period)
+                    * decreasing_step,
             ),
             1,
         )
@@ -2011,29 +2015,33 @@ mod tests {
     }
 
     #[test]
-    fn test_calculate_committee_size() {
-        let mut size = calculate_committee_size(5, 4, 0, 1);
+    fn test_current_committee_size_requirement() {
+        let mut size = current_committee_size_requirement(5, 4, 1, 0, 1);
 
         assert_eq!(size, 5);
 
-        size = calculate_committee_size(5, 4, 0, 300);
+        size = current_committee_size_requirement(5, 4, 1, 0, 300);
 
         assert_eq!(size, 5);
 
-        size = calculate_committee_size(5, 4, 3, 4);
+        size = current_committee_size_requirement(5, 4, 1, 3, 4);
 
         assert_eq!(size, 5);
 
-        size = calculate_committee_size(5, 4, 3, 7);
+        size = current_committee_size_requirement(5, 4, 1, 3, 7);
 
         assert_eq!(size, 4);
 
-        size = calculate_committee_size(5, 4, 3, 12);
+        size = current_committee_size_requirement(5, 4, 1, 3, 12);
 
         assert_eq!(size, 3);
 
-        size = calculate_committee_size(5, 4, 3, 200);
+        size = current_committee_size_requirement(5, 4, 1, 3, 200);
 
         assert_eq!(size, 1);
+
+        size = current_committee_size_requirement(100, 5, 5, 5, 50);
+
+        assert_eq!(size, 55);
     }
 }

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -26,7 +26,7 @@
 //!     - Removing the UTXOs that the transaction spends as inputs.
 //!     - Adding a new UTXO for every output in the transaction.
 use std::{
-    cmp::{Ordering,max},
+    cmp::{max, Ordering},
     collections::{HashMap, HashSet},
     convert::TryFrom,
     time::Duration,
@@ -40,7 +40,7 @@ use ansi_term::Color::{Purple, White, Yellow};
 use failure::Fail;
 use futures::future::{join_all, Future};
 use itertools::Itertools;
-use witnet_crypto::{key::CryptoEngine, hash::calculate_sha256};
+use witnet_crypto::{hash::calculate_sha256, key::CryptoEngine};
 use witnet_data_structures::{
     chain::{
         penalize_factor, reputation_issuance, Alpha, AltKeys, Block, BlockHeader, Bn256PublicKey,
@@ -1850,7 +1850,7 @@ fn calculate_committee_size(
     default_committee_size: u32,
     decreasing_period: u32,
     last_consolidated_checkpoint: u32,
-    current_checkpoint: u32
+    current_checkpoint: u32,
 ) -> u32 {
     // If the last consolidated superblock is 0, we return the default committee size
     if last_consolidated_checkpoint == 0 {
@@ -1860,12 +1860,9 @@ fn calculate_committee_size(
         // If this difference exceeds the decreasing_period, we reduce the committee size
         // The minimum committee size is 1
         max(
-            default_committee_size
-                .saturating_sub(
-                    current_checkpoint
-                        .saturating_sub(last_consolidated_checkpoint)
-                        / decreasing_period,
-                ),
+            default_committee_size.saturating_sub(
+                current_checkpoint.saturating_sub(last_consolidated_checkpoint) / decreasing_period,
+            ),
             1,
         )
     }
@@ -2015,77 +2012,28 @@ mod tests {
 
     #[test]
     fn test_calculate_committee_size() {
+        let mut size = calculate_committee_size(5, 4, 0, 1);
 
-        let mut size = calculate_committee_size(
-            5,
-            4,
-            0,
-            1
-        );
+        assert_eq!(size, 5);
 
-        assert_eq!(
-            size,
-            5
-        );
+        size = calculate_committee_size(5, 4, 0, 300);
 
-        size = calculate_committee_size(
-            5,
-            4,
-            0,
-            300
-        );
+        assert_eq!(size, 5);
 
-        assert_eq!(
-            size,
-            5
-        );
+        size = calculate_committee_size(5, 4, 3, 4);
 
-        size = calculate_committee_size(
-            5,
-            4,
-            3,
-            4
-        );
+        assert_eq!(size, 5);
 
-        assert_eq!(
-            size,
-            5
-        );
+        size = calculate_committee_size(5, 4, 3, 7);
 
-        size = calculate_committee_size(
-            5,
-            4,
-            3,
-            7
-        );
+        assert_eq!(size, 4);
 
-        assert_eq!(
-            size,
-            4
-        );
+        size = calculate_committee_size(5, 4, 3, 12);
 
-        size = calculate_committee_size(
-            5,
-            4,
-            3,
-            12
-        );
+        assert_eq!(size, 3);
 
-        assert_eq!(
-            size,
-            3
-        );
+        size = calculate_committee_size(5, 4, 3, 200);
 
-        size = calculate_committee_size(
-            5,
-            4,
-            3,
-            200
-        );
-
-        assert_eq!(
-            size,
-            1
-        );
+        assert_eq!(size, 1);
     }
 }

--- a/node/tests/serialization.rs
+++ b/node/tests/serialization.rs
@@ -40,6 +40,7 @@ fn chain_state() {
             initial_difficulty: 0,
             epochs_with_initial_difficulty: 0,
             superblock_signing_committee_size: 100,
+            superblock_agreement_decreasing_period: 100,
         },
         highest_block_checkpoint: CheckpointBeacon {
             checkpoint: 0,

--- a/node/tests/serialization.rs
+++ b/node/tests/serialization.rs
@@ -40,7 +40,8 @@ fn chain_state() {
             initial_difficulty: 0,
             epochs_with_initial_difficulty: 0,
             superblock_signing_committee_size: 100,
-            superblock_agreement_decreasing_period: 100,
+            superblock_committee_decreasing_period: 100,
+            superblock_committee_decreasing_step: 5,
         },
         highest_block_checkpoint: CheckpointBeacon {
             checkpoint: 0,

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -305,7 +305,8 @@ message ConsensusConstants {
     uint32 epochs_with_initial_difficulty = 19;
     repeated string bootstrapping_committee = 20;
     uint32 superblock_signing_committee_size = 21;
-    uint32 superblock_agreement_decreasing_period = 22;
+    uint32 superblock_committee_decreasing_period = 22;
+    uint32 superblock_committee_decreasing_step = 23;
 }
 
 message VrfProof {

--- a/schemas/witnet/witnet.proto
+++ b/schemas/witnet/witnet.proto
@@ -305,6 +305,7 @@ message ConsensusConstants {
     uint32 epochs_with_initial_difficulty = 19;
     repeated string bootstrapping_committee = 20;
     uint32 superblock_signing_committee_size = 21;
+    uint32 superblock_agreement_decreasing_period = 22;
 }
 
 message VrfProof {

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -5247,7 +5247,8 @@ fn test_block_with_drpool_and_utxo_set<F: FnMut(&mut Block) -> bool>(
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
         superblock_signing_committee_size: 100,
-        superblock_agreement_decreasing_period: 100,
+        superblock_committee_decreasing_period: 100,
+        superblock_committee_decreasing_step: 5,
     };
 
     // Insert output to utxo
@@ -5509,7 +5510,8 @@ fn block_difficult_proof() {
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
         superblock_signing_committee_size: 100,
-        superblock_agreement_decreasing_period: 100,
+        superblock_committee_decreasing_period: 100,
+        superblock_committee_decreasing_step: 5,
     };
 
     // Insert output to utxo
@@ -6104,7 +6106,8 @@ fn test_blocks_with_limits(
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
         superblock_signing_committee_size: 100,
-        superblock_agreement_decreasing_period: 100,
+        superblock_committee_decreasing_period: 100,
+        superblock_committee_decreasing_step: 5,
     };
 
     // Insert output to utxo
@@ -6668,7 +6671,8 @@ fn genesis_block_after_not_bootstrap_hash() {
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
         superblock_signing_committee_size: 100,
-        superblock_agreement_decreasing_period: 100,
+        superblock_committee_decreasing_period: 100,
+        superblock_committee_decreasing_step: 5,
     };
     let mut signatures_to_verify = vec![];
 
@@ -6743,7 +6747,8 @@ fn genesis_block_value_overflow() {
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
         superblock_signing_committee_size: 100,
-        superblock_agreement_decreasing_period: 100,
+        superblock_committee_decreasing_period: 100,
+        superblock_committee_decreasing_step: 5,
     };
     let vrf_input = CheckpointVRF::default();
     let mut signatures_to_verify = vec![];
@@ -6823,7 +6828,8 @@ fn genesis_block_full_validate() {
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
         superblock_signing_committee_size: 100,
-        superblock_agreement_decreasing_period: 100,
+        superblock_committee_decreasing_period: 100,
+        superblock_committee_decreasing_step: 5,
     };
 
     // Validate block
@@ -6884,7 +6890,8 @@ fn validate_block_transactions_uses_block_number_in_utxo_diff() {
             initial_difficulty: 0,
             epochs_with_initial_difficulty: 0,
             superblock_signing_committee_size: 100,
-            superblock_agreement_decreasing_period: 100,
+            superblock_committee_decreasing_period: 100,
+            superblock_committee_decreasing_step: 5,
         };
         let dr_pool = DataRequestPool::default();
         let vrf = &mut VrfCtx::secp256k1().unwrap();
@@ -7067,7 +7074,8 @@ fn validate_commit_transactions_included_in_utxo_diff() {
             initial_difficulty: 0,
             epochs_with_initial_difficulty: 0,
             superblock_signing_committee_size: 100,
-            superblock_agreement_decreasing_period: 100,
+            superblock_committee_decreasing_period: 100,
+            superblock_committee_decreasing_step: 5,
         };
 
         let (inputs, outputs) = (vec![vti], vec![change_vto.clone()]);

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -5247,6 +5247,7 @@ fn test_block_with_drpool_and_utxo_set<F: FnMut(&mut Block) -> bool>(
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
         superblock_signing_committee_size: 100,
+        superblock_agreement_decreasing_period: 100,
     };
 
     // Insert output to utxo
@@ -5508,6 +5509,7 @@ fn block_difficult_proof() {
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
         superblock_signing_committee_size: 100,
+        superblock_agreement_decreasing_period: 100,
     };
 
     // Insert output to utxo
@@ -6102,6 +6104,7 @@ fn test_blocks_with_limits(
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
         superblock_signing_committee_size: 100,
+        superblock_agreement_decreasing_period: 100,
     };
 
     // Insert output to utxo
@@ -6665,6 +6668,7 @@ fn genesis_block_after_not_bootstrap_hash() {
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
         superblock_signing_committee_size: 100,
+        superblock_agreement_decreasing_period: 100,
     };
     let mut signatures_to_verify = vec![];
 
@@ -6739,6 +6743,7 @@ fn genesis_block_value_overflow() {
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
         superblock_signing_committee_size: 100,
+        superblock_agreement_decreasing_period: 100,
     };
     let vrf_input = CheckpointVRF::default();
     let mut signatures_to_verify = vec![];
@@ -6818,6 +6823,7 @@ fn genesis_block_full_validate() {
         initial_difficulty: 0,
         epochs_with_initial_difficulty: 0,
         superblock_signing_committee_size: 100,
+        superblock_agreement_decreasing_period: 100,
     };
 
     // Validate block
@@ -6878,6 +6884,7 @@ fn validate_block_transactions_uses_block_number_in_utxo_diff() {
             initial_difficulty: 0,
             epochs_with_initial_difficulty: 0,
             superblock_signing_committee_size: 100,
+            superblock_agreement_decreasing_period: 100,
         };
         let dr_pool = DataRequestPool::default();
         let vrf = &mut VrfCtx::secp256k1().unwrap();
@@ -7060,6 +7067,7 @@ fn validate_commit_transactions_included_in_utxo_diff() {
             initial_difficulty: 0,
             epochs_with_initial_difficulty: 0,
             superblock_signing_committee_size: 100,
+            superblock_agreement_decreasing_period: 100,
         };
 
         let (inputs, outputs) = (vec![vti], vec![change_vto.clone()]);


### PR DESCRIPTION
This PR adds functionality for reducing the superblock voting committee size if sufficient epochs elpase without consolidated superblock. The period after which the comittee gets reduced is configurable through consensus constants.

This PR aims at solving the problem of loss of availability of a percetange of the ARS members. 2 approaches were discussed to achieve this:

- Reduce the 2/3 votes required to consolidate a block
- Reduce the committee size, thus increasing the probability of achieving 2/3 of the votes.

The first clearly recovers the chain faster, but also in my view decreases the security of the system by breaking the 2/3 vote assumption. The latter spends more time recovering the chain (ideally, for each committee reduction, several iterations would need to be tried before a new reduction happens). However, it also maintains the 2/3 vote approach. In the catastrophic event of a high loss of availability, I believe it is preferable to halt the network for a higher amount of time but maintaining the security guarantees, specially for the bridge. One committee where an attacker achieves the necessary votes to consolidate a superblock is sufficient to break the Ethereum bridge forever, and as such, I believe it is preferable to opt for the second option.