### PR TITLE
Limit mempool size

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -352,6 +352,8 @@ pub struct Mining {
     #[partial_struct(skip)]
     #[partial_struct(serde(default))]
     pub mint_external_address: Option<String>,
+    /// Mempool size limit in weight units
+    pub transactions_pool_total_weight_limit: u64,
 }
 
 /// NTP-related configuration
@@ -662,6 +664,10 @@ impl Mining {
                 .to_owned()
                 .unwrap_or_else(|| defaults.mining_mint_external_percentage()),
             mint_external_address: config.mint_external_address.clone(),
+            transactions_pool_total_weight_limit: config
+                .transactions_pool_total_weight_limit
+                .to_owned()
+                .unwrap_or_else(|| defaults.mining_transactions_pool_total_weight_limit()),
         }
     }
 }

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -187,6 +187,12 @@ pub trait Defaults {
         50
     }
 
+    /// Mempool size limit in weight units
+    fn mining_transactions_pool_total_weight_limit(&self) -> u64 {
+        // Default: no limit
+        u64::MAX
+    }
+
     fn consensus_constants_max_vt_weight(&self) -> u32 {
         20_000
     }

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -189,8 +189,14 @@ pub trait Defaults {
 
     /// Mempool size limit in weight units
     fn mining_transactions_pool_total_weight_limit(&self) -> u64 {
-        // Default: no limit
-        u64::MAX
+        // Default limit: enough to fill 24 hours worth of blocks
+        // With max_block_weight = 100_000 and block_period = 45, this is 192_000_000
+        let seconds_in_one_hour = 60 * 60;
+        let block_period = u64::from(self.consensus_constants_checkpoints_period());
+        let max_block_weight = u64::from(
+            self.consensus_constants_max_vt_weight() + self.consensus_constants_max_dr_weight(),
+        );
+        24 * seconds_in_one_hour * max_block_weight / block_period
     }
 
     fn consensus_constants_max_vt_weight(&self) -> u32 {

--- a/data_structures/Cargo.toml
+++ b/data_structures/Cargo.toml
@@ -31,7 +31,7 @@ vrf = "0.2.2"
 
 witnet_crypto = { path = "../crypto" }
 witnet_reputation = { path = "../reputation", features = ["serde"] }
-witnet_protected = { path = "../protected" }
+witnet_protected = { path = "../protected", features = ["serde"] }
 witnet_util = { path = "../util" }
 
 [build-dependencies]

--- a/data_structures/examples/transactions_pool_overhead.rs
+++ b/data_structures/examples/transactions_pool_overhead.rs
@@ -1,0 +1,126 @@
+use rand::{thread_rng, Rng};
+use witnet_data_structures::chain::{
+    DataRequestOutput, Hash, Input, KeyedSignature, OutputPointer, PublicKeyHash, RADAggregate,
+    RADRequest, RADRetrieve, RADTally, RADType, Secp256k1Signature, Signature, TransactionsPool,
+    ValueTransferOutput,
+};
+use witnet_data_structures::transaction::{
+    DRTransaction, DRTransactionBody, Transaction, VTTransaction, VTTransactionBody,
+};
+
+fn random_request() -> RADRequest {
+    RADRequest {
+        time_lock: 0,
+        retrieve: vec![
+            RADRetrieve {
+                kind: RADType::HttpGet,
+                url: String::from("https://www.bitstamp.net/api/ticker/"),
+                script: vec![130, 24, 119, 130, 24, 100, 100, 108, 97, 115, 116],
+            },
+            RADRetrieve {
+                kind: RADType::HttpGet,
+                url: String::from("https://api.coindesk.com/v1/bpi/currentprice.json"),
+                script: vec![
+                    132, 24, 119, 130, 24, 102, 99, 98, 112, 105, 130, 24, 102, 99, 85, 83, 68,
+                    130, 24, 100, 106, 114, 97, 116, 101, 95, 102, 108, 111, 97, 116,
+                ],
+            },
+        ],
+        aggregate: RADAggregate {
+            filters: vec![],
+            reducer: 3,
+        },
+        tally: RADTally {
+            filters: vec![],
+            reducer: 3,
+        },
+    }
+}
+
+fn random_dr_output() -> DataRequestOutput {
+    let mut rng = thread_rng();
+
+    DataRequestOutput {
+        data_request: random_request(),
+        witness_reward: rng.gen(),
+        // The number of witnesses changes the RAM usage considerably
+        // More witnesses = more weight = less transactions in pool = less RAM usage
+        witnesses: 2,
+        commit_and_reveal_fee: rng.gen(),
+        min_consensus_percentage: rng.gen(),
+        collateral: rng.gen(),
+    }
+}
+
+fn random_transaction() -> (Transaction, u64) {
+    let mut rng = thread_rng();
+
+    let num_inputs = rng.gen_range(1, 3);
+    let num_outputs = 2;
+
+    let mut inputs = vec![];
+    for _ in 0..num_inputs {
+        let random_32_bytes: [u8; 32] = rng.gen();
+        let transaction_id = Hash::from(random_32_bytes.to_vec());
+        let output_pointer = OutputPointer {
+            transaction_id,
+            output_index: rng.gen(),
+        };
+        inputs.push(Input::new(output_pointer));
+    }
+
+    let mut outputs = vec![];
+    for _ in 0..num_outputs {
+        let random_20_bytes: [u8; 20] = rng.gen();
+        let pkh = PublicKeyHash::from_bytes(&random_20_bytes).unwrap();
+        outputs.push(ValueTransferOutput {
+            pkh,
+            value: 0,
+            time_lock: 0,
+        });
+    }
+
+    let signature = KeyedSignature {
+        signature: Signature::Secp256k1(Secp256k1Signature {
+            // DER encoded signature = 72 bytes
+            der: vec![0xFF; 72],
+        }),
+        public_key: Default::default(),
+    };
+
+    let t = if rng.gen() {
+        Transaction::ValueTransfer(VTTransaction {
+            body: VTTransactionBody::new(inputs, outputs),
+            signatures: vec![signature; num_inputs],
+        })
+    } else {
+        let dr_output = random_dr_output();
+        Transaction::DataRequest(DRTransaction {
+            body: DRTransactionBody::new(inputs, outputs, dr_output),
+            signatures: vec![signature; num_inputs],
+        })
+    };
+
+    let fee = rng.gen();
+
+    (t, fee)
+}
+
+fn main() {
+    let mut pool = TransactionsPool::new();
+    let testnet_weight_limit = 192_000_000;
+    println!("Setting weight limit to {}", testnet_weight_limit);
+    pool.set_total_weight_limit(testnet_weight_limit, 1.0);
+
+    let mut limit_reached = false;
+
+    for i in 0..1_000_000 {
+        let (transaction, fee) = random_transaction();
+        let removed_transactions = pool.insert(transaction, fee);
+
+        if !limit_reached && !removed_transactions.is_empty() {
+            println!("Limit reached after {} transactions", i);
+            limit_reached = true;
+        }
+    }
+}

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1500,24 +1500,6 @@ impl TransactionsPool {
         self.remove_transactions_for_size_limit()
     }
 
-    /// Returns the number of transactions the pool can hold without
-    /// reallocating.
-    ///
-    /// This number is a lower bound; the pool might be able to hold
-    /// more, but is guaranteed to be able to hold at least this many.
-    ///
-    /// # Examples:
-    ///
-    /// ```
-    /// # use witnet_data_structures::chain::TransactionsPool;
-    /// let pool = TransactionsPool::with_capacity(20);
-    ///
-    /// assert!(pool.capacity() >= 20);
-    /// ```
-    pub fn capacity(&self) -> usize {
-        self.vt_transactions.capacity()
-    }
-
     /// Returns `true` if the pool contains no transactions.
     ///
     /// # Examples:

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -90,6 +90,8 @@ impl ChainManager {
                 // Get consensus parameter from config
                 act.consensus_c = config.connections.consensus_c;
 
+                let _removed_transactions = act.transactions_pool.set_total_weight_limit(config.mining.transactions_pool_total_weight_limit);
+
                 storage_mngr::get::<_, ChainState>(&storage_keys::chain_state_key(magic))
                     .into_actor(act)
                     .then(|chain_state_from_storage, _, _| {

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -90,7 +90,9 @@ impl ChainManager {
                 // Get consensus parameter from config
                 act.consensus_c = config.connections.consensus_c;
 
-                let _removed_transactions = act.transactions_pool.set_total_weight_limit(config.mining.transactions_pool_total_weight_limit);
+                // Set weight limit of transactions pool
+                let vt_to_dr_factor = f64::from(config.consensus_constants.max_vt_weight) / f64::from(config.consensus_constants.max_dr_weight);
+                let _removed_transactions = act.transactions_pool.set_total_weight_limit(config.mining.transactions_pool_total_weight_limit, vt_to_dr_factor);
 
                 storage_mngr::get::<_, ChainState>(&storage_keys::chain_state_key(magic))
                     .into_actor(act)


### PR DESCRIPTION
Close #1495 

This PR adds a size limit to the `TransactionsPool`. The default is around 192M.

With this limit, when adding new transaction to a full `TransactionsPool`, the transactions with the smaller `fee / weight` ratio will be removed. Note that the limit only applies to value transfer and data request transactions. It does not apply to commits and reveals because they are implicitly limited by the number of data requests.

This limit can be configured in `witnet.toml`, as `mining.transactions_pool_total_weight_limit`. The units are "weight units" as described in https://github.com/witnet/WIPs/pull/32

Estimated overhead: total memory usage of a typical `TransactionsPool` with `transactions_pool_total_weight_limit = 192M`

* With only value transfer transactions with (1, 2, or 3) inputs and 2 outputs, the peak RAM usage is about 320MB.
* With only data request transactions with (1, 2, or 3) inputs, 2 outputs, and witnesses=2, the peak RAM usage is about 220MB. This does not include the potential commits and reveals, which are taken into account when calculating a data request weight.

Therefore, I think we can assume that the overhead will be less than x2, so the default `transactions_pool_total_weight_limit = 192M` will require at most 384 MB of RAM for the `TransactionsPool`. You can profile the memory usage using by compiling `data_structures/examples/transactions_pool_overhead.rs` and running it through a memory profiler like massif or heaptrack.