### PR TITLE
fix(wallet): remove wrong and unused fee computation

### DIFF
--- a/wallet/src/actors/app/handlers/create_vtt.rs
+++ b/wallet/src/actors/app/handlers/create_vtt.rs
@@ -1,6 +1,5 @@
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
 
 use crate::actors::app;
 use crate::types;
@@ -60,7 +59,6 @@ impl Handler<CreateVttRequest> for app::App {
                 .map(|transaction, _, _| {
                     let transaction_id = hex::encode(transaction.hash().as_ref());
                     let bytes = hex::encode(transaction.to_pb_bytes().unwrap());
-                    let fee = msg.fee * u64::try_from(bytes.len()).unwrap();
 
                     CreateVttResponse {
                         transaction_id,
@@ -69,7 +67,7 @@ impl Handler<CreateVttRequest> for app::App {
                         metadata: VttMetadata {
                             to: msg.address,
                             value: msg.amount,
-                            fee,
+                            fee: msg.fee,
                             time_lock: msg.time_lock,
                         },
                     }


### PR DESCRIPTION
Currently the wallet was showing wrong transaction fee metadata because it was multiplying the given `fee` by the bytes length of the transaction. However, nodes are weighting transactions differently depending on the number of inputs and outputs.

This problem should be fixed in #1635.

This PR fixes the wrong fee metadata by just passing the absolute value of the `fee` defined by the user to compute the value transfer components (e.g. UTXOs to be used). The wallet will send back the corrected absolute fee.