### PR TITLE
feat(bridge): add timeout to post_to_witnet_more_than_once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4159,6 +4159,7 @@ dependencies = [
  "web3 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_crypto 0.3.2",
  "witnet_data_structures 0.3.2",
+ "witnet_util 0.3.2",
  "witnet_validations 0.3.2",
 ]
 

--- a/bridges/ethereum/Cargo.toml
+++ b/bridges/ethereum/Cargo.toml
@@ -21,4 +21,5 @@ tokio-core = "0.1.17"
 web3 = "0.10.0"
 witnet_data_structures = { path = "../../data_structures" }
 witnet_crypto = { path = "../../crypto" }
+witnet_util = { path = "../../util" }
 witnet_validations = { path = "../../validations" }

--- a/bridges/ethereum/src/config.rs
+++ b/bridges/ethereum/src/config.rs
@@ -30,6 +30,9 @@ pub struct Config {
     pub enable_claim_and_inclusion: bool,
     /// Enable data request result reporting
     pub enable_result_reporting: bool,
+    /// If post_to_witnet_more_than_once is enabled, this is the minimum time in seconds that must
+    /// elapse before the same data request is created and broadcasted to the Witnet network.
+    pub post_to_witnet_again_after_timeout: u64,
     /// Post data request more than once? Useful to retry if the data request
     /// was not included in a block
     pub post_to_witnet_more_than_once: bool,

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -18,6 +18,9 @@ enable_block_relay_old_blocks = true
 enable_claim_and_inclusion = true
 # Enable data request result reporting
 enable_result_reporting = true
+# If post_to_witnet_more_than_once is enabled, this is the minimum time in seconds that must
+# elapse before the same data request is created and broadcasted to the Witnet network.
+post_to_witnet_again_after_timeout = 3600 # 1 hour
 # Post data request more than once? Useful to retry if the data request
 # was not included in a block
 post_to_witnet_more_than_once = true


### PR DESCRIPTION
Fix #1293 (if post_to_witnet_more_than_once is set to true)

This solves issues where data requests get stuck in claimed state because they are not included in a witnet block.