### PR TITLE
fix(wallet): create wallet twice should return an error

### DIFF
--- a/wallet/src/actors/app/error.rs
+++ b/wallet/src/actors/app/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     SessionsStillOpen,
     #[fail(display = "wallet not found")]
     WalletNotFound,
+    #[fail(display = "wallet with id {} already exists", _0)]
+    WalletAlreadyExists(String),
 }
 
 impl Error {
@@ -34,6 +36,7 @@ impl Error {
             ),
             Error::SessionNotFound => (401, "Unauthorized", None),
             Error::WalletNotFound => (402, "Forbidden", None),
+            Error::WalletAlreadyExists(cause) => (409, "Conflict", Some(json!({ "cause": cause }))),
             Error::Node(e) => {
                 log::error!("Node Error: {}", &e);
                 (
@@ -90,7 +93,10 @@ impl From<actix::MailboxError> for Error {
 
 impl From<actors::worker::Error> for Error {
     fn from(err: actors::worker::Error) -> Self {
-        internal_error(err)
+        match err {
+            actors::worker::Error::WalletAlreadyExists(e) => Error::WalletAlreadyExists(e),
+            _ => internal_error(err),
+        }
     }
 }
 

--- a/wallet/src/actors/worker/error.rs
+++ b/wallet/src/actors/worker/error.rs
@@ -36,6 +36,8 @@ pub enum Error {
     EpochCalculation(#[cause] witnet_data_structures::error::EpochCalculationError),
     #[fail(display = "failed because wallet is still syncing: {}", _0)]
     StillSyncing(String),
+    #[fail(display = "wallet with id {} already exists", _0)]
+    WalletAlreadyExists(String),
 }
 
 #[derive(Debug, Fail)]

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -78,6 +78,16 @@ impl Worker {
             self.params.id_hash_iterations,
         );
 
+        // If wallet ID already exists, return Err
+        if self
+            .wallets
+            .infos()?
+            .into_iter()
+            .any(|wallet| wallet.id == id)
+        {
+            return Err(Error::WalletAlreadyExists(id));
+        };
+
         let default_account_index = 0;
         let default_account =
             account::gen_account(&self.engine, default_account_index, &master_key)?;


### PR DESCRIPTION
If a user tries to create twice a wallet with the same seed phrase, the wallet will return a `409 Conflict` error message.