### PR TITLE
feat(wallet): allow shutdown if no open sessions

### DIFF
--- a/wallet/src/actors/app/error.rs
+++ b/wallet/src/actors/app/error.rs
@@ -18,6 +18,8 @@ pub enum Error {
     NodeNotConnected,
     #[fail(display = "session not found")]
     SessionNotFound,
+    #[fail(display = "session(s) are still open")]
+    SessionsStillOpen,
     #[fail(display = "wallet not found")]
     WalletNotFound,
 }
@@ -49,6 +51,7 @@ impl Error {
                     Some(json!({ "cause": format!("{}", e) })),
                 )
             }
+            Error::SessionsStillOpen => (401, "Unauthorized", None),
         }
     }
 }

--- a/wallet/src/actors/app/handlers/shutdown.rs
+++ b/wallet/src/actors/app/handlers/shutdown.rs
@@ -20,7 +20,7 @@ impl Handler<Shutdown> for app::App {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ShutdownRequest {
-    session_id: types::SessionId,
+    session_id: Option<types::SessionId>,
 }
 
 impl Message for ShutdownRequest {
@@ -31,6 +31,6 @@ impl Handler<ShutdownRequest> for app::App {
     type Result = <ShutdownRequest as Message>::Result;
 
     fn handle(&mut self, msg: ShutdownRequest, ctx: &mut Self::Context) -> Self::Result {
-        self.shutdown_request(&msg.session_id, ctx)
+        self.shutdown_request(msg.session_id, ctx)
     }
 }

--- a/wallet/src/actors/app/methods.rs
+++ b/wallet/src/actors/app/methods.rs
@@ -601,13 +601,18 @@ impl App {
         Box::new(f)
     }
 
-    /// Shutdown system if session id is valid
+    /// Shutdown system if session id is valid or there are no open sessions
     pub fn shutdown_request(
         &mut self,
-        session_id: &types::SessionId,
+        session_id: Option<types::SessionId>,
         ctx: &mut <Self as Actor>::Context,
     ) -> Result<()> {
-        self.state.get_wallets_by_session(&session_id)?;
+        // Check if valid id or no open session(s)
+        if let Some(session_id) = session_id {
+            self.state.get_wallets_by_session(&session_id)?;
+        } else if !self.state.sessions.is_empty() {
+            return Err(app::Error::SessionsStillOpen);
+        }
         self.stop(ctx);
 
         Ok(())


### PR DESCRIPTION
Now `shutdown` can be called without specifying a `session_id` for shutting down the wallet, only if there are not any open session.