### PR TITLE
fix(peers_manager): avoid temporarily import peers

### DIFF
--- a/node/src/actors/peers_manager/actor.rs
+++ b/node/src/actors/peers_manager/actor.rs
@@ -10,6 +10,7 @@ use crate::{
     config_mngr, storage_mngr,
 };
 use witnet_p2p::peers::Peers;
+use witnet_util::timestamp::get_timestamp;
 
 /// Make actor from PeersManager
 impl Actor for PeersManager {
@@ -52,9 +53,15 @@ impl Actor for PeersManager {
                     .and_then(move |peers_from_storage, act, _ctx| {
                         // peers_from_storage can be None if the storage does not contain that key
                         if let Some(peers_from_storage) = peers_from_storage {
-                            // Add all the peers from storage
-                            // The add method handles duplicates by overwriting the old values
-                            act.import_peers(peers_from_storage, known_peers);
+                            // FIXME(#1646): Remove skip import peers from storage
+                            // Skip importing peers from storage if timestamp is earlier than
+                            // Tuesday, October 20, 2020 09:00:00 AM UTC
+                            let current_timestamp = get_timestamp();
+                            if current_timestamp > 1_603_184_400 {
+                                // Add all the peers from storage
+                                // The add method handles duplicates by overwriting the old values
+                                act.import_peers(peers_from_storage, known_peers);
+                            }
                         }
 
                         fut::ok(())


### PR DESCRIPTION
Skip importing peers from storage if timestamp is earlier than Tuesday, October 20, 2020 11:00:00 AM UTC

This should be removed in #1646