### PR TITLE
feat(witnet_rad): ignore line breaks at the end of a float, int or bool when parsing from string

### DIFF
--- a/rad/src/operators/string.rs
+++ b/rad/src/operators/string.rs
@@ -35,20 +35,31 @@ pub fn parse_json_array(input: &RadonString) -> Result<RadonArray, RadError> {
     item.try_into()
 }
 
+pub fn radon_trim(input: &RadonString) -> String {
+    if input.value().ends_with('\n') {
+        input.value()[..input.value().len() - 1].to_string()
+    } else {
+        input.value()
+    }
+}
+
 pub fn to_float(input: &RadonString) -> Result<RadonFloat, RadError> {
-    f64::from_str(&input.value())
+    let str_value = radon_trim(input);
+    f64::from_str(&str_value)
         .map(RadonFloat::from)
         .map_err(Into::into)
 }
 
 pub fn to_int(input: &RadonString) -> Result<RadonInteger, RadError> {
-    i128::from_str(&input.value())
+    let str_value = radon_trim(input);
+    i128::from_str(&str_value)
         .map(RadonInteger::from)
         .map_err(Into::into)
 }
 
 pub fn to_bool(input: &RadonString) -> Result<RadonBoolean, RadError> {
-    bool::from_str(&input.value())
+    let str_value = radon_trim(input);
+    bool::from_str(&str_value)
         .map(RadonBoolean::from)
         .map_err(Into::into)
 }


### PR DESCRIPTION
Implemented ignoring a line break when parsing float / int or bool tackling issue #1145 

I chose to truncate the string with one character if necessary rather than "blindly" replacing newlines because that is more strict. Even though I cannot think of anything exploiting replacing all newlines, I'd say stricter is always better.

Even though the issue only mentions integer parsing, the same goes for floats and bools, so I also added the code there. I guess I could abstract the truncating code to a separate function but since there are only three occurences, that would be pretty much the same overhead in terms of lines of code. Would you still prefer putting it into a separate function (e.g., for maintainability)?