### PR TITLE
feat(mining): allow miners to set a minimum required fee for including a VTT in a block

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -329,6 +329,9 @@ pub struct Mining {
     pub mint_external_address: Option<String>,
     /// Mempool size limit in weight units
     pub transactions_pool_total_weight_limit: u64,
+    /// Minimum value transfer transaction fee that allows being included into a block
+    #[partial_struct(serde(default, rename = "minimum_vtt_fee_nanowits"))]
+    pub minimum_vtt_fee: u64,
 }
 
 /// NTP-related configuration
@@ -748,6 +751,10 @@ impl Mining {
                 .transactions_pool_total_weight_limit
                 .to_owned()
                 .unwrap_or_else(|| defaults.mining_transactions_pool_total_weight_limit()),
+            minimum_vtt_fee: config
+                .minimum_vtt_fee
+                .to_owned()
+                .unwrap_or_else(|| defaults.mining_minimum_vtt_fee()),
         }
     }
 
@@ -760,6 +767,7 @@ impl Mining {
             mint_external_percentage: Some(self.mint_external_percentage),
             mint_external_address: self.mint_external_address.clone(),
             transactions_pool_total_weight_limit: Some(self.transactions_pool_total_weight_limit),
+            minimum_vtt_fee: Some(self.minimum_vtt_fee),
         }
     }
 }

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -214,6 +214,12 @@ pub trait Defaults {
         24 * seconds_in_one_hour * max_block_weight / block_period
     }
 
+    /// Allow setting a minimum value transfer transaction fee to be included in a block
+    /// Setting it to zero essentially means all VTT's can be included in a block
+    fn mining_minimum_vtt_fee(&self) -> u64 {
+        0
+    }
+
     fn consensus_constants_max_vt_weight(&self) -> u32 {
         20_000
     }

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -97,6 +97,9 @@ impl ChainManager {
                 let vt_to_dr_factor = f64::from(config.consensus_constants.max_vt_weight) / f64::from(config.consensus_constants.max_dr_weight);
                 let _removed_transactions = act.transactions_pool.set_total_weight_limit(config.mining.transactions_pool_total_weight_limit, vt_to_dr_factor);
 
+                // Minimum fee required to include a VTT into a block
+                act.transactions_pool.set_minimum_vtt_fee(config.mining.minimum_vtt_fee);
+
                 storage_mngr::get::<_, ChainState>(&storage_keys::chain_state_key(magic))
                     .into_actor(act)
                     .then(|chain_state_from_storage, _, _| {

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -2351,7 +2351,7 @@ pub fn log_removed_transactions(removed_transactions: &[Transaction], inserted_t
 
         if removed_the_one_we_just_inserted {
             log::trace!(
-                "Transaction {} was not added because the TransactionsPool is full",
+                "Transaction {} was not added because the fee was too low",
                 inserted_tx_hash
             );
         } else {
@@ -2359,7 +2359,7 @@ pub fn log_removed_transactions(removed_transactions: &[Transaction], inserted_t
         }
 
         log::debug!(
-            "TransactionsPool is full! Removed the following transactions: {:?}",
+            "Removed the following transactions: {:?}",
             removed_tx_hashes
         );
     }

--- a/witnet.toml
+++ b/witnet.toml
@@ -91,6 +91,8 @@ genesis_path = ".witnet/config/genesis_block.json"
 # the percentage of the block rewards that will be assigned to `mint_external_address` (50% by default)
 #mint_external_address = "twit1jqgf4rxjrgas3kdhj3t4cr3mg3n33m8zw0aglr"
 #mint_external_percentage = 50
+# Set a minimum fee you require before your node includes a value transfer transaction into a block
+minimum_vtt_fee_nanowits = 1
 
 [log]
 # Logging level, i.e. from more verbose to quieter: "trace" > "debug" > "info" > "warn" > "error" > "none"


### PR DESCRIPTION
This is a proposal to limit spamming the network with free VTT's (like we saw today). It could also be extended to DR's, but I did not include that yet because I'm not sure that is something we ultimately want.

This PR would allow a node operator to set a minimum transaction fee he wants to receive before including a VTT into a block whenever he's eligible. I would set this to 1 nanoWIT (though I did not set that as default), but obviously everyone can choose a setting.

Let me know what you think about this and if this unexpectedly breaks something. For example, I am not sure if this would let the VTT pool grow unlimited in the case of spam (I thought there was some sort of periodic cleanup).