### PR TITLE
fix(node): do not restore chain state when processing empty AddBlocks

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -303,9 +303,6 @@ impl Handler<AddBlocks> for ChainManager {
                 if msg.blocks.is_empty() {
                     log::debug!("Received an empty AddBlocks message");
                     self.update_state_machine(StateMachine::WaitingConsensus);
-                    self.initialize_from_storage(ctx);
-                    log::info!("Restored chain state from storage");
-
                     return;
                 }
 


### PR DESCRIPTION
This is a workaround to #1532.

That issue is still not solved because stopping the node while synchronizing does not store the chain state.

Explanation: the `Session` actor implicitly use an empty `AddBlocks` message to indicate an error. For example, when a peer disconnects while the node is receiving blocks from them, the `Session` actor will send an empty add blocks.

Before this PR, the `ChainManager` would restore the chain state to the last consolidated state, which is epoch 0 in nodes that are synchronizing the first time. This would make the synchronization process restart, and as the number of blocks increases synchronizing a new node would become impossible. After this PR, the `ChainManager` will simply request a new blocks batch from another peer when a peer fails to send the required blocks.