### PR TITLE
feat: support x86_64-pc-windows-msvc target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 [[package]]
 name = "cbor-codec"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/witnet/cbor-codec.git?branch=feat/ldexpf-shim#bfea8a49d0f9ba4902f0f45b7e48199acf3134cc"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4207,7 +4207,7 @@ dependencies = [
  "bech32 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bls-signatures-rs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cbor-codec 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cbor-codec 0.7.1 (git+https://github.com/witnet/cbor-codec.git?branch=feat/ldexpf-shim)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "exonum-build 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4310,7 +4310,7 @@ dependencies = [
 name = "witnet_rad"
 version = "0.3.2"
 dependencies = [
- "cbor-codec 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cbor-codec 0.7.1 (git+https://github.com/witnet/cbor-codec.git?branch=feat/ldexpf-shim)",
  "failure 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4485,7 +4485,7 @@ dependencies = [
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-"checksum cbor-codec 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e083a023562b37c52837e850131a51b1154cceb9d149f41ee3d386737b140f46"
+"checksum cbor-codec 0.7.1 (git+https://github.com/witnet/cbor-codec.git?branch=feat/ldexpf-shim)" = "<none>"
 "checksum cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
 "checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,10 @@ opt-level = 0
 
 [profile.release]
 opt-level = 3
+
+[package.metadata.vcpkg]
+git = "https://github.com/microsoft/vcpkg"
+rev = "4c1db68"
+
+[package.metadata.vcpkg.target]
+x86_64-pc-windows-msvc = { triplet = "x64-windows-static", install = ["openssl"] }

--- a/data_structures/Cargo.toml
+++ b/data_structures/Cargo.toml
@@ -10,7 +10,7 @@ workspace = ".."
 bls-signatures-rs = "0.1.0"
 bech32 = "0.7.2"
 byteorder = "1.3.4"
-cbor-codec = "0.7.1"
+cbor-codec = { git = "https://github.com/witnet/cbor-codec.git", branch = "feat/ldexpf-shim" }
 chrono = "0.4.10"
 failure = "0.1.8"
 hex = "0.4.1"

--- a/rad/Cargo.toml
+++ b/rad/Cargo.toml
@@ -7,7 +7,7 @@ workspace = ".."
 description = "RAD component"
 
 [dependencies]
-cbor-codec = "0.7.1"
+cbor-codec = { git = "https://github.com/witnet/cbor-codec.git", branch = "feat/ldexpf-shim" }
 failure = "0.1.8"
 futures = "0.3.4"
 hex = "0.4.1"


### PR DESCRIPTION
The main change here is a custom dependency on a forked version of `cbor-codec` that uses a shim for the `ldexpf` system function when on Windows (as such function does not exist on MSVC's own `libc` / `libm`).

## Compilation dependencies (orientative)
- Rust (`x86_64-pc-windows-msvc` toolchain)
- LLVM
- Microsoft Visual C++ Distributable Package
- `vcpkg`
- `openssl:x64-windows-static` (installed through `vcpkg`)

## Command for compiling
```console
OPENSSL_STATIC=1 OPENSSL_DIR="C:\Program Files\vcpkg\installed\x64-windows-static" cargo build --release
```