### PR TITLE
fix(chain manager): avoid overflows while selecting committee

### DIFF
--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -1584,11 +1584,23 @@ impl ChainManager {
         superblock_period: u32,
     ) -> Option<u32> {
         if sync_target.superblock.checkpoint
-            == self.chain_state.superblock_state.get_beacon().checkpoint
+            <= self.chain_state.superblock_state.get_beacon().checkpoint
         {
             None
         } else {
             Some(sync_target.superblock.checkpoint * superblock_period)
+        }
+    }
+
+    fn superblock_candidate_is_needed(
+        &self,
+        candidate_superblock_epoch: u32,
+        superblock_period: u32,
+    ) -> Option<u32> {
+        if candidate_superblock_epoch <= self.chain_state.superblock_state.get_beacon().checkpoint {
+            None
+        } else {
+            Some(candidate_superblock_epoch * superblock_period)
         }
     }
 


### PR DESCRIPTION
This PR solves the issue observed during synchronization that generated substraction overflows. This happened because the node tried to create a consolidate and candidate superblocks that it already had built before but then lost synchronization because of lack of consensus on the beacons sent by its peers. While constructing the target superblock again after having constructed the candidate, the substaction between these two checkpoints yields negative.

This PR adds functionality to check whether we need to construct the target AND CANDIDATE blocks while syncronizing

Closes #1526 
