### PR TITLE
Send superblocks to block relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4159,6 +4159,7 @@ dependencies = [
  "web3 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "witnet_crypto 0.3.2",
  "witnet_data_structures 0.3.2",
+ "witnet_util 0.3.2",
  "witnet_validations 0.3.2",
 ]
 

--- a/bridges/ethereum/Cargo.toml
+++ b/bridges/ethereum/Cargo.toml
@@ -21,4 +21,5 @@ tokio-core = "0.1.17"
 web3 = "0.10.0"
 witnet_data_structures = { path = "../../data_structures" }
 witnet_crypto = { path = "../../crypto" }
+witnet_util = { path = "../../util" }
 witnet_validations = { path = "../../validations" }

--- a/bridges/ethereum/src/actors/block_relay_and_poi.rs
+++ b/bridges/ethereum/src/actors/block_relay_and_poi.rs
@@ -42,6 +42,7 @@ pub fn get_blocks(
     })
     .collect()
 }
+
 /// Actor which receives Witnet superblocks, posts them to the block relay,
 /// and sends Proofs of Inclusion to Ethereum
 pub fn block_relay_and_poi(
@@ -80,265 +81,269 @@ pub fn block_relay_and_poi(
             };
 
             get_blocks(confirmed_block_hashes, witnet_client)
-            .and_then(                        {
-                                                  let config = Arc::clone(&config);
-                let eth_state = Arc::clone(&eth_state);
+                .and_then({
+                    let config = Arc::clone(&config);
+                    let eth_state = Arc::clone(&eth_state);
 
 
-                move |confirmed_blocks| {
-                // Optimization: do not process empty blocks
-                let is_non_empty = confirmed_blocks.iter().any(|block| {
-                    block.block_header.merkle_roots.dr_hash_merkle_root != empty_hash || block.block_header.merkle_roots.tally_hash_merkle_root != empty_hash
-                });
-                if !is_non_empty {
-                    log::debug!("Skipping empty superblock");
-                    return futures::finished(());
-                }
+                    move |confirmed_blocks| {
+                        // Optimization: do not process empty blocks
+                        let is_non_empty = confirmed_blocks.iter().any(|block| {
+                            block.block_header.merkle_roots.dr_hash_merkle_root != empty_hash || block.block_header.merkle_roots.tally_hash_merkle_root != empty_hash
+                        });
+                        if !is_non_empty {
+                            log::debug!("Skipping empty superblock");
+                            return futures::finished(());
+                        }
 
-                if (is_new_block && config.enable_block_relay_new_blocks) || (!is_new_block && config.enable_block_relay_old_blocks) {
-                    let superblock_epoch: U256 = superblock.index.into();
-                    let dr_merkle_root: U256 =
-                        match superblock.data_request_root {
-                            Hash::SHA256(x) => x.into(),
-                        };
-                    let tally_merkle_root: U256 =
-                        match superblock.tally_root {
-                            Hash::SHA256(x) => x.into(),
-                        };
+                        if (is_new_block && config.enable_block_relay_new_blocks) || (!is_new_block && config.enable_block_relay_old_blocks) {
+                            let superblock_epoch: U256 = superblock.index.into();
+                            let dr_merkle_root: U256 =
+                                match superblock.data_request_root {
+                                    Hash::SHA256(x) => x.into(),
+                                };
+                            let tally_merkle_root: U256 =
+                                match superblock.tally_root {
+                                    Hash::SHA256(x) => x.into(),
+                                };
 
-                    let block_relay_contract2 = block_relay_contract.clone();
+                            let block_relay_contract2 = block_relay_contract.clone();
 
-                    // Post witnet superblock to BlockRelay wrb_contract
-                    tokio::spawn(
-                        block_relay_contract
-                            .query(
-                                "readDrMerkleRoot",
-                                (superblock_hash, ),
-                                eth_account,
-                                contract::Options::default(),
-                                None,
-                            )
-                            .map(move |_: U256| {
-                                log::debug!("Superblock {:x} was already posted", superblock_hash);
-                            })
-                            .or_else({
-                                let config = Arc::clone(&config);
-
-                                move |_| {
-                                log::debug!("Trying to relay superblock {:x}", superblock_hash);
-                                block_relay_contract2
-                                    .call_with_confirmations(
-                                        "postNewBlock",
-                                        (superblock_hash, superblock_epoch, dr_merkle_root, tally_merkle_root),
+                            // Post witnet superblock to BlockRelay wrb_contract
+                            tokio::spawn(
+                                block_relay_contract
+                                    .query(
+                                        "readDrMerkleRoot",
+                                        (superblock_hash, ),
                                         eth_account,
-                                        contract::Options::with(|opt| {
-                                            opt.gas = config.gas_limits.post_new_block.map(Into::into);
-                                        }),
-                                        1,
+                                        contract::Options::default(),
+                                        None,
                                     )
-                                    .map_err(|e| log::error!("postNewBlock: {:?}", e))
-                                    .and_then(move |tx| {
-                                        log::debug!("postNewBlock: {:?}", tx);
-
-                                        handle_receipt(tx).map_err(move |()| {
-                                            log::warn!("Failed to post superblock {:x} to block relay, maybe it was already posted?", superblock_hash)
-                                        })
+                                    .map(move |_: U256| {
+                                        log::debug!("Superblock {:x} was already posted", superblock_hash);
                                     })
-                                    .map(move |()| {
-                                        log::info!("Posted superblock {:x} to block relay", superblock_hash);
-                                    })
-                            }})
-                    );
-                }
+                                    .or_else({
+                                        let config = Arc::clone(&config);
 
-                // Wait for someone else to publish the witnet block to ethereum
-                let (wbtx, wbrx) = oneshot::channel();
-                let fut = wait_for_witnet_block_tx2.send((superblock_hash, wbtx))
-                    .map_err(|e| log::error!("Failed to send message to block_ticker channel: {}", e))
-                    .and_then(move |_| {
-                        // Receiving the new block notification can fail if the block_ticker got
-                        // a different subscription to the same block hash.
-                        // In that case, since there already is another future waiting for the
-                        // same block, we can exit this one
-                        wbrx.map_err(move |e| {
-                            log::debug!("Failed to receive message through oneshot channel while waiting for superblock {}: {:x}", e, superblock_hash)
-                        })
-                    })
-                    .and_then({
-                        let eth_state = Arc::clone(&eth_state);
-                        move |()| {
-                        eth_state.wrb_requests.read()
-                    }})
-                    .and_then({
-                        let config = Arc::clone(&config);
-                        let eth_state = Arc::clone(&eth_state);
-                        move |wrb_requests| {
-                        let block_hash: U256 = match superblock.hash() {
-                            Hash::SHA256(x) => x.into(),
-                        };
-                        let dr_txs: Vec<DRTransaction> = confirmed_blocks.iter().flat_map(|block| {
-                            block.txns.data_request_txns.clone()
-                        }).collect();
-                        let tally_txs: Vec<TallyTransaction> = confirmed_blocks.iter().flat_map(|block| {
-                            block.txns.tally_txns.clone()
-                        }).collect();
+                                        move |_| {
+                                            log::debug!("Trying to relay superblock {:x}", superblock_hash);
+                                            block_relay_contract2
+                                                .call_with_confirmations(
+                                                    "postNewBlock",
+                                                    (superblock_hash, superblock_epoch, dr_merkle_root, tally_merkle_root),
+                                                    eth_account,
+                                                    contract::Options::with(|opt| {
+                                                        opt.gas = config.gas_limits.post_new_block.map(Into::into);
+                                                    }),
+                                                    1,
+                                                )
+                                                .map_err(|e| log::error!("postNewBlock: {:?}", e))
+                                                .and_then(move |tx| {
+                                                    log::debug!("postNewBlock: {:?}", tx);
 
-                        let block_epoch: U256 = superblock.index.into();
-
-                        let mut including = vec![];
-                        let mut resolving = vec![];
-
-                        let claimed_drs = wrb_requests.claimed();
-                        let waiting_for_tally = wrb_requests.included();
-
-                        if enable_claim_and_inclusion {
-                            for dr in &dr_txs {
-                                for dr_id in claimed_drs.get_by_right(&dr.body.dr_output.hash())
-                                {
-                                    let dr_inclusion_proof = match superblock.dr_proof_of_inclusion(&confirmed_blocks, &dr) {
-                                        Some(x) => x,
-                                        None => {
-                                            log::error!("Error creating data request proof of inclusion");
-                                            continue;
+                                                    handle_receipt(tx).map_err(move |()| {
+                                                        log::warn!("Failed to post superblock {:x} to block relay, maybe it was already posted?", superblock_hash)
+                                                    })
+                                                })
+                                                .map(move |()| {
+                                                    log::info!("Posted superblock {:x} to block relay", superblock_hash);
+                                                })
                                         }
+                                    })
+                            );
+                        }
+
+                        // Wait for someone else to publish the witnet block to ethereum
+                        let (wbtx, wbrx) = oneshot::channel();
+                        let fut = wait_for_witnet_block_tx2.send((superblock_hash, wbtx))
+                            .map_err(|e| log::error!("Failed to send message to block_ticker channel: {}", e))
+                            .and_then(move |_| {
+                                // Receiving the new block notification can fail if the block_ticker got
+                                // a different subscription to the same block hash.
+                                // In that case, since there already is another future waiting for the
+                                // same block, we can exit this one
+                                wbrx.map_err(move |e| {
+                                    log::debug!("Failed to receive message through oneshot channel while waiting for superblock {}: {:x}", e, superblock_hash)
+                                })
+                            })
+                            .and_then({
+                                let eth_state = Arc::clone(&eth_state);
+                                move |()| {
+                                    eth_state.wrb_requests.read()
+                                }
+                            })
+                            .and_then({
+                                let config = Arc::clone(&config);
+                                let eth_state = Arc::clone(&eth_state);
+                                move |wrb_requests| {
+                                    let block_hash: U256 = match superblock.hash() {
+                                        Hash::SHA256(x) => x.into(),
                                     };
+                                    let dr_txs: Vec<DRTransaction> = confirmed_blocks.iter().flat_map(|block| {
+                                        block.txns.data_request_txns.clone()
+                                    }).collect();
+                                    let tally_txs: Vec<TallyTransaction> = confirmed_blocks.iter().flat_map(|block| {
+                                        block.txns.tally_txns.clone()
+                                    }).collect();
 
-                                    let poi: Vec<U256> = dr_inclusion_proof
-                                        .lemma
-                                        .iter()
-                                        .map(|x| match x {
-                                            Hash::SHA256(x) => x.into(),
-                                        })
-                                        .collect();
-                                    let poi_index = U256::from(dr_inclusion_proof.index);
+                                    let block_epoch: U256 = superblock.index.into();
 
-                                    log::debug!(
+                                    let mut including = vec![];
+                                    let mut resolving = vec![];
+
+                                    let claimed_drs = wrb_requests.claimed();
+                                    let waiting_for_tally = wrb_requests.included();
+
+                                    if enable_claim_and_inclusion {
+                                        for dr in &dr_txs {
+                                            for dr_id in claimed_drs.get_by_right(&dr.body.dr_output.hash())
+                                            {
+                                                let dr_inclusion_proof = match superblock.dr_proof_of_inclusion(&confirmed_blocks, &dr) {
+                                                    Some(x) => x,
+                                                    None => {
+                                                        log::error!("Error creating data request proof of inclusion");
+                                                        continue;
+                                                    }
+                                                };
+
+                                                let poi: Vec<U256> = dr_inclusion_proof
+                                                    .lemma
+                                                    .iter()
+                                                    .map(|x| match x {
+                                                        Hash::SHA256(x) => x.into(),
+                                                    })
+                                                    .collect();
+                                                let poi_index = U256::from(dr_inclusion_proof.index);
+
+                                                log::debug!(
                                     "Proof of inclusion for data request {}:\nPoi: {:x?}\nPoi index: {}",
                                     dr.hash(),
                                     poi,
                                     poi_index,
                                 );
-                                    log::info!("[{}] Claimed dr got included in witnet block!", dr_id);
-                                    log::info!("[{}] Sending proof of inclusion to WRB wrb_contract", dr_id);
+                                                log::info!("[{}] Claimed dr got included in witnet block!", dr_id);
+                                                log::info!("[{}] Sending proof of inclusion to WRB wrb_contract", dr_id);
 
-                                    including.push((*dr_id, poi.clone(), poi_index, block_hash, block_epoch));
-                                }
-                            }
-                        }
-
-                        if enable_result_reporting {
-                            for tally in &tally_txs {
-                                for dr_id in waiting_for_tally.get_by_right(&tally.dr_pointer)
-                                {
-                                    let Hash::SHA256(dr_pointer_bytes) = tally.dr_pointer;
-                                    log::info!("[{}] Found tally for data request, posting to WRB", dr_id);
-                                    let tally_inclusion_proof = match superblock.tally_proof_of_inclusion(&confirmed_blocks, &tally) {
-                                        Some(x) => x,
-                                        None => {
-                                            log::error!("Error creating tally data proof of inclusion");
-                                            continue;
+                                                including.push((*dr_id, poi.clone(), poi_index, block_hash, block_epoch));
+                                            }
                                         }
-                                    };
-                                    log::debug!(
+                                    }
+
+                                    if enable_result_reporting {
+                                        for tally in &tally_txs {
+                                            for dr_id in waiting_for_tally.get_by_right(&tally.dr_pointer)
+                                            {
+                                                let Hash::SHA256(dr_pointer_bytes) = tally.dr_pointer;
+                                                log::info!("[{}] Found tally for data request, posting to WRB", dr_id);
+                                                let tally_inclusion_proof = match superblock.tally_proof_of_inclusion(&confirmed_blocks, &tally) {
+                                                    Some(x) => x,
+                                                    None => {
+                                                        log::error!("Error creating tally data proof of inclusion");
+                                                        continue;
+                                                    }
+                                                };
+                                                log::debug!(
                                     "Proof of inclusion for tally        {}:\nData: {:?}\n{:?}",
                                     tally.hash(),
                                     [&dr_pointer_bytes[..], &tally.tally].concat(),
                                     tally_inclusion_proof
                                 );
 
-                                    // Call report_result
-                                    let poi: Vec<U256> = tally_inclusion_proof
-                                        .lemma
-                                        .iter()
-                                        .map(|x| match x {
-                                            Hash::SHA256(x) => x.into(),
-                                        })
-                                        .collect();
-                                    let poi_index = U256::from(tally_inclusion_proof.index);
-                                    let result: Bytes = tally.tally.clone();
-                                    resolving.push((*dr_id, poi.clone(), poi_index, block_hash, block_epoch, result.clone()));
-                                }
-                            }
-                        }
+                                                // Call report_result
+                                                let poi: Vec<U256> = tally_inclusion_proof
+                                                    .lemma
+                                                    .iter()
+                                                    .map(|x| match x {
+                                                        Hash::SHA256(x) => x.into(),
+                                                    })
+                                                    .collect();
+                                                let poi_index = U256::from(tally_inclusion_proof.index);
+                                                let result: Bytes = tally.tally.clone();
+                                                resolving.push((*dr_id, poi.clone(), poi_index, block_hash, block_epoch, result.clone()));
+                                            }
+                                        }
+                                    }
 
-                        // Check if we need to acquire a write lock
-                        if !including.is_empty() || !resolving.is_empty() {
-                            Either::A(eth_state.wrb_requests.write().map(move |mut wrb_requests| {
-                                for (dr_id, poi, poi_index, block_hash, block_epoch) in including {
-                                    if wrb_requests.claimed().contains_left(&dr_id) {
-                                        wrb_requests.set_including(dr_id, poi.clone(), poi_index, block_hash, block_epoch);
-                                        let wrb_requests = eth_state.wrb_requests.clone();
-                                        let params_str = format!("{:?}", (dr_id, poi.clone(), poi_index, block_hash, block_epoch));
-                                        tokio::spawn(
-                                            wrb_contract
-                                                .call_with_confirmations(
-                                                    "reportDataRequestInclusion",
-                                                    (dr_id, poi, poi_index, block_hash, block_epoch),
-                                                    eth_account,
-                                                    contract::Options::with(|opt| {
-                                                        opt.gas = config.gas_limits.report_data_request_inclusion.map(Into::into);
-                                                    }),
-                                                    1,
-                                                )
+                                    // Check if we need to acquire a write lock
+                                    if !including.is_empty() || !resolving.is_empty() {
+                                        Either::A(eth_state.wrb_requests.write().map(move |mut wrb_requests| {
+                                            for (dr_id, poi, poi_index, block_hash, block_epoch) in including {
+                                                if wrb_requests.claimed().contains_left(&dr_id) {
+                                                    wrb_requests.set_including(dr_id, poi.clone(), poi_index, block_hash, block_epoch);
+                                                    let wrb_requests = eth_state.wrb_requests.clone();
+                                                    let params_str = format!("{:?}", (dr_id, poi.clone(), poi_index, block_hash, block_epoch));
+                                                    tokio::spawn(
+                                                        wrb_contract
+                                                            .call_with_confirmations(
+                                                                "reportDataRequestInclusion",
+                                                                (dr_id, poi, poi_index, block_hash, block_epoch),
+                                                                eth_account,
+                                                                contract::Options::with(|opt| {
+                                                                    opt.gas = config.gas_limits.report_data_request_inclusion.map(Into::into);
+                                                                }),
+                                                                1,
+                                                            )
 
-                                                .then(move |tx| {
-                                                    match tx {
-                                                        Ok(tx) => {
-                                                            log::debug!("reportDataRequestInclusion: {:?}", tx);
-                                                            Either::A(handle_receipt(tx).map_err(|()| log::error!("handle_receipt: transaction failed")))
-                                                        }
-                                                        Err(e) => {
-                                                            log::error!("reportDataRequestInclusion{}: {:?}", params_str, e);
-                                                            Either::B(wrb_requests.write().map(move |mut wrb_requests| wrb_requests.undo_including(dr_id)))
-                                                        }
-                                                    }
-                                                }),
-                                        );
+                                                            .then(move |tx| {
+                                                                match tx {
+                                                                    Ok(tx) => {
+                                                                        log::debug!("reportDataRequestInclusion: {:?}", tx);
+                                                                        Either::A(handle_receipt(tx).map_err(|()| log::error!("handle_receipt: transaction failed")))
+                                                                    }
+                                                                    Err(e) => {
+                                                                        log::error!("reportDataRequestInclusion{}: {:?}", params_str, e);
+                                                                        Either::B(wrb_requests.write().map(move |mut wrb_requests| wrb_requests.undo_including(dr_id)))
+                                                                    }
+                                                                }
+                                                            }),
+                                                    );
+                                                }
+                                            }
+                                            for (dr_id, poi, poi_index, block_hash, block_epoch, result) in resolving {
+                                                if wrb_requests.included().contains_left(&dr_id) {
+                                                    wrb_requests.set_resolving(dr_id, poi.clone(), poi_index, block_hash, block_epoch, result.clone());
+                                                    let wrb_requests = eth_state.wrb_requests.clone();
+                                                    let params_str = format!("{:?}", &(dr_id, poi.clone(), poi_index, block_hash, block_epoch, result.clone()));
+                                                    tokio::spawn(
+                                                        wrb_contract
+                                                            .call_with_confirmations(
+                                                                "reportResult",
+                                                                (dr_id, poi, poi_index, block_hash, block_epoch, result),
+                                                                eth_account,
+                                                                contract::Options::with(|opt| {
+                                                                    opt.gas = config.gas_limits.report_result.map(Into::into);
+                                                                }),
+                                                                1,
+                                                            )
+                                                            .then(move |tx| {
+                                                                match tx {
+                                                                    Ok(tx) => {
+                                                                        log::debug!("reportResult: {:?}", tx);
+                                                                        Either::A(handle_receipt(tx).map_err(|()| log::error!("handle_receipt: transaction failed")))
+                                                                    }
+                                                                    Err(e) => {
+                                                                        log::error!("reportResult{}: {:?}", params_str, e);
+                                                                        Either::B(wrb_requests.write().map(move |mut wrb_requests| wrb_requests.undo_resolving(dr_id)))
+                                                                    }
+                                                                }
+                                                            }),
+                                                    );
+                                                }
+                                            }
+                                        }))
+                                    } else {
+                                        Either::B(futures::finished(()))
                                     }
                                 }
-                                for (dr_id, poi, poi_index, block_hash, block_epoch, result) in resolving {
-                                    if wrb_requests.included().contains_left(&dr_id) {
-                                        wrb_requests.set_resolving(dr_id, poi.clone(), poi_index, block_hash, block_epoch, result.clone());
-                                        let wrb_requests = eth_state.wrb_requests.clone();
-                                        let params_str = format!("{:?}", &(dr_id, poi.clone(), poi_index, block_hash, block_epoch, result.clone()));
-                                        tokio::spawn(
-                                            wrb_contract
-                                                .call_with_confirmations(
-                                                    "reportResult",
-                                                    (dr_id, poi, poi_index, block_hash, block_epoch, result),
-                                                    eth_account,
-                                                    contract::Options::with(|opt| {
-                                                        opt.gas = config.gas_limits.report_result.map(Into::into);
-                                                    }),
-                                                    1,
-                                                )
-                                                .then(move |tx| {
-                                                    match tx {
-                                                        Ok(tx) => {
-                                                            log::debug!("reportResult: {:?}", tx);
-                                                            Either::A(handle_receipt(tx).map_err(|()| log::error!("handle_receipt: transaction failed")))
-                                                        }
-                                                        Err(e) => {
-                                                            log::error!("reportResult{}: {:?}", params_str, e);
-                                                            Either::B(wrb_requests.write().map(move |mut wrb_requests| wrb_requests.undo_resolving(dr_id)))
-                                                        }
-                                                    }
-                                                }),
-                                        );
-                                    }
-                                }
-                            }))
-                        } else {
-                            Either::B(futures::finished(()))
-                        }
-                    }})
-                    // Without this line the actor will panic on the first failure
-                    .then(|_| Result::<(), ()>::Ok(()));
+                            })
+                            // Without this line the actor will panic on the first failure
+                            .then(|_| Result::<(), ()>::Ok(()));
 
-                // Process multiple blocks in parallel
-                tokio::spawn(fut);
-                futures::done(Result::<(), ()>::Ok(()))
-            }})
+                        // Process multiple blocks in parallel
+                        tokio::spawn(fut);
+                        futures::done(Result::<(), ()>::Ok(()))
+                    }
+                })
         })
         .map(|_| ());
 

--- a/bridges/ethereum/src/actors/claim_and_post.rs
+++ b/bridges/ethereum/src/actors/claim_and_post.rs
@@ -488,21 +488,17 @@ fn claim_and_post_dr(
 pub fn claim_and_post(
     config: Arc<Config>,
     eth_state: Arc<EthState>,
+    witnet_client: Arc<TcpSocket>,
 ) -> (
-    async_jsonrpc_client::transports::shared::EventLoopHandle,
     mpsc::Sender<ClaimMsg>,
     impl Future<Item = (), Error = ()>,
 ) {
     // Important: the handle cannot be dropped, otherwise the client stops
     // processing events
-    let witnet_addr = config.witnet_jsonrpc_addr.to_string();
-    let (handle, witnet_client) =
-        async_jsonrpc_client::transports::tcp::TcpSocket::new(&witnet_addr).unwrap();
-    let witnet_client = Arc::new(witnet_client);
+    let witnet_client = Arc::clone(&witnet_client);
     let (tx, rx) = mpsc::channel(16);
 
     (
-        handle,
         tx,
         rx.map_err(|_| ()).for_each(move |msg| {
             if !config.enable_claim_and_inclusion {

--- a/bridges/ethereum/src/actors/claim_and_post.rs
+++ b/bridges/ethereum/src/actors/claim_and_post.rs
@@ -489,10 +489,7 @@ pub fn claim_and_post(
     config: Arc<Config>,
     eth_state: Arc<EthState>,
     witnet_client: Arc<TcpSocket>,
-) -> (
-    mpsc::Sender<ClaimMsg>,
-    impl Future<Item = (), Error = ()>,
-) {
+) -> (mpsc::Sender<ClaimMsg>, impl Future<Item = (), Error = ()>) {
     // Important: the handle cannot be dropped, otherwise the client stops
     // processing events
     let witnet_client = Arc::clone(&witnet_client);

--- a/bridges/ethereum/src/actors/mod.rs
+++ b/bridges/ethereum/src/actors/mod.rs
@@ -29,6 +29,15 @@ pub struct SuperBlockNotification {
     pub consolidated_block_hashes: Vec<Hash>,
 }
 
+/// Struct for deserializing the message returned by the getSuperblockBlocks client response
+#[derive(Debug, Deserialize)]
+pub struct SuperblockIndex {
+    /// The hashes of the blocks that we are willing to retrieve.
+    pub block_hashes: Vec<Hash>,
+    /// The index of the superblock containing the aforementioned hashes.
+    pub superblock_index: u32,
+}
+
 /// Message to the block_relay_and_poi actor
 #[derive(Debug)]
 pub enum WitnetSuperBlock {

--- a/bridges/ethereum/src/actors/mod.rs
+++ b/bridges/ethereum/src/actors/mod.rs
@@ -1,6 +1,7 @@
 use futures::Future;
+use serde::Deserialize;
 use web3::types::{TransactionReceipt, U256};
-use witnet_data_structures::chain::Block;
+use witnet_data_structures::chain::{Block, Hash, SuperBlock};
 
 pub mod block_relay_and_poi;
 pub mod block_relay_check;
@@ -19,7 +20,28 @@ pub enum ClaimMsg {
     Tick,
 }
 
+/// Struct for deserializing the message returned by the superblock notification
+#[derive(Debug, Deserialize)]
+pub struct SuperBlockNotification {
+    /// The superblock that we are signaling as consolidated.
+    pub superblock: SuperBlock,
+    /// The hashes of the blocks that we are signaling as consolidated.
+    pub consolidated_block_hashes: Vec<Hash>,
+}
+
 /// Message to the block_relay_and_poi actor
+#[derive(Debug)]
+pub enum WitnetSuperBlock {
+    /// The subscription to new Witnet blocks just sent us a new block.
+    /// Post it to the block relay, and process data requests and tallies.
+    New(SuperBlockNotification),
+    /// This old block may have tallies for data requests whose inclusion can
+    /// be reported to the WRB.
+    /// Process data requests and tallies.
+    Replay(SuperBlockNotification),
+}
+
+/// Previous message to the block_relay_and_poi actor
 #[derive(Debug)]
 pub enum WitnetBlock {
     /// The subscription to new Witnet blocks just sent us a new block.

--- a/bridges/ethereum/src/actors/tally_finder.rs
+++ b/bridges/ethereum/src/actors/tally_finder.rs
@@ -1,6 +1,7 @@
 //! Periodically ask the Witnet node for resolved data requests
 
 use crate::{actors::WitnetBlock, config::Config, eth::EthState};
+use async_jsonrpc_client::transports::tcp::TcpSocket;
 use async_jsonrpc_client::{futures::Stream, Transport};
 use futures::{future::Either, sink::Sink};
 use rand::{thread_rng, Rng};
@@ -12,7 +13,6 @@ use std::{
 use tokio::{sync::mpsc, timer::Interval};
 use web3::futures::Future;
 use witnet_data_structures::{chain::Block, chain::DataRequestInfo};
-use async_jsonrpc_client::transports::tcp::TcpSocket;
 
 /// Periodically ask the Witnet node for resolved data requests
 pub fn tally_finder(
@@ -20,9 +20,8 @@ pub fn tally_finder(
     eth_state: Arc<EthState>,
     tx: mpsc::Sender<WitnetBlock>,
     witnet_client: Arc<TcpSocket>,
-) ->
-    impl Future<Item = (), Error = ()>
- {
+) -> impl Future<Item = (), Error = ()> {
+    let witnet_client = Arc::new(witnet_client);
 
     Interval::new(Instant::now(), Duration::from_millis(config.witnet_dr_report_polling_rate_ms))
         .map_err(|e| log::error!("Error creating interval: {:?}", e))

--- a/bridges/ethereum/src/actors/tally_finder.rs
+++ b/bridges/ethereum/src/actors/tally_finder.rs
@@ -12,24 +12,19 @@ use std::{
 use tokio::{sync::mpsc, timer::Interval};
 use web3::futures::Future;
 use witnet_data_structures::{chain::Block, chain::DataRequestInfo};
+use async_jsonrpc_client::transports::tcp::TcpSocket;
 
 /// Periodically ask the Witnet node for resolved data requests
 pub fn tally_finder(
     config: Arc<Config>,
     eth_state: Arc<EthState>,
     tx: mpsc::Sender<WitnetBlock>,
-) -> (
-    async_jsonrpc_client::transports::shared::EventLoopHandle,
-    impl Future<Item = (), Error = ()>,
-) {
-    let witnet_addr = config.witnet_jsonrpc_addr.to_string();
-    // Important: the handle cannot be dropped, otherwise the client stops
-    // processing events
-    let (handle, witnet_client) =
-        async_jsonrpc_client::transports::tcp::TcpSocket::new(&witnet_addr).unwrap();
-    let witnet_client = Arc::new(witnet_client);
+    witnet_client: Arc<TcpSocket>,
+) ->
+    impl Future<Item = (), Error = ()>
+ {
 
-    (handle, Interval::new(Instant::now(), Duration::from_millis(config.witnet_dr_report_polling_rate_ms))
+    Interval::new(Instant::now(), Duration::from_millis(config.witnet_dr_report_polling_rate_ms))
         .map_err(|e| log::error!("Error creating interval: {:?}", e))
         .and_then(move |x| eth_state.wrb_requests.read().map(move |wrb_requests| (wrb_requests, x)))
         .and_then({
@@ -91,5 +86,5 @@ pub fn tally_finder(
 
         })
         .then(|_| Ok(()))
-        .for_each(|_| Ok(())))
+        .for_each(|_| Ok(()))
 }

--- a/bridges/ethereum/src/config.rs
+++ b/bridges/ethereum/src/config.rs
@@ -30,6 +30,9 @@ pub struct Config {
     pub enable_claim_and_inclusion: bool,
     /// Enable data request result reporting
     pub enable_result_reporting: bool,
+    /// If post_to_witnet_more_than_once is enabled, this is the minimum time in seconds that must
+    /// elapse before the same data request is created and broadcasted to the Witnet network.
+    pub post_to_witnet_again_after_timeout: u64,
     /// Post data request more than once? Useful to retry if the data request
     /// was not included in a block
     pub post_to_witnet_more_than_once: bool,

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -18,6 +18,9 @@ enable_block_relay_old_blocks = true
 enable_claim_and_inclusion = true
 # Enable data request result reporting
 enable_result_reporting = true
+# If post_to_witnet_more_than_once is enabled, this is the minimum time in seconds that must
+# elapse before the same data request is created and broadcasted to the Witnet network.
+post_to_witnet_again_after_timeout = 3600 # 1 hour
 # Post data request more than once? Useful to retry if the data request
 # was not included in a block
 post_to_witnet_more_than_once = true

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -1,13 +1,13 @@
 # Address of the witnet node JSON-RPC server
-witnet_jsonrpc_addr = "127.0.0.1:1234"
+witnet_jsonrpc_addr = "127.0.0.1:21338"
 # Url of the ethereum client
-eth_client_url = "http://127.0.0.1:8545"
+eth_client_url = "http://127.0.0.1:8888"
 # Address of the WitnetRequestsBoard deployed contract
-wrb_contract_addr = "0x49824bd89338C26Ea204F20AcbAd404CFeAB3301"
+wrb_contract_addr = "0x354B08f9fD4b171e774898261908DfeA113b0e14"
 # Address of the BlockRelay deployed contract
-block_relay_contract_addr = "0x1D774D4D7EC51B111EFE48EB5D53022C3e9CC4Af"
+block_relay_contract_addr = "0xEaA9e7Ea612b169f5b41cfF86dA6322f57264a19"
 # Ethereum account used to create the transactions
-eth_account = "0x20E56DAc7582782584c46061F382812D502Dd139"
+eth_account = "0x333b18f64949C59Cd0b84b51C7580f260c563c31"
 # Enable block relay from witnet to ethereum, relay only new blocks
 # (blocks that were recently consolidated)
 enable_block_relay_new_blocks = true
@@ -23,7 +23,7 @@ enable_result_reporting = true
 post_to_witnet_again_after_timeout = 3600 # 1 hour
 # Post data request more than once? Useful to retry if the data request
 # was not included in a block
-post_to_witnet_more_than_once = true
+post_to_witnet_more_than_once = false
 # Subscribe to witnet blocks? This is only necessary for block relay
 subscribe_to_witnet_blocks = true
 # Period to check for new blocks in block relay
@@ -46,8 +46,8 @@ read_dr_hash_interval_ms = 10_000
 # Gas limits for some methods.
 # To let the client estimate, comment out the fields
 [gas_limits]
-claim_data_requests = 500000
-post_data_request = 1000000
-post_new_block = 200000
-report_data_request_inclusion = 200000
-report_result = 200000
+claim_data_requests = 5000000
+post_data_request = 10000000
+post_new_block = 2000000
+report_data_request_inclusion = 2000000
+report_result = 2000000


### PR DESCRIPTION
This PR utilizes the superblocks subscription from branch  #1488 

It also adds support for storing superblocks and adds a method for retreving a superblock for a given epoch

It modifies the bridge to make it able to send superblocks to the block relay

Supersedes #1530

Close #1498 