### PR TITLE
feat(log): show current commit stage and current reveal stage

### DIFF
--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -45,9 +45,9 @@ use witnet_data_structures::{
     chain::{
         penalize_factor, reputation_issuance, Alpha, AltKeys, Block, BlockHeader, Bn256PublicKey,
         ChainInfo, ChainState, CheckpointBeacon, CheckpointVRF, ConsensusConstants,
-        DataRequestInfo, Epoch, EpochConstants, Hash, Hashable, InventoryEntry, InventoryItem,
-        NodeStats, PublicKeyHash, Reputation, ReputationEngine, SignaturesToVerify, SuperBlock,
-        SuperBlockVote, TransactionsPool,
+        DataRequestInfo, DataRequestStage, Epoch, EpochConstants, Hash, Hashable, InventoryEntry,
+        InventoryItem, NodeStats, PublicKeyHash, Reputation, ReputationEngine, SignaturesToVerify,
+        SuperBlock, SuperBlockVote, TransactionsPool,
     },
     data_request::DataRequestPool,
     radon_report::{RadonReport, ReportContext},
@@ -2174,14 +2174,32 @@ fn show_info_dr(data_request_pool: &DataRequestPool, block: &Block) {
         .data_request_pool
         .iter()
         .fold(String::new(), |acc, (k, v)| {
-            format!(
-                "{}\n\t* {} Stage: {}, Commits: {}, Reveals: {}",
-                acc,
-                White.bold().paint(k.to_string()),
-                White.bold().paint(format!("{:?}", v.stage)),
-                v.info.commits.len(),
-                v.info.reveals.len()
-            )
+            if v.stage == DataRequestStage::COMMIT || v.stage == DataRequestStage::REVEAL {
+                let current_round = if v.stage == DataRequestStage::COMMIT {
+                    v.info.current_commit_round
+                } else {
+                    v.info.current_reveal_round
+                };
+                format!(
+                    "{}\n\t* {} Stage: {} ({}/{}), Commits: {}, Reveals: {}",
+                    acc,
+                    White.bold().paint(k.to_string()),
+                    White.bold().paint(format!("{:?}", v.stage)),
+                    current_round,
+                    data_request_pool.extra_rounds + 1,
+                    v.info.commits.len(),
+                    v.info.reveals.len()
+                )
+            } else {
+                format!(
+                    "{}\n\t* {} Stage: {}, Commits: {}, Reveals: {}",
+                    acc,
+                    White.bold().paint(k.to_string()),
+                    White.bold().paint(format!("{:?}", v.stage)),
+                    v.info.commits.len(),
+                    v.info.reveals.len()
+                )
+            }
         });
 
     if info.is_empty() {


### PR DESCRIPTION
This PR (should) solve(s) issue #1005.

I split logging format string for COMMIT and REVEAL (taking the appropriate current round) on the one hand and TALLY on the other hand. Issue #1005 hints to use `extra_commit_rounds`, but that parameter does not exist anymore, so instead I took the `extra_rounds` parameter from the DataRequestPool struct.

I wanted to test whether the logging actually prints the correct messages, but I have not minted any blocks yet, so I am too poor to launch data requests and no one else is launching any either.

