### PR TITLE
Store superblocks in storage

### DIFF
--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -69,9 +69,9 @@ use crate::{
         inventory_manager::InventoryManager,
         json_rpc::JsonRpcServer,
         messages::{
-            AddItems, AddTransaction, Anycast, BlockNotify, Broadcast, GetBlocksEpochRange,
-            GetItemBlock, SendInventoryItem, SendLastBeacon, SendSuperBlockVote,
-            StoreInventoryItem, SuperBlockNotify,
+            AddItem, AddItems, AddTransaction, Anycast, BlockNotify, Broadcast,
+            GetBlocksEpochRange, GetItemBlock, SendInventoryItem, SendLastBeacon,
+            SendSuperBlockVote, StoreInventoryItem, SuperBlockNotify,
         },
         sessions_manager::SessionsManager,
         storage_keys,
@@ -1530,10 +1530,18 @@ impl ChainManager {
             let consolidated_block_hashes: Vec<Hash> =
                 beacons.iter().cloned().map(|(_epoch, hash)| hash).collect();
 
+            // Store the list of block hashes that pertain to this superblock
+            InventoryManager::from_registry().do_send(AddItem {
+                item: StoreInventoryItem::Superblock((
+                    superblock.index,
+                    consolidated_block_hashes.clone(),
+                )),
+            });
+
             JsonRpcServer::from_registry().do_send(SuperBlockNotify {
                 superblock,
                 consolidated_block_hashes,
-            })
+            });
         }
     }
 }

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -1529,19 +1529,17 @@ impl ChainManager {
         if let Ok(beacons) = beacons {
             let consolidated_block_hashes: Vec<Hash> =
                 beacons.iter().cloned().map(|(_epoch, hash)| hash).collect();
+            let superblock_notify = SuperBlockNotify {
+                superblock,
+                consolidated_block_hashes,
+            };
 
             // Store the list of block hashes that pertain to this superblock
             InventoryManager::from_registry().do_send(AddItem {
-                item: StoreInventoryItem::Superblock((
-                    superblock.index,
-                    consolidated_block_hashes.clone(),
-                )),
+                item: StoreInventoryItem::Superblock(superblock_notify.clone()),
             });
 
-            JsonRpcServer::from_registry().do_send(SuperBlockNotify {
-                superblock,
-                consolidated_block_hashes,
-            });
+            JsonRpcServer::from_registry().do_send(superblock_notify);
         }
     }
 }

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -473,7 +473,7 @@ pub enum StoreInventoryItem {
     /// Transactions are stored as pointers to blocks
     Transaction(Hash, PointerToBlock),
     /// Superblocks are stored as the list of block hashes
-    Superblock((u32, Vec<Hash>)),
+    Superblock(SuperBlockNotify),
 }
 
 /// Add a new item
@@ -533,7 +533,7 @@ pub struct GetItemSuperblock {
 }
 
 impl Message for GetItemSuperblock {
-    type Result = Result<Vec<Hash>, InventoryManagerError>;
+    type Result = Result<SuperBlockNotify, InventoryManagerError>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -915,7 +915,7 @@ pub struct BlockNotify {
 ///
 /// As per current consensus algorithm, "consolidated blocks" implies that there exists at least one
 /// superblock in the chain that builds upon the superblock where those blocks were anchored.
-#[derive(Message, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Message, Serialize, Deserialize)]
 pub struct SuperBlockNotify {
     /// The superblock that we are signaling as consolidated.
     pub superblock: SuperBlock,

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -915,7 +915,7 @@ pub struct BlockNotify {
 ///
 /// As per current consensus algorithm, "consolidated blocks" implies that there exists at least one
 /// superblock in the chain that builds upon the superblock where those blocks were anchored.
-#[derive(Clone, Debug, PartialEq, Eq, Message, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Message, PartialEq, Serialize)]
 pub struct SuperBlockNotify {
     /// The superblock that we are signaling as consolidated.
     pub superblock: SuperBlock,

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -472,6 +472,8 @@ pub enum StoreInventoryItem {
     Block(Box<Block>),
     /// Transactions are stored as pointers to blocks
     Transaction(Hash, PointerToBlock),
+    /// Superblocks are stored as the list of block hashes
+    Superblock((u32, Vec<Hash>)),
 }
 
 /// Add a new item
@@ -522,6 +524,16 @@ pub struct GetItemTransaction {
 
 impl Message for GetItemTransaction {
     type Result = Result<(Transaction, PointerToBlock), InventoryManagerError>;
+}
+
+/// Ask for a superblock identified by its index
+pub struct GetItemSuperblock {
+    /// item hash
+    pub superblock_index: u32,
+}
+
+impl Message for GetItemSuperblock {
+    type Result = Result<Vec<Hash>, InventoryManagerError>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Close #1548 

Add JSON-RPC method `getSuperblock` that given a `superblock_index` returns the superblock, and the list of block hashes that pertain to that superblock. But only if the superblock has already seen a majority of votes and is consolidated. Also works when given a `block_epoch` instead of a `superblock_index`: will convert the block epoch to superblock index.

Note that nodes will only store superblocks when they are consolidated, so a new node that synchronizes to the testnet will not store the superblocks that were created when the node was offline.

You can test this method using:

```
echo '{"jsonrpc":"2.0","id":"1","method":"getSuperblock","params":{"superblock_index":0}}' | cargo run -- -c witnet.toml node raw
```