### PR TITLE
feat(jsonrpc): add "confirmed" field to getBlock method

### DIFF
--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -701,7 +701,7 @@ impl ChainManager {
                         }
                         // Persist blocks and transactions but do not persist chain_state, it will
                         // be persisted on superblock consolidation
-                        // FIXME #1437: discard persisted and non-consolidated blocks
+                        // FIXME(#1663): discard persisted and non-consolidated blocks
                         // This means that after a reorganization a call to getBlock or
                         // getTransaction will show the content without any warning that the block
                         // is not on the main chain. To fix this we could remove forked blocks when

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -345,6 +345,19 @@ pub struct AddSuperBlock {
     pub superblock: SuperBlock,
 }
 
+/// Returns true if the provided block hash is the consolidated block for the provided epoch, and
+/// there exists a superblock with a majority of votes to confirm that.
+pub struct IsConfirmedBlock {
+    /// Block hash
+    pub block_hash: Hash,
+    /// Block checkpoint
+    pub block_epoch: u32,
+}
+
+impl Message for IsConfirmedBlock {
+    type Result = Result<bool, failure::Error>;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // MESSAGES FROM CONNECTIONS MANAGER
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -54,7 +54,6 @@ pub fn run(conf: Config) -> Result<(), Error> {
     };
     let genesis_hash = conf.consensus_constants.genesis_hash;
     let genesis_prev_hash = conf.consensus_constants.bootstrap_hash;
-    let superblock_period = conf.consensus_constants.superblock_period;
 
     // Db-encryption params
     let db_hash_iterations = conf.wallet.db_encrypt_hash_iterations;
@@ -126,7 +125,6 @@ pub fn run(conf: Config) -> Result<(), Error> {
         node_sync_batch_size,
         genesis_hash,
         genesis_prev_hash,
-        superblock_period,
         sync_address_batch_length,
     };
 

--- a/wallet/src/params.rs
+++ b/wallet/src/params.rs
@@ -24,7 +24,6 @@ pub struct Params {
     pub node_sync_batch_size: u32,
     pub genesis_hash: Hash,
     pub genesis_prev_hash: Hash,
-    pub superblock_period: u16,
     pub sync_address_batch_length: u16,
 }
 
@@ -43,7 +42,6 @@ impl Default for Params {
             node_sync_batch_size: 100,
             genesis_hash: Hash::default(),
             genesis_prev_hash: Hash::default(),
-            superblock_period: 10,
             sync_address_batch_length: 10,
         }
     }

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -123,11 +123,6 @@ where
         self.params.genesis_prev_hash
     }
 
-    /// Returns the superblock period consensus constant
-    pub fn get_superblock_period(&self) -> u16 {
-        self.params.superblock_period
-    }
-
     /// Clears local pending wallet state to match the persisted state in database
     pub fn clear_pending_state(&self) -> Result<()> {
         let account = 0;


### PR DESCRIPTION
This allows to know if a block has been consolidated by a majority of the superblock committee.

The implementation checks that the block epoch is below the last confirmed block according to the superblock beacon, and that the block hash exists at the expected position in the block chain.

This method is used in the wallet synchronization.

Close #1437