### PR TITLE
fix(node): clear best_candidate on every epoch

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -113,6 +113,9 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
         }
 
         self.peers_beacons_received = false;
+        // The best candidate must be cleared on every epoch
+        let best_candidate = self.best_candidate.take();
+
         match self.sm_state {
             StateMachine::WaitingConsensus => {
                 if let Some(chain_info) = &self.chain_state.chain_info {
@@ -152,7 +155,7 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                             utxo_diff,
                             reputation: _,
                             vrf_proof: _,
-                        }) = self.best_candidate.take()
+                        }) = best_candidate
                         {
                             // Persist block and update ChainState
                             self.consolidate_block(ctx, block, utxo_diff);


### PR DESCRIPTION
This fixes a criticial issue in the node where sometimes the best block candidate can be consolidated twice, causing the node to fork and never recover.

The issue is as follows:

* Blocks 48 and 49 are consolidated by the node in synced state
* Block 50 is received as a candidate, but the network enters a high load state and the node cannot keep up
* The node goes to WaitingConsensus and starts synchronizing
* Blocks 51 and 52 are consolidated by the node when synchronizing
* Block 50 is consolidated as a candidate again, when the last block is 51, resulting in a corrupted state

Therefore, the chain is 48 -> 49 -> 50 -> 51 -> 50 and the node enters an inconsistent state and can never recover.