### PR TITLE
Wallet load balancing

### DIFF
--- a/src/cli/wallet/with_wallet.rs
+++ b/src/cli/wallet/with_wallet.rs
@@ -9,7 +9,7 @@ pub fn exec_cmd(command: Command, mut config: Config) -> Result<(), failure::Err
     match command {
         Command::Run(params) => {
             if let Some(node) = params.node {
-                config.wallet.node_url = Some(node);
+                config.wallet.node_url = vec![node];
             }
             if let Some(db) = params.db {
                 config.wallet.db_path = db;

--- a/witnet.toml
+++ b/witnet.toml
@@ -98,4 +98,5 @@ level = "info"
 
 [wallet]
 # The address (IP and port) of a Witnet node's JSON-RPC server. This should normally match `json_rpc.server_address`.
+# If more than one address is provided, the wallet will choose one at random.
 node_url = "127.0.0.1:21338"


### PR DESCRIPTION
Close #1632 

Allow setting multiple node urls in witnet.toml:

```
node_url = ["52.166.178.145:21338", "52.166.178.145:21339"]
# And the old format also works
node_url = "52.166.178.145:21338"
```

When there is more than one node_url, it will choose one at random.

Using the command line only allows one node url and overrides the config.
