### PR TITLE
chore(cargo): bump version to 0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "witnet"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytecount 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witnet"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Witnet Foundation <info@witnet.foundation>"]
 publish = false
 repository = "witnet/witnet-rust"

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -366,8 +366,8 @@ impl Defaults for Development {
     }
 
     fn consensus_constants_checkpoint_zero_timestamp(&self) -> i64 {
-        // Wednesday, 24-Jun-2020, 11:00 UTC
-        1_592_996_400
+        // Wednesday, 19-Aug-2020, 09:00 UTC
+        1_597_827_600
     }
 
     fn connections_reject_sybil_inbounds(&self) -> bool {


### PR DESCRIPTION
Just bumping the `witnet-rust` version to 0.9.2 and setting the bootstrap timestamp to Wednesday, 19-Aug-2020, 09:00 UTC (`1_597_827_600`).