### PR TITLE
fix(node): wait 1 epoch before sending superblock vote

### DIFF
--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -293,7 +293,11 @@ impl SuperBlockState {
             }
         };
         // TODO: delete this log after testing
-        log::debug!("Add vote: {:?}", r);
+        log::debug!(
+            "Add vote: {:?} {}",
+            r,
+            crate::types::Command::SuperBlockVote(sbv.clone())
+        );
 
         r
     }


### PR DESCRIPTION
Fix #1573

Also, improved the "Add vote" log line, now it looks like:

```
[2020-09-21T13:04:10Z DEBUG witnet_data_structures::superblock] Add vote: ValidWithSameHash SUPERBLOCK_VOTE twit1fulan0j78dmdfa3gx0779kszj5sc5j35feljv5 #3463: ce1ff0a6b34a1fb0587bebae84a4440240500f08cb1581fce0b1e71b09cc85d7
```