### PR TITLE
feat(witnet_rad): Allow specification of thousand and decimal separators in get_integer and get_float

### DIFF
--- a/rad/src/operators/map.rs
+++ b/rad/src/operators/map.rs
@@ -9,6 +9,22 @@ use crate::{
     },
 };
 
+pub fn replace_separators(
+    value: RadonTypes,
+    thousand_separator: serde_cbor::Value,
+    decimal_separator: serde_cbor::Value,
+) -> RadonTypes {
+    let rad_str_value: RadonString = value.try_into().unwrap();
+    let thousand = from_value::<String>(thousand_separator).unwrap_or_else(|_| "".to_string());
+    let decimal = from_value::<String>(decimal_separator).unwrap_or_else(|_| ".".to_string());
+    RadonTypes::from(RadonString::from(
+        rad_str_value
+            .value()
+            .replace(&thousand, "")
+            .replace(&decimal, "."),
+    ))
+}
+
 pub fn get(input: &RadonMap, args: &[Value]) -> Result<RadonTypes, RadError> {
     let wrong_args = || RadError::WrongArguments {
         input_type: RadonMap::radon_type_name(),
@@ -40,11 +56,21 @@ pub fn get_bytes(input: &RadonMap, args: &[Value]) -> Result<RadonBytes, RadErro
 }
 pub fn get_integer(input: &RadonMap, args: &[Value]) -> Result<RadonInteger, RadError> {
     let item = get(input, args)?;
-    item.try_into()
+    let value = if args.len() == 3 {
+        replace_separators(item, args[1].clone(), args[2].clone())
+    } else {
+        item
+    };
+    value.try_into()
 }
 pub fn get_float(input: &RadonMap, args: &[Value]) -> Result<RadonFloat, RadError> {
     let item = get(input, args)?;
-    item.try_into()
+    let value = if args.len() == 3 {
+        replace_separators(item, args[1].clone(), args[2].clone())
+    } else {
+        item
+    };
+    value.try_into()
 }
 pub fn get_map(input: &RadonMap, args: &[Value]) -> Result<RadonMap, RadError> {
     let item = get(input, args)?;


### PR DESCRIPTION
This is more of a proposal on how to solve issue #1133, rather than a finalized PR.

What I would do is allow a data requester to specify the format of the numeric type he wants to fetch by defining the thousand and decimal separator. This would allow fetching data from "weird" API's that follow, e.g., the European convention of adding spaces or dots between groups of thousand multiples or a comma as a decimal separator.

The getFloat or getInt functions are (apparently) extensible by default to allow extra arguments, so the data request from issue #1133 could be extended as follows:
```
import * as Witnet from "witnet-requests"

const random = new Witnet.Source("https://www.chards.co.uk/data/update-prices?full=false&currency=eur")
    .parseJSONMap()
    .getMap("gold")
    .getFloat("kilogram", ",", ".") // First argument is the map key, second the thousand separator and third the decimal separator
    .multiply(1000)
    .round()

const aggregator = new Witnet.Aggregator({
    filters: [],
    reducer: Witnet.Types.REDUCERS.averageMean
})

const tally = new Witnet.Tally({
    filters: [],
    reducer: Witnet.Types.REDUCERS.averageMean
})

const request = new Witnet.Request()
    .addSource(random) // Use source 1
    .setAggregator(aggregator) // Set the aggregation script
    .setTally(tally) // Set the tally script
    .setQuorum(4, 70) // Set witness count
    .setFees(10, 1) // Set economic incentives
    .schedule(0) // Make this request immediately solvable
// Do not forget to export the request object
export { request as default }
```

This yields following hex string:
`0a7a08a199d2fb05126a124368747470733a2f2f7777772e6368617264732e636f2e756b2f646174612f7570646174652d7072696365733f66756c6c3d66616c73652663757272656e63793d6575721a2385187782186664676f6c64841864686b696c6f6772616d612c612e8218571903e8185b1a02100322021003100a180420012846308094ebdc03`

Losing the separator definitions and replace kilogram by gram (for a valid float value), yields following hex string:
`0a720896efd6fb051262124368747470733a2f2f7777772e6368617264732e636f2e756b2f646174612f7570646174652d7072696365733f66756c6c3d66616c73652663757272656e63793d6575721a1b85187782186664676f6c64821864646772616d8218571903e8185b1a02100322021003100a180420012846308094ebdc03`

Both of these still work, but the extra separator arguments allow for greater flexibility on the data requester side in dealing with "weird" API data.

I am obviously open to any suggestions (also, there is a significant possibility I sinned against more than one Rust conversion convention).