### PR TITLE
Improve chain_state persist logs and add panics

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -2756,36 +2756,6 @@ impl ChainState {
             .consensus_constants
             .clone()
     }
-
-    /// Method to check that all inputs point to unspent outputs
-    pub fn find_unspent_outputs(&self, inputs: &[Input]) -> bool {
-        inputs.iter().all(|tx_input| {
-            let output_pointer = tx_input.output_pointer();
-
-            self.unspent_outputs_pool.contains_key(&output_pointer)
-        })
-    }
-    /// Retrieve the output pointed by the output pointer in an input
-    pub fn get_output_from_input(&self, input: &Input) -> Option<&ValueTransferOutput> {
-        let output_pointer = input.output_pointer();
-
-        self.unspent_outputs_pool.get(&output_pointer)
-    }
-    /// Map a vector of inputs to a the vector of ValueTransferOutputs pointed by the inputs' output pointers
-    pub fn get_outputs_from_inputs(
-        &self,
-        inputs: &[Input],
-    ) -> Result<Vec<ValueTransferOutput>, Input> {
-        let v = inputs
-            .iter()
-            .map(|i| self.get_output_from_input(i))
-            .fuse()
-            .flatten()
-            .cloned()
-            .collect();
-
-        Ok(v)
-    }
 }
 
 /// Alternative public key mapping: maps each secp256k1 public key hash to

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -234,6 +234,12 @@ impl ChainManager {
                 act.best_candidate = None;
                 act.candidates.clear();
                 act.seen_candidates.clear();
+                // Delete any saved copies of the old chain state to avoid accidentally persisting
+                // a forked state
+                act.chain_state_snapshot.clear();
+                // When initializing for the first time, we need to set the
+                // highest_persisted_superblock to the top consolidated superblock
+                act.chain_state_snapshot.highest_persisted_superblock = act.get_superblock_beacon().checkpoint;
 
                 SessionsManager::from_registry().do_send(SetLastBeacon {
                     beacon: LastBeacon {
@@ -242,9 +248,6 @@ impl ChainManager {
                     },
                 });
 
-                // Copy current chain state into previous chain state, and persist it
-                act.move_chain_state_forward();
-                act.persist_previous_chain_state(ctx);
             }).wait(ctx);
     }
 


### PR DESCRIPTION
Fix #1439

Followup to #1471 

This PR adds a new data structure `chain_state_snapshot` to replace the old `previous_chain_state`. The functionality is the same, but the `chain_state_snapshot` also stores the superblock index of the previous chain state, and the superblock index of the last chain state that has been persisted to the storage.

This will prevent accidentally persisting the same chain state twice, or skipping a superblock in some edge cases. The node will panic if it:
* Stores in memory two different copies of the chain state for the same superblock index. This means that one of the copies is wrong.
* Tries to persist the chain state for superblock N, when there is no copy of the chain state for superblock N (because we forgot to call `self.move_chain_state_forward`)
* Tries to persist the chain state for a superblock older than the highest persisted superblock (overwritting the chain state with an older copy)

Also, this PR improves some logs and deletes some unused functions.