### PR TITLE
refactor(wallet): use type safe database api

### DIFF
--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -102,7 +102,7 @@ impl Worker {
 
         let wallet_db = db::EncryptedDb::new(self.db.clone(), prefix, key, iv.clone());
         wallet_db.put(
-            constants::ENCRYPTION_CHECK_KEY,
+            &constants::ENCRYPTION_CHECK_KEY,
             constants::ENCRYPTION_CHECK_VALUE,
         )?; // used when unlocking to check if the password is correct
 
@@ -188,7 +188,7 @@ impl Worker {
 
         // Check if password-derived key is able to read the special stored value
         wallet_db
-            .get(constants::ENCRYPTION_CHECK_KEY)
+            .get(&constants::ENCRYPTION_CHECK_KEY)
             .map_err(|err| match err {
                 db::Error::DbKeyNotFound { .. } => Error::WrongPassword,
                 err => Error::Db(err),

--- a/wallet/src/constants.rs
+++ b/wallet/src/constants.rs
@@ -3,6 +3,8 @@
 //! KeyPath constant values are taken from the WIP definition:
 //! https://github.com/aesedepece/WIPs/blob/wip-adansdpc-hdwallets/wip-adansdpc-hdwallets.md#path-levels
 
+use crate::repository::keys::Key;
+
 /// Default offset used when returning paginated results.
 pub static DEFAULT_PAGINATION_OFFSET: u32 = 0;
 
@@ -25,7 +27,7 @@ pub static INTERNAL_KEYCHAIN: u32 = 1;
 
 /// Special key used to check if a decryption key is the correct one
 /// for a wallet.
-pub static ENCRYPTION_CHECK_KEY: &str = "ENC_KEY";
+pub static ENCRYPTION_CHECK_KEY: Key<&'static str, ()> = Key::new_const("ENC_KEY");
 
 /// Special value stored with `ENCRYPTION_CHECK_KEY`.
 pub static ENCRYPTION_CHECK_VALUE: () = ();

--- a/wallet/src/db/encrypted/write_batch.rs
+++ b/wallet/src/db/encrypted/write_batch.rs
@@ -17,14 +17,15 @@ impl EncryptedWriteBatch {
 }
 
 impl WriteBatch for EncryptedWriteBatch {
-    fn put<K, V>(&mut self, key: K, value: V) -> Result<()>
+    fn put<K, V, Vref>(&mut self, key: &Key<K, V>, value: Vref) -> Result<()>
     where
         K: AsRef<[u8]>,
-        V: serde::Serialize,
+        V: serde::Serialize + ?Sized,
+        Vref: Borrow<V>,
     {
         let prefix_key = self.prefixer.prefix(key.as_ref());
         let enc_key = self.engine.encrypt(&prefix_key)?;
-        let enc_val = self.engine.encrypt(&value)?;
+        let enc_val = self.engine.encrypt(value.borrow())?;
 
         self.batch.put(enc_key, enc_val)?;
 

--- a/wallet/src/db/plain/write_batch.rs
+++ b/wallet/src/db/plain/write_batch.rs
@@ -6,12 +6,13 @@ pub struct PlainWriteBatch {
 }
 
 impl WriteBatch for PlainWriteBatch {
-    fn put<K, V>(&mut self, key: K, value: V) -> Result<()>
+    fn put<K, V, Vref>(&mut self, key: &Key<K, V>, value: Vref) -> Result<()>
     where
         K: AsRef<[u8]>,
-        V: serde::Serialize,
+        V: serde::Serialize + ?Sized,
+        Vref: Borrow<V>,
     {
-        let bytes = bincode::serialize(&value)?;
+        let bytes = bincode::serialize(value.borrow())?;
 
         self.batch.put(key, bytes)?;
 

--- a/wallet/src/model.rs
+++ b/wallet/src/model.rs
@@ -4,6 +4,7 @@ use std::{collections::HashMap, fmt};
 use failure::_core::fmt::Formatter;
 use serde::{Deserialize, Serialize};
 
+use crate::repository::keys::Key;
 use crate::{account, types};
 
 #[derive(Debug, Clone, Serialize)]
@@ -43,7 +44,7 @@ pub struct Addresses {
 pub struct AddressInfo {
     /// Database key for storing `AddressInfo` objects
     #[serde(skip)]
-    pub db_key: String,
+    pub db_key: Key<String, AddressInfo>,
     pub label: Option<String>,
     pub received_payments: Vec<String>,
     pub received_amount: u64,

--- a/wallet/src/repository/keys.rs
+++ b/wallet/src/repository/keys.rs
@@ -1,163 +1,259 @@
-use crate::types::PublicKeyHash;
+use crate::model;
+use crate::types::*;
+use std::fmt;
+use std::marker::PhantomData;
+
+/// Type-safe database key.
+///
+/// `K` is the type of the key itself, and `V` is the type of the value stored in the database.
+/// For example, to store a `u32` using a `&'static str` key, use: `Key<&'static str, u32>`.
+pub struct Key<K: AsRef<[u8]>, V: ?Sized>(K, PhantomData<V>);
+
+impl<K: AsRef<[u8]>, V: ?Sized> Key<K, V> {
+    /// Create new key
+    pub fn new(key: K) -> Key<K, V> {
+        Key(key, PhantomData)
+    }
+}
+
+impl<V: ?Sized> Key<&'static str, V> {
+    // FIXME: remove this method and make Self::new a const fn
+    // This cannot be done because of the error:
+    // trait bounds other than `Sized` on const fn parameters are unstable
+    // https://github.com/rust-lang/rust/issues/57563
+    pub const fn new_const(key: &'static str) -> Key<&'static str, V> {
+        Key(key, PhantomData)
+    }
+}
+
+// Manually implement traits instead of using derive because the derive automatically inserts a
+// bound for V, which is not needed. For example, `Key<K, V>: Clone` does not need `V: Clone`
+impl<K, V> Clone for Key<K, V>
+where
+    K: AsRef<[u8]> + Clone,
+    V: ?Sized,
+{
+    fn clone(&self) -> Self {
+        Self::new(self.0.clone())
+    }
+}
+
+impl<K, V> Copy for Key<K, V>
+where
+    K: AsRef<[u8]> + Copy,
+    V: ?Sized,
+{
+}
+
+impl<K, V> AsRef<[u8]> for Key<K, V>
+where
+    K: AsRef<[u8]>,
+    V: ?Sized,
+{
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl<K, V> fmt::Debug for Key<K, V>
+where
+    K: AsRef<[u8]> + fmt::Debug,
+    V: ?Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<K, V> Default for Key<K, V>
+where
+    K: AsRef<[u8]> + Default,
+    V: ?Sized,
+{
+    fn default() -> Self {
+        Self::new(K::default())
+    }
+}
+
+impl<K, V> PartialEq<Key<K, V>> for Key<K, V>
+where
+    K: AsRef<[u8]> + PartialEq<K>,
+    V: ?Sized,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eq(&other.0)
+    }
+}
 
 /// The list of wallet ids stored in the database.
 #[inline]
-pub fn wallet_ids() -> &'static str {
-    "wallets"
+pub fn wallet_ids() -> Key<&'static str, Vec<String>> {
+    Key::new("wallets")
 }
 
 /// A wallet's name.
 #[inline]
-pub fn wallet_name() -> &'static str {
-    "name"
+pub fn wallet_name() -> Key<&'static str, String> {
+    Key::new("name")
 }
 
 /// A wallet's description.
 #[inline]
-pub fn wallet_description() -> &'static str {
-    "description"
+pub fn wallet_description() -> Key<&'static str, String> {
+    Key::new("description")
 }
 
 /// A wallet's name.
 #[inline]
-pub fn wallet_id_name(id: &str) -> String {
-    format!("{}name", id)
+pub fn wallet_id_name(id: &str) -> Key<String, String> {
+    Key::new(format!("{}name", id))
 }
 
 /// A wallet's encryption salt.
 #[inline]
-pub fn wallet_id_salt(wallet_id: &str) -> String {
-    format!("{}salt", wallet_id)
+pub fn wallet_id_salt(wallet_id: &str) -> Key<String, Vec<u8>> {
+    Key::new(format!("{}salt", wallet_id))
 }
 
 /// A wallet's encryption iv.
 #[inline]
-pub fn wallet_id_iv(wallet_id: &str) -> String {
-    format!("{}iv", wallet_id)
+pub fn wallet_id_iv(wallet_id: &str) -> Key<String, Vec<u8>> {
+    Key::new(format!("{}iv", wallet_id))
 }
 
 /// A wallet's generated account indexes.
 #[inline]
-pub fn wallet_accounts() -> &'static str {
-    "accounts"
+pub fn wallet_accounts() -> Key<&'static str, Vec<u32>> {
+    Key::new("accounts")
 }
 
 /// The default account that an unlocked wallet will use.
 #[inline]
-pub fn wallet_default_account() -> &'static str {
-    "default-account"
+pub fn wallet_default_account() -> Key<&'static str, u32> {
+    Key::new("default-account")
 }
 
 /// The epoch of the latest block that was processed by the wallet
 #[inline]
-pub fn wallet_last_sync() -> &'static str {
-    "last-sync"
+pub fn wallet_last_sync() -> Key<&'static str, CheckpointBeacon> {
+    Key::new("last-sync")
 }
 
 /// An account's external key.
 #[inline]
-pub fn account_key(account_index: u32, keychain: u32) -> String {
-    format!("account-{}-{}-key", account_index, keychain)
+pub fn account_key(account_index: u32, keychain: u32) -> Key<String, ExtendedSK> {
+    Key::new(format!("account-{}-{}-key", account_index, keychain))
 }
 
 /// An account's total balance.
 #[inline]
-pub fn account_balance(account_index: u32) -> String {
-    format!("account-{}-balance", account_index)
+pub fn account_balance(account_index: u32) -> Key<String, model::BalanceInfo> {
+    Key::new(format!("account-{}-balance", account_index))
 }
 
 /// An account's UTXO set.
 #[inline]
-pub fn account_utxo_set(account_index: u32) -> String {
-    format!("account-{}-utxo-set", account_index)
+pub fn account_utxo_set(account_index: u32) -> Key<String, model::UtxoSet> {
+    Key::new(format!("account-{}-utxo-set", account_index))
 }
 
 /// An account's next index to use for generating an address.
 #[inline]
-pub fn account_next_index(account_index: u32, keychain: u32) -> String {
-    format!("account-{}-{}-next-index", account_index, keychain)
+pub fn account_next_index(account_index: u32, keychain: u32) -> Key<String, u32> {
+    Key::new(format!("account-{}-{}-next-index", account_index, keychain))
 }
 
 /// A wallet's account address.
 #[inline]
-pub fn address(account_index: u32, keychain: u32, key_index: u32) -> String {
-    format!(
+pub fn address(account_index: u32, keychain: u32, key_index: u32) -> Key<String, String> {
+    Key::new(format!(
         "account-{}-key-{}-{}-address",
         account_index, keychain, key_index
-    )
+    ))
 }
 
 /// An address' path.
 #[inline]
-pub fn address_path(account_index: u32, keychain: u32, key_index: u32) -> String {
-    format!(
+pub fn address_path(account_index: u32, keychain: u32, key_index: u32) -> Key<String, String> {
+    Key::new(format!(
         "account-{}-key-{}-{}-address-path",
         account_index, keychain, key_index
-    )
+    ))
 }
 
 /// An address' pkh.
 #[inline]
-pub fn address_pkh(account_index: u32, keychain: u32, key_index: u32) -> String {
-    format!(
+pub fn address_pkh(
+    account_index: u32,
+    keychain: u32,
+    key_index: u32,
+) -> Key<String, PublicKeyHash> {
+    Key::new(format!(
         "account-{}-key-{}-{}-address-pkh",
         account_index, keychain, key_index
-    )
+    ))
 }
 
 /// An address additional information.
 #[inline]
-pub fn address_info(account_index: u32, keychain: u32, key_index: u32) -> String {
-    format!(
+pub fn address_info(
+    account_index: u32,
+    keychain: u32,
+    key_index: u32,
+) -> Key<String, model::AddressInfo> {
+    Key::new(format!(
         "account-{}-key-{}-{}-address-info",
         account_index, keychain, key_index
-    )
+    ))
 }
 
 /// Path information associated to a pkh (account, keychain and index).
 #[inline]
-pub fn pkh(pkh: &PublicKeyHash) -> Vec<u8> {
-    [b"pkh-", pkh.as_ref()].concat().to_vec()
+pub fn pkh(pkh: &PublicKeyHash) -> Key<Vec<u8>, model::Path> {
+    Key::new([b"pkh-", pkh.as_ref()].concat().to_vec())
 }
 
 /// An custom key decided by the client to store something.
 #[inline]
-pub fn custom(key: &str) -> String {
-    format!("custom-{}", key,)
+pub fn custom(key: &str) -> Key<String, String> {
+    Key::new(format!("custom-{}", key))
 }
 
 /// A created transaction pending to be sent or removed.
 #[inline]
-pub fn transaction(transaction_hash: &str) -> String {
-    format!("transaction-{}", transaction_hash)
+pub fn transaction(transaction_hash: &str) -> Key<String, Transaction> {
+    Key::new(format!("transaction-{}", transaction_hash))
 }
 
 /// An index of transaction hashes.
 #[inline]
-pub fn transactions_index(transaction_hash: &[u8]) -> Vec<u8> {
-    [b"transactions-index-{}", transaction_hash].concat()
+pub fn transactions_index(transaction_hash: &[u8]) -> Key<Vec<u8>, u32> {
+    Key::new([b"transactions-index-{}", transaction_hash].concat())
 }
 
 /// Next transaction id.
 #[inline]
-pub fn transaction_next_id(account_index: u32) -> String {
-    format!("account-{}-transactions-next-id", account_index)
+pub fn transaction_next_id(account_index: u32) -> Key<String, u32> {
+    Key::new(format!("account-{}-transactions-next-id", account_index))
 }
 
 /// Transaction hash.
 #[inline]
-pub fn transaction_hash(account_index: u32, transaction_id: u32) -> String {
-    format!(
+pub fn transaction_hash(account_index: u32, transaction_id: u32) -> Key<String, Vec<u8>> {
+    Key::new(format!(
         "account-{}-transaction-{}-hash",
         account_index, transaction_id
-    )
+    ))
 }
 
 /// Transaction movement.
 #[inline]
-pub fn transaction_movement(account_index: u32, transaction_id: u32) -> String {
-    format!(
+pub fn transaction_movement(
+    account_index: u32,
+    transaction_id: u32,
+) -> Key<String, model::BalanceMovement> {
+    Key::new(format!(
         "account-{}-transaction-{}-movement",
         account_index, transaction_id
-    )
+    ))
 }

--- a/wallet/src/repository/mod.rs
+++ b/wallet/src/repository/mod.rs
@@ -1,5 +1,5 @@
 mod error;
-mod keys;
+pub mod keys;
 mod wallet;
 mod wallets;
 

--- a/wallet/src/repository/wallet/tests/factories.rs
+++ b/wallet/src/repository/wallet/tests/factories.rs
@@ -1,10 +1,9 @@
-use std::{cell::RefCell, rc::Rc};
-
 use witnet_data_structures::chain::Hash;
 
 use super::*;
+use crate::db::HashMapDb;
 
-pub fn wallet(data: Option<HashMap<Vec<u8>, Vec<u8>>>) -> (Wallet<db::HashMapDb>, db::HashMapDb) {
+pub fn wallet(data: Option<HashMapDb>) -> (Wallet<db::HashMapDb>, db::HashMapDb) {
     let id = "example-wallet";
     let params = params::Params::default();
     let mnemonic = types::MnemonicGen::new()
@@ -26,8 +25,7 @@ pub fn wallet(data: Option<HashMap<Vec<u8>, Vec<u8>>>) -> (Wallet<db::HashMapDb>
     let salt = crypto::salt(&mut rng, params.db_salt_length);
     let iv = crypto::salt(&mut rng, params.db_iv_length);
 
-    let storage = Rc::new(RefCell::new(data.unwrap_or_default()));
-    let db = db::HashMapDb::new(storage);
+    let db = data.unwrap_or_default();
     let wallets = Wallets::new(db.clone());
 
     // Create the initial data required by the wallet

--- a/wallet/src/repository/wallets/mod.rs
+++ b/wallet/src/repository/wallets/mod.rs
@@ -31,7 +31,7 @@ impl<T: Database> Wallets<T> {
 
     /// Retrieve public information of wallets stored in the wallets DB
     pub fn infos(&self) -> Result<Vec<model::Wallet>> {
-        let ids: Vec<String> = self.db.get_or_default(keys::wallet_ids())?;
+        let ids: Vec<String> = self.db.get_or_default(&keys::wallet_ids())?;
         let mut wallets = Vec::with_capacity(ids.len());
 
         for id in ids {
@@ -48,7 +48,7 @@ impl<T: Database> Wallets<T> {
         let mut batch = self.db.batch();
 
         if let Some(name) = name {
-            batch.put(keys::wallet_id_name(&id), name)?;
+            batch.put(&keys::wallet_id_name(&id), name)?;
         }
 
         self.db.write(batch)?;
@@ -76,28 +76,28 @@ impl<T: Database> Wallets<T> {
 
         // We first write name and description into private wallet DB
         if let Some(name) = name.as_ref() {
-            wbatch.put(keys::wallet_name(), name.clone())?;
-            batch.put(keys::wallet_id_name(&id), name.clone())?;
+            wbatch.put(&keys::wallet_name(), name.clone())?;
+            batch.put(&keys::wallet_id_name(&id), name.clone())?;
         }
 
         if let Some(description) = description {
-            wbatch.put(keys::wallet_description(), description)?;
+            wbatch.put(&keys::wallet_description(), description)?;
         }
 
-        wbatch.put(keys::wallet_default_account(), account.index)?;
+        wbatch.put(&keys::wallet_default_account(), account.index)?;
         wbatch.put(
-            keys::account_key(account.index, constants::EXTERNAL_KEYCHAIN),
+            &keys::account_key(account.index, constants::EXTERNAL_KEYCHAIN),
             &account.external,
         )?;
         wbatch.put(
-            keys::account_key(account.index, constants::INTERNAL_KEYCHAIN),
+            &keys::account_key(account.index, constants::INTERNAL_KEYCHAIN),
             &account.internal,
         )?;
 
         wallet_db.write(wbatch)?;
 
-        batch.put(keys::wallet_id_salt(&id), &salt)?;
-        batch.put(keys::wallet_id_iv(&id), &iv)?;
+        batch.put(&keys::wallet_id_salt(&id), &salt)?;
+        batch.put(&keys::wallet_id_iv(&id), &iv)?;
 
         // FIXME: Use merge operator or a transaction when available in rocksdb crate
         let wallet_id = id.to_string();
@@ -105,7 +105,7 @@ impl<T: Database> Wallets<T> {
         let mut ids: Vec<String> = self.db.get_or_default(&keys::wallet_ids())?;
         if !ids.contains(&wallet_id) {
             ids.push(wallet_id);
-            batch.put(keys::wallet_ids(), ids)?;
+            batch.put(&keys::wallet_ids(), ids)?;
         }
         self.db.write(batch)?;
         drop(lock);

--- a/wallet/src/repository/wallets/tests/mod.rs
+++ b/wallet/src/repository/wallets/tests/mod.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::iter::FromIterator;
 
 use super::*;
 use crate::*;
@@ -17,11 +16,9 @@ fn test_wallet_infos_when_no_wallets() {
 
 #[test]
 fn test_wallet_infos_when_wallets() {
-    let data = HashMap::from_iter(vec![(
-        keys::wallet_ids().as_bytes().to_vec(),
-        bincode::serialize(&vec!["a-wallet-id".to_string()]).unwrap(),
-    )]);
-    let (wallets, _db) = factories::wallets(Some(data));
+    let (wallets, db) = factories::wallets(Some(HashMap::new()));
+    db.put(&keys::wallet_ids(), vec!["a-wallet-id".to_string()])
+        .unwrap();
 
     let infos = wallets.infos().unwrap();
 
@@ -31,11 +28,8 @@ fn test_wallet_infos_when_wallets() {
 #[test]
 fn test_update_wallet_info() {
     let id = "a-wallet-id".to_string();
-    let data = HashMap::from_iter(vec![(
-        keys::wallet_ids().as_bytes().to_vec(),
-        bincode::serialize(&vec![id.clone()]).unwrap(),
-    )]);
-    let (wallets, db) = factories::wallets(Some(data));
+    let (wallets, db) = factories::wallets(Some(HashMap::new()));
+    db.put(&keys::wallet_ids(), vec![id.clone()]).unwrap();
 
     let wallet_info = &wallets.infos().unwrap()[0];
 
@@ -49,8 +43,5 @@ fn test_update_wallet_info() {
     let wallet_info = &wallets.infos().unwrap()[0];
 
     assert_eq!(name, wallet_info.name);
-    assert_eq!(
-        name,
-        db.get_opt::<_, String>(&keys::wallet_id_name(&id)).unwrap()
-    );
+    assert_eq!(name, db.get_opt(&keys::wallet_id_name(&id)).unwrap());
 }


### PR DESCRIPTION
This PR adds types to the keys used in the wallet database.

This way one does not need to specify the type when using `db.get()`, and also it's impossible to deserialize a value as a wrong type. All the keys and types should be compatible with the ones in master, but we should double check that this does not break anything.