### PR TITLE
feat(cli): add claim command to node CLI

### DIFF
--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -1035,6 +1035,7 @@ pub fn add_peers(addr: SocketAddr, peers: Vec<SocketAddr>) -> Result<(), failure
 
 #[derive(Serialize, Deserialize)]
 struct SignatureWithData {
+    address: String,
     identifier: String,
     public_key: String,
     signature: String,
@@ -1060,7 +1061,12 @@ pub fn claim(
     let signature: KeyedSignature = parse_response(&response)?;
     match serde_json::to_string_pretty(&SignatureWithData {
         identifier: identifier.clone(),
-        public_key: PublicKeyHash::from_public_key(&signature.public_key).to_string(),
+        address: PublicKeyHash::from_public_key(&signature.public_key).to_string(),
+        public_key: signature
+            .public_key
+            .to_bytes()
+            .iter()
+            .fold(String::new(), |acc, x| format!("{}{:02x}", acc, x)),
         signature: signature
             .signature
             .to_bytes()?

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -8,13 +8,13 @@ use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
     fmt,
+    fs::File,
     io::{self, BufRead, BufReader, Read, Write},
     net::{SocketAddr, TcpStream},
     path::Path,
     str::FromStr,
 };
 
-use std::fs::File;
 use witnet_crypto::{
     hash::calculate_sha256,
     key::{CryptoEngine, ExtendedPK, ExtendedSK},

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -259,6 +259,10 @@ pub enum Command {
         #[structopt(long = "limit", allow_hyphen_values = true, default_value = "-50")]
         limit: i64,
     },
+    #[structopt(
+        name = "claim",
+        about = "Claim a Witnet identity by signing the identifier with the node master key"
+    )]
     Claim {
         /// Socket address of the Witnet node to query
         #[structopt(short = "n", long = "node")]

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -18,6 +18,9 @@ pub fn exec_cmd(
     mut config: Config,
 ) -> Result<(), failure::Error> {
     match command {
+        Command::Claim { node, identifier } => {
+            rpc::sign_claiming_data(node.unwrap_or(config.jsonrpc.server_address), identifier)
+        }
         Command::GetBlock { node, hash } => {
             rpc::get_block(node.unwrap_or(config.jsonrpc.server_address), hash)
         }
@@ -234,6 +237,14 @@ pub enum Command {
         /// If zero, unlimited
         #[structopt(long = "limit", allow_hyphen_values = true, default_value = "-50")]
         limit: i64,
+    },
+    Claim {
+        /// Socket address of the Witnet node to query
+        #[structopt(short = "n", long = "node")]
+        node: Option<SocketAddr>,
+        /// Identifier to be claimed by the node (e.g. Witnet ID)
+        #[structopt(short = "i", long = "identifier")]
+        identifier: String,
     },
     #[structopt(
         name = "minerList",


### PR DESCRIPTION
This PR adds a new command to the node CLI called `claim` a node identity.

This command will be used in order to prove the ownership of a node identity by signing a given data (e.g. an identifier) with the node master key. The output will also contain the signed data, the public key and the signature itself.

```bash
USAGE:
    witnet node claim [FLAGS] [OPTIONS] --identifier <identifier>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information
        --write      Write the signed claimed data to "storage_path/claim-<id>-<public_key>.txt"

OPTIONS:
    -i, --identifier <identifier>    Identifier to be claimed by the node (e.g. Witnet ID)
    -n, --node <node>                Socket address of the Witnet node to query
        --write-to <write-to>        Change the path to write storage_path/claim-<id>-<public_key>.txt". Implies --write
```

The command also supports writing the output into a file by using the option `--write` or by directly defining the output file with the `--write-to` option.

The output is formatted using JSON as follows:

```json
{
  "address": "twit1...",
  "identifier": "WITNET_XYZ",
  "public_key": "<hex_code>",
  "signature": "<hex_code>"
}
```

Closes #1445 