### PR TITLE
Request with zero retrieval source set as invalid

### DIFF
--- a/data_structures/src/error.rs
+++ b/data_structures/src/error.rs
@@ -467,6 +467,8 @@ pub enum DataRequestError {
     NotTallyStage,
     #[fail(display = "Cannot persist unfinished data request (with no Tally)")]
     UnfinishedDataRequest,
+    #[fail(display = "The data request is not valid since it has no retrieval sources")]
+    NoRetrievalSource,
 }
 
 /// Possible errors when converting between epoch and timestamp

--- a/data_structures/src/error.rs
+++ b/data_structures/src/error.rs
@@ -468,7 +468,7 @@ pub enum DataRequestError {
     #[fail(display = "Cannot persist unfinished data request (with no Tally)")]
     UnfinishedDataRequest,
     #[fail(display = "The data request is not valid since it has no retrieval sources")]
-    NoRetrievalSource,
+    NoRetrievalSources,
 }
 
 /// Possible errors when converting between epoch and timestamp

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -1706,8 +1706,8 @@ fn data_request_no_scripts() {
         tally: RADTally::default(),
     });
     assert_eq!(
-        x.unwrap_err().downcast::<RadError>().unwrap(),
-        RadError::UnsupportedReducerInAT { operator: 0 }
+        x.unwrap_err().downcast::<DataRequestError>().unwrap(),
+        DataRequestError::NoRetrievalSources,
     );
 }
 
@@ -1734,7 +1734,7 @@ fn data_request_empty_scripts() {
     // The data request should be invalid since the sources are empty
     assert_eq!(
         x.unwrap_err().downcast::<DataRequestError>().unwrap(),
-        DataRequestError::NoRetrievalSource,
+        DataRequestError::NoRetrievalSources,
     );
 }
 

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -5,6 +5,8 @@ use std::{
     fmt,
 };
 
+//std::cmp::PartialEq<std::vec::Vec<_>>
+
 use itertools::Itertools;
 
 use witnet_crypto::{
@@ -293,7 +295,15 @@ pub fn validate_mint_transaction(
 /// Function to validate a rad request
 pub fn validate_rad_request(rad_request: &RADRequest) -> Result<(), failure::Error> {
     let retrieval_paths = &rad_request.retrieve;
+    // If the data requests has no retrive it is set as invalid
+    if retrieval_paths.is_empty() {
+        return Err(RadError::UnsupportedReducerInAT { operator: 0 }.into());
+    }
     for path in retrieval_paths {
+        // If the sources are empty the data request is set as invalid
+        if path.url == "" {
+            return Err(DataRequestError::NoRetrievalSource.into());
+        }
         unpack_radon_script(path.script.as_slice())?;
     }
 

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -5,8 +5,6 @@ use std::{
     fmt,
 };
 
-//std::cmp::PartialEq<std::vec::Vec<_>>
-
 use itertools::Itertools;
 
 use witnet_crypto::{
@@ -295,14 +293,14 @@ pub fn validate_mint_transaction(
 /// Function to validate a rad request
 pub fn validate_rad_request(rad_request: &RADRequest) -> Result<(), failure::Error> {
     let retrieval_paths = &rad_request.retrieve;
-    // If the data requests has no retrive it is set as invalid
+    // If the data request has no sources to retrieve, it is set as invalid
     if retrieval_paths.is_empty() {
-        return Err(RadError::UnsupportedReducerInAT { operator: 0 }.into());
+        return Err(DataRequestError::NoRetrievalSources.into());
     }
     for path in retrieval_paths {
         // If the sources are empty the data request is set as invalid
         if path.url == "" {
-            return Err(DataRequestError::NoRetrievalSource.into());
+            return Err(DataRequestError::NoRetrievalSources.into());
         }
         unpack_radon_script(path.script.as_slice())?;
     }


### PR DESCRIPTION
This PR adds two checks in the function `validate_rad_request`:
 - If the data request has an empty retrieve vector it returns the error `UnsupportedReducerInAT`.
 - If the data request has an empty url source is returns the error `NoRetrievalSource`.

The tests have been changed since the data request used as example was not longer valid.

Closes #1288 