### PR TITLE
Add config parameter to limit the number of blocks downloaded when synchronizing

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -276,6 +276,9 @@ pub struct Connections {
     /// Reject (tarpit) inbound connections coming from addresses in the same /16 IP range, so as
     /// to prevent sybil peers from monopolizing our inbound capacity (128 by default).
     pub reject_sybil_inbounds: bool,
+
+    /// Limit the number of requested blocks that will be processed as one batch
+    pub requested_blocks_batch_limit: u32,
 }
 
 fn to_millis<S>(val: &Option<Duration>, serializer: S) -> Result<S::Ok, S::Error>
@@ -724,6 +727,10 @@ impl Connections {
                 .reject_sybil_inbounds
                 .to_owned()
                 .unwrap_or_else(|| defaults.connections_reject_sybil_inbounds()),
+            requested_blocks_batch_limit: config
+                .requested_blocks_batch_limit
+                .to_owned()
+                .unwrap_or_else(|| defaults.connections_requested_blocks_batch_limit()),
         }
     }
 
@@ -746,6 +753,7 @@ impl Connections {
             bucketing_ice_period: Some(self.bucketing_ice_period),
             bucketing_update_period: Some(self.bucketing_update_period),
             reject_sybil_inbounds: Some(self.reject_sybil_inbounds),
+            requested_blocks_batch_limit: Some(self.requested_blocks_batch_limit),
         }
     }
 }
@@ -1145,6 +1153,7 @@ mod tests {
             bucketing_ice_period: Some(Duration::from_secs(13200)),
             bucketing_update_period: Some(200),
             reject_sybil_inbounds: Some(false),
+            requested_blocks_batch_limit: Some(99),
         };
         let config = Connections::from_partial(&partial_config, &Testnet);
 
@@ -1165,6 +1174,7 @@ mod tests {
         assert_eq!(config.bucketing_ice_period, Duration::from_secs(13200));
         assert_eq!(config.bucketing_update_period, 200);
         assert_eq!(config.reject_sybil_inbounds, false);
+        assert_eq!(config.requested_blocks_batch_limit, 99);
     }
 
     #[test]

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -98,6 +98,12 @@ pub trait Defaults {
         true
     }
 
+    /// Limit the number of requested blocks that will be processed as one batch
+    fn connections_requested_blocks_batch_limit(&self) -> u32 {
+        // Default: 500 blocks
+        500
+    }
+
     /// Timestamp at the start of epoch 0
     fn consensus_constants_checkpoint_zero_timestamp(&self) -> i64;
 


### PR DESCRIPTION
Close #1279

Built on top of #1577 

Adds a configurable limit to the received blocks batch size, used when synchronizing.

```
[connections]
requested_blocks_batch_limit = 50
```

Note that values higher than 500 will work as 500, because there is a hardcoded limit to the sent blocks batch size:

```rust
/// Maximum blocks number to be sent during synchronization process
pub const MAX_BLOCKS_SYNC: usize = 500;
```

Also, setting `requested_blocks_batch_limit = 1` will result in an infinite loop and the node not syncing, because of #1580 

Setting `requested_blocks_batch_limit = 2` does also not work because the node stops requesting new blocks after reaching the target superblock.

So setting values smaller than 2 times the superblock period (2 * 10 in the current testnet) are silently set to that value (2 * 10).

