### PR TITLE
CLI(reputation): --all shows correct eligibility percentage

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -1357,7 +1357,15 @@ impl Handler<GetReputation> for ChainManager {
         };
 
         let identities = if all {
-            rep_eng.trs().identities().map(|(k, _v)| k).collect()
+            // Add identities with reputation > 0
+            let mut identities: Vec<_> = rep_eng.trs().identities().map(|(k, _v)| k).collect();
+            // Add identitities active but with 0 reputation
+            for pkh in rep_eng.ars().active_identities() {
+                if rep_eng.trs().get(pkh).0 == 0 {
+                    identities.push(pkh);
+                }
+            }
+            identities
         } else {
             vec![&pkh]
         };

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -276,26 +276,31 @@ pub fn get_reputation(
             serde_json::to_string(&pkh)?,
         )
     };
-
     let response = send_request(&mut stream, &request)?;
     let res = parse_response::<GetReputationResult>(&response)?;
 
     if res.stats.is_empty() {
         println!("No identities have reputation yet");
     }
-
     for (pkh, rep_stats) in res.stats.into_iter().sorted_by_key(|(_, rep_stats)| {
         std::cmp::Reverse((rep_stats.reputation.0, rep_stats.eligibility))
     }) {
-        let active = if rep_stats.is_active { 'A' } else { ' ' };
         let eligibility = f64::from(rep_stats.eligibility) / res.total_reputation as f64;
-        println!(
-            "    [{}] {} -> Reputation: {}, Eligibility: {:.6}%",
-            active,
-            pkh,
-            rep_stats.reputation.0,
-            eligibility * 100_f64
-        );
+        let active = if rep_stats.is_active { 'A' } else { ' ' };
+        if rep_stats.is_active || !all {
+            println!(
+                "    [{}] {} -> Reputation: {}, Eligibility: {:.6}%",
+                active,
+                pkh,
+                rep_stats.reputation.0,
+                eligibility * 100_f64
+            );
+        } else {
+            println!(
+                "    [{}] {} -> Reputation: {}",
+                active, pkh, rep_stats.reputation.0
+            );
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Change the method reputation so that when adding the flag `--all` shows the identities active with their reputation and eligibility and those identities that are not active but have 0 reputation, in this case the eligibility is not printed.
This way the sum of the elegibilities is 100%.

For example in a case with 3 identitities active with reputation, the command shows
![image](https://user-images.githubusercontent.com/52961116/94138174-fabd0680-fe67-11ea-9018-90e81bff17cc.png)

But if we stop one of the nodes so that is not longer active, the command prints
![image](https://user-images.githubusercontent.com/52961116/94138310-38ba2a80-fe68-11ea-93f2-6084f789e700.png)


Closes #1514 