### PR TITLE
feat(wallet): add balances and add time_lock support in create VTTs

### DIFF
--- a/wallet/src/actors/app/handlers/create_vtt.rs
+++ b/wallet/src/actors/app/handlers/create_vtt.rs
@@ -26,6 +26,7 @@ pub struct VttMetadata {
     to: String,
     value: u64,
     fee: u64,
+    time_lock: u64,
 }
 
 #[derive(Debug, Serialize)]
@@ -47,7 +48,7 @@ impl Handler<CreateVttRequest> for app::App {
         let testnet = self.params.testnet;
         let validated = validate(testnet, &msg.address).map_err(app::validation_error);
 
-        let f = fut::result(validated).and_then(move |pkh, slf: &mut Self, _ctx| {
+        let f = fut::result(validated).and_then(move |pkh, act: &mut Self, _ctx| {
             let params = types::VttParams {
                 pkh,
                 value: msg.amount,
@@ -55,7 +56,7 @@ impl Handler<CreateVttRequest> for app::App {
                 time_lock: msg.time_lock,
             };
 
-            slf.create_vtt(&msg.session_id, &msg.wallet_id, params)
+            act.create_vtt(&msg.session_id, &msg.wallet_id, params)
                 .map(|transaction, _, _| {
                     let transaction_id = hex::encode(transaction.hash().as_ref());
                     let bytes = hex::encode(transaction.to_pb_bytes().unwrap());
@@ -69,6 +70,7 @@ impl Handler<CreateVttRequest> for app::App {
                             to: msg.address,
                             value: msg.amount,
                             fee,
+                            time_lock: msg.time_lock,
                         },
                     }
                 })

--- a/wallet/src/actors/app/handlers/get_balance.rs
+++ b/wallet/src/actors/app/handlers/get_balance.rs
@@ -10,7 +10,7 @@ pub struct GetBalanceRequest {
     wallet_id: String,
 }
 
-pub type GetBalanceResponse = model::Balance;
+pub type GetBalanceResponse = model::WalletBalance;
 
 impl Message for GetBalanceRequest {
     type Result = app::Result<GetBalanceResponse>;

--- a/wallet/src/actors/app/handlers/unlock_wallet.rs
+++ b/wallet/src/actors/app/handlers/unlock_wallet.rs
@@ -1,8 +1,7 @@
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::actors::app;
-use crate::types;
+use crate::{actors::app, model, types};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UnlockWalletRequest {
@@ -17,7 +16,7 @@ pub struct UnlockWalletResponse {
     caption: Option<String>,
     available_accounts: Vec<u32>,
     current_account: u32,
-    account_balance: u64,
+    account_balance: model::WalletBalance,
     session_expiration_secs: u64,
 }
 

--- a/wallet/src/actors/app/methods.rs
+++ b/wallet/src/actors/app/methods.rs
@@ -636,8 +636,8 @@ impl App {
             self.state
                 .get_wallet_by_session_and_id(&session_id, &wallet_id),
         )
-        .and_then(move |wallet, slf: &mut Self, _| {
-            slf.send_inventory_transaction(transaction.clone())
+        .and_then(move |wallet, act: &mut Self, _| {
+            act.send_inventory_transaction(transaction.clone())
                 .and_then(move |jsonrpc_result, _slf, _ctx| {
                     match wallet.add_local_movement(&model::ExtendedTransaction {
                         transaction,

--- a/wallet/src/actors/app/methods.rs
+++ b/wallet/src/actors/app/methods.rs
@@ -140,7 +140,7 @@ impl App {
         &mut self,
         session_id: types::SessionId,
         wallet_id: String,
-    ) -> ResponseActFuture<model::Balance> {
+    ) -> ResponseActFuture<model::WalletBalance> {
         let f = fut::result(
             self.state
                 .get_wallet_by_session_and_id(&session_id, &wallet_id),

--- a/wallet/src/actors/worker/handlers/get_balance.rs
+++ b/wallet/src/actors/worker/handlers/get_balance.rs
@@ -6,7 +6,7 @@ use crate::{model, types};
 pub struct GetBalance(pub types::SessionWallet);
 
 impl Message for GetBalance {
-    type Result = worker::Result<model::Balance>;
+    type Result = worker::Result<model::WalletBalance>;
 }
 
 impl Handler<GetBalance> for worker::Worker {

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -201,12 +201,10 @@ impl Worker {
         Ok(addresses)
     }
 
-    pub fn balance(&mut self, wallet: &types::Wallet) -> Result<model::Balance> {
+    pub fn balance(&mut self, wallet: &types::Wallet) -> Result<model::WalletBalance> {
         let balance = wallet.balance()?;
 
-        Ok(model::Balance {
-            total: balance.amount.to_string(),
-        })
+        Ok(balance)
     }
 
     pub fn transactions(
@@ -277,8 +275,8 @@ impl Worker {
                 "events": events.unwrap_or_default(),
                 "status": {
                     "account": {
-                        "id": balance.account,
-                        "balance": balance.amount,
+                        "id": wallet_data.current_account,
+                        "balance": balance,
                     },
                     "node": {
                         "address": client.url,

--- a/wallet/src/model.rs
+++ b/wallet/src/model.rs
@@ -255,12 +255,15 @@ impl fmt::Display for OutPtr {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+/// UTXO information including amount, address and time lock
+#[derive(Clone, Debug, Eq, Deserialize, PartialEq, Serialize)]
 pub struct KeyBalance {
-    /// PKH receiving this balance
-    pub pkh: types::PublicKeyHash,
     /// Amount of the UTXO
     pub amount: u64,
+    /// PKH receiving this balance
+    pub pkh: types::PublicKeyHash,
+    /// Timestamp in which UTXO is unlocked
+    pub time_lock: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Default, Serialize, Deserialize)]

--- a/wallet/src/model.rs
+++ b/wallet/src/model.rs
@@ -48,8 +48,8 @@ pub struct AddressInfo {
     pub label: Option<String>,
     pub received_payments: Vec<String>,
     pub received_amount: u64,
-    pub first_payment_date: Option<i64>,
-    pub last_payment_date: Option<i64>,
+    pub first_payment_date: Option<u64>,
+    pub last_payment_date: Option<u64>,
 }
 
 /// A balance with a distinction between UTXOs that are expendable or time-locked
@@ -144,7 +144,7 @@ pub struct Transaction {
     /// Reward to miner for including transaction in the block
     pub miner_fee: u64,
     /// Date when transaction was included a block (same as block date)
-    pub timestamp: i64,
+    pub timestamp: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/wallet/src/model.rs
+++ b/wallet/src/model.rs
@@ -52,9 +52,24 @@ pub struct AddressInfo {
     pub last_payment_date: Option<i64>,
 }
 
-#[derive(Debug, Serialize)]
-pub struct Balance {
-    pub total: String,
+/// A balance with a distinction between UTXOs that are expendable or time-locked
+#[derive(Copy, Clone, Debug, Eq, Default, Deserialize, PartialEq, Serialize)]
+pub struct BalanceInfo {
+    /// Expendable funds
+    pub available: u64,
+    /// Time-locked funds
+    pub locked: u64,
+}
+
+/// List of wallet balances (confirmed, unconfirmed and pending)
+#[derive(Copy, Clone, Debug, Eq, Default, Deserialize, PartialEq, Serialize)]
+pub struct WalletBalance {
+    /// Total amount of wallet's funds after last confirmed superblock
+    pub confirmed: BalanceInfo,
+    /// Amount of local pending movements not yet indexed in a block
+    pub local_movements: u64,
+    /// Total amount of wallet's funds after last block
+    pub unconfirmed: BalanceInfo,
 }
 
 #[derive(Debug, Serialize)]

--- a/wallet/src/model.rs
+++ b/wallet/src/model.rs
@@ -67,7 +67,7 @@ pub struct WalletBalance {
     /// Total amount of wallet's funds after last confirmed superblock
     pub confirmed: BalanceInfo,
     /// Amount of local pending movements not yet indexed in a block
-    pub local_movements: u64,
+    pub local: u64,
     /// Total amount of wallet's funds after last block
     pub unconfirmed: BalanceInfo,
 }

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -69,8 +69,12 @@ where
         state.pending_movements.clear();
         state.pending_addresses_by_path.clear();
         state.pending_addresses_by_block.clear();
+        state.local_movements.clear();
 
         // Restore state from database
+        state.transaction_next_id = self
+            .db
+            .get_or_default::<_, u32>(&keys::transaction_next_id(account))?;
         state.next_external_index = self.db.get_or_default(&keys::account_next_index(
             account,
             constants::EXTERNAL_KEYCHAIN,

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -134,7 +134,7 @@ where
                     )
             });
         let balance = model::WalletBalance {
-            local_movements: 0,
+            local: 0,
             unconfirmed: balance_info,
             confirmed: balance_info,
         };
@@ -942,9 +942,9 @@ where
                 txn_hash,
                 block_info.epoch,
             );
-            state.balance.local_movements = state
+            state.balance.local = state
                 .balance
-                .local_movements
+                .local
                 .checked_sub(local_movement.amount)
                 .ok_or_else(|| Error::TransactionValueOverflow)?;
         }
@@ -1035,9 +1035,9 @@ where
                 "Local pending movement added for transaction id: {})",
                 txn_hash
             );
-            state.balance.local_movements = state
+            state.balance.local = state
                 .balance
-                .local_movements
+                .local
                 .checked_add(account_mutation.balance_movement.amount)
                 .ok_or_else(|| Error::TransactionValueOverflow)?;
 

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -826,9 +826,12 @@ where
         }
 
         let mut first_pkh = None;
+        let timestamp = get_timestamp() as u64;
         for (out_ptr, key_balance) in state.utxo_set.iter() {
             if payment >= target {
                 break;
+            } else if key_balance.time_lock > timestamp {
+                continue;
             }
 
             let input = types::TransactionInput::new(types::OutputPointer {
@@ -1092,8 +1095,9 @@ where
                     output_index: u32::try_from(index).unwrap(),
                 };
                 let key_balance = model::KeyBalance {
-                    pkh: output.pkh,
                     amount: output.value,
+                    pkh: output.pkh,
+                    time_lock: output.time_lock,
                 };
                 output_amount = output_amount
                     .checked_add(output.value)

--- a/wallet/src/repository/wallet/state.rs
+++ b/wallet/src/repository/wallet/state.rs
@@ -6,7 +6,7 @@ use witnet_data_structures::chain::EpochConstants;
 #[derive(Clone, Debug)]
 pub struct StateSnapshot {
     /// Current wallet balance (including pending movements)
-    pub balance: u64,
+    pub balance: model::BalanceInfo,
     /// Block beacon
     pub beacon: model::Beacon,
     /// Next transaction identifier of the wallet
@@ -25,7 +25,7 @@ pub struct State {
     /// Available account indices
     pub available_accounts: Vec<u32>,
     /// Current wallet balance (including pending movements)
-    pub balance: u64,
+    pub balance: model::WalletBalance,
     /// Wallet caption
     pub caption: Option<String>,
     /// Epoch constants

--- a/wallet/src/repository/wallet/tests/factories.rs
+++ b/wallet/src/repository/wallet/tests/factories.rs
@@ -104,6 +104,7 @@ impl Input {
 pub struct VttOutput {
     pkh: Option<types::PublicKeyHash>,
     value: Option<u64>,
+    time_lock: Option<u64>,
 }
 
 impl VttOutput {
@@ -117,10 +118,15 @@ impl VttOutput {
         self
     }
 
+    pub fn with_time_lock(mut self, value: u64) -> Self {
+        self.time_lock = Some(value);
+        self
+    }
+
     pub fn create(self) -> types::VttOutput {
         let pkh = self.pkh.unwrap_or_else(pkh);
-        let value = self.value.unwrap_or_else(rand::random);
-        let time_lock = rand::random();
+        let value = self.value.unwrap_or(1u64);
+        let time_lock = self.time_lock.unwrap_or(0u64);
 
         types::VttOutput {
             pkh,

--- a/wallet/src/repository/wallet/tests/mod.rs
+++ b/wallet/src/repository/wallet/tests/mod.rs
@@ -15,7 +15,7 @@ fn test_wallet_public_data() {
 
     assert!(data.name.is_none());
     assert!(data.caption.is_none());
-    assert_eq!(0, data.balance.local_movements);
+    assert_eq!(0, data.balance.local);
     assert_eq!(0, data.balance.unconfirmed.available);
     assert_eq!(0, data.balance.unconfirmed.locked);
     assert_eq!(0, data.balance.confirmed.available);
@@ -303,7 +303,7 @@ fn test_balance() {
     let (wallet, _db) = factories::wallet(None);
 
     let balance = wallet.balance().unwrap();
-    assert_eq!(0, balance.local_movements);
+    assert_eq!(0, balance.local);
     assert_eq!(0, balance.unconfirmed.available);
     assert_eq!(0, balance.unconfirmed.locked);
     assert_eq!(0, balance.confirmed.available);
@@ -1065,6 +1065,8 @@ fn test_create_vtt_with_locked_balance() {
 
     assert_eq!(
         mem::discriminant(&repository::Error::InsufficientBalance),
-        mem::discriminant(&err)
+        mem::discriminant(&err),
+        "{:?}",
+        err,
     );
 }

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -130,7 +130,7 @@ pub struct WalletData {
     pub id: String,
     pub name: Option<String>,
     pub caption: Option<String>,
-    pub balance: u64,
+    pub balance: model::WalletBalance,
     pub current_account: u32,
     pub available_accounts: Vec<u32>,
     pub last_sync: CheckpointBeacon,
@@ -158,16 +158,11 @@ pub struct DataReqParams {
     pub request: DataRequestOutput,
 }
 
-pub struct Balance {
-    pub account: u32,
-    pub amount: u64,
-}
-
 #[derive(Debug)]
 pub struct TransactionComponents {
     pub value: u64,
     pub change: u64,
-    pub balance: u64,
+    pub balance: model::BalanceInfo,
     pub inputs: Vec<TransactionInput>,
     pub outputs: Vec<VttOutput>,
     pub sign_keys: Vec<SK>,


### PR DESCRIPTION
This PR implements different balances (unconfirmed, confirmed and pending) and fixes some problems of creating transactions (avoids using time-locked UTXOs).

Closes #1481 
Closes #1602