### PR TITLE
refactor: remove DataRequestReport in favor of DataRequestInfo

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -6,8 +6,8 @@ use std::{
 
 use witnet_data_structures::{
     chain::{
-        Block, ChainState, CheckpointBeacon, DataRequestInfo, DataRequestReport, Epoch, Hash,
-        Hashable, NodeStats, SuperBlockVote,
+        Block, ChainState, CheckpointBeacon, DataRequestInfo, Epoch, Hash, Hashable, NodeStats,
+        SuperBlockVote,
     },
     error::{ChainInfoError, TransactionError::DataRequestNotFound},
     transaction::{DRTransaction, Transaction, VTTransaction},
@@ -24,7 +24,7 @@ use crate::{
         messages::{
             AddBlocks, AddCandidates, AddCommitReveal, AddSuperBlock, AddSuperBlockVote,
             AddTransaction, Broadcast, BuildDrt, BuildVtt, EpochNotification, GetBalance,
-            GetBlocksEpochRange, GetDataRequestReport, GetHighestCheckpointBeacon,
+            GetBlocksEpochRange, GetDataRequestInfo, GetHighestCheckpointBeacon,
             GetMemoryTransaction, GetMempool, GetMempoolResult, GetNodeStats, GetReputation,
             GetReputationResult, GetState, GetSuperBlockVotes, GetUtxoInfo, PeersBeacons,
             ReputationStats, SendLastBeacon, SessionUnitResult, SetLastBeacon, TryMineBlock,
@@ -1252,10 +1252,10 @@ impl Handler<GetState> for ChainManager {
     }
 }
 
-impl Handler<GetDataRequestReport> for ChainManager {
+impl Handler<GetDataRequestInfo> for ChainManager {
     type Result = ResponseFuture<DataRequestInfo, failure::Error>;
 
-    fn handle(&mut self, msg: GetDataRequestReport, _ctx: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: GetDataRequestInfo, _ctx: &mut Self::Context) -> Self::Result {
         let dr_pointer = msg.dr_pointer;
 
         // First, try to get it from memory
@@ -1270,9 +1270,9 @@ impl Handler<GetDataRequestReport> for ChainManager {
         } else {
             let dr_pointer_string = format!("DR-REPORT-{}", dr_pointer);
             // Otherwise, try to get it from storage
-            let fut = storage_mngr::get::<_, DataRequestReport>(&dr_pointer_string).and_then(
-                move |dr_report| match dr_report {
-                    Some(x) => futures::finished(DataRequestInfo::from(x)),
+            let fut = storage_mngr::get::<_, DataRequestInfo>(&dr_pointer_string).and_then(
+                move |dr_info| match dr_info {
+                    Some(x) => futures::finished(x),
                     None => futures::failed(DataRequestNotFound { hash: dr_pointer }.into()),
                 },
             );

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -45,7 +45,7 @@ use witnet_data_structures::{
     chain::{
         penalize_factor, reputation_issuance, Alpha, AltKeys, Block, BlockHeader, Bn256PublicKey,
         ChainInfo, ChainState, CheckpointBeacon, CheckpointVRF, ConsensusConstants,
-        DataRequestReport, Epoch, EpochConstants, Hash, Hashable, InventoryEntry, InventoryItem,
+        DataRequestInfo, Epoch, EpochConstants, Hash, Hashable, InventoryEntry, InventoryItem,
         NodeStats, PublicKeyHash, Reputation, ReputationEngine, SignaturesToVerify, SuperBlock,
         SuperBlockVote, TransactionsPool,
     },
@@ -327,14 +327,14 @@ impl ChainManager {
     }
 
     /// Method to persist a Data Request into the Storage
-    fn persist_data_requests(&self, ctx: &mut Context<Self>, dr_reports: Vec<DataRequestReport>) {
-        let kvs: Vec<_> = dr_reports
+    fn persist_data_requests(&self, ctx: &mut Context<Self>, dr_infos: Vec<DataRequestInfo>) {
+        let kvs: Vec<_> = dr_infos
             .into_iter()
-            .map(|dr_report| {
-                let dr_pointer = &dr_report.tally.dr_pointer;
+            .map(|dr_info| {
+                let dr_pointer = &dr_info.tally.as_ref().unwrap().dr_pointer;
                 let dr_pointer_string = format!("DR-REPORT-{}", dr_pointer);
 
-                (dr_pointer_string, dr_report)
+                (dr_pointer_string, dr_info)
             })
             .collect();
         let kvs_len = kvs.len();
@@ -647,8 +647,8 @@ impl ChainManager {
                         // Persist finished data requests into storage
                         let to_be_stored =
                             self.chain_state.data_request_pool.finished_data_requests();
-                        for dr_report in &to_be_stored {
-                            show_tally_info(&dr_report.tally, block_epoch);
+                        for dr_info in &to_be_stored {
+                            show_tally_info(&dr_info.tally.as_ref().unwrap(), block_epoch);
                         }
                         self.persist_data_requests(ctx, to_be_stored);
 

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -33,7 +33,7 @@ use crate::{
         inventory_manager::{InventoryManager, InventoryManagerError},
         messages::{
             AddCandidates, AddPeers, AddTransaction, BuildDrt, BuildVtt, GetBalance,
-            GetBlocksEpochRange, GetConsolidatedPeers, GetDataRequestReport, GetEpoch,
+            GetBlocksEpochRange, GetConsolidatedPeers, GetDataRequestInfo, GetEpoch,
             GetHighestCheckpointBeacon, GetItemBlock, GetItemSuperblock, GetItemTransaction,
             GetKnownPeers, GetMemoryTransaction, GetMempool, GetNodeStats, GetReputation, GetState,
             GetUtxoInfo,
@@ -899,7 +899,7 @@ pub fn create_vrf(params: Result<Vec<u8>, jsonrpc_core::Error>) -> JsonRpcResult
     Box::new(fut)
 }
 
-/// Data request report
+/// Data request info
 pub fn data_request_report(params: Result<(Hash,), jsonrpc_core::Error>) -> JsonRpcResultAsync {
     let dr_pointer = match params {
         Ok(x) => x.0,
@@ -909,7 +909,7 @@ pub fn data_request_report(params: Result<(Hash,), jsonrpc_core::Error>) -> Json
     let chain_manager_addr = ChainManager::from_registry();
 
     let fut = chain_manager_addr
-        .send(GetDataRequestReport { dr_pointer })
+        .send(GetDataRequestInfo { dr_pointer })
         .map_err(internal_error)
         .and_then(|dr_info| match dr_info {
             Ok(x) => match serde_json::to_value(&x) {

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -222,14 +222,14 @@ impl Message for GetState {
     type Result = Result<StateMachine, ()>;
 }
 
-/// Get Data Request Report
+/// Get Data Request Info
 #[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Serialize, Deserialize)]
-pub struct GetDataRequestReport {
+pub struct GetDataRequestInfo {
     /// `DataRequest` transaction hash
     pub dr_pointer: Hash,
 }
 
-impl Message for GetDataRequestReport {
+impl Message for GetDataRequestInfo {
     type Result = Result<DataRequestInfo, failure::Error>;
 }
 


### PR DESCRIPTION
Replaced DataRequestReport with DataRequestInfo everywhere since the latter is basically an encompassing struct containing all data used by DataRequestReport. Clippy, FMT and all tests (cargo test --all --verbose) pass or are ignored. Let me know any comments you have.

This PR tackles issue #792.