### PR TITLE
Update wallet infos

### DIFF
--- a/wallet/src/actors/app/handlers/create_wallet.rs
+++ b/wallet/src/actors/app/handlers/create_wallet.rs
@@ -9,7 +9,7 @@ use crate::types;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateWalletRequest {
     name: Option<String>,
-    caption: Option<String>,
+    description: Option<String>,
     password: types::Password,
     seed_source: String,
     seed_data: types::Password,
@@ -36,7 +36,7 @@ impl Handler<CreateWalletRequest> for app::App {
                 params.password,
                 params.seed_source,
                 params.name,
-                params.caption,
+                params.description,
                 params.overwrite,
             )
             .map(|wallet_id| CreateWalletResponse { wallet_id })
@@ -48,7 +48,7 @@ impl Handler<CreateWalletRequest> for app::App {
 }
 
 struct Validated {
-    pub caption: Option<String>,
+    pub description: Option<String>,
     pub name: Option<String>,
     pub overwrite: bool,
     pub password: types::Password,
@@ -62,7 +62,7 @@ struct Validated {
 /// - seed_sources has to be `mnemonics | xprv`
 fn validate(req: CreateWalletRequest) -> Result<Validated, app::ValidationErrors> {
     let name = req.name;
-    let caption = req.caption;
+    let description = req.description;
     let seed_data = req.seed_data;
     let source = match req.seed_source.as_ref() {
         "xprv" => Ok(types::SeedSource::Xprv(seed_data)),
@@ -85,7 +85,7 @@ fn validate(req: CreateWalletRequest) -> Result<Validated, app::ValidationErrors
     let overwrite = req.overwrite.unwrap_or(false);
 
     app::combine_field_errors(source, password, move |seed_source, password| Validated {
-        caption,
+        description,
         name,
         overwrite,
         password,

--- a/wallet/src/actors/app/handlers/unlock_wallet.rs
+++ b/wallet/src/actors/app/handlers/unlock_wallet.rs
@@ -13,7 +13,7 @@ pub struct UnlockWalletRequest {
 pub struct UnlockWalletResponse {
     session_id: types::SessionId,
     name: Option<String>,
-    caption: Option<String>,
+    description: Option<String>,
     available_accounts: Vec<u32>,
     current_account: u32,
     account_balance: model::WalletBalance,
@@ -35,7 +35,7 @@ impl Handler<UnlockWalletRequest> for app::App {
                 UnlockWalletResponse {
                     session_id,
                     name: data.name,
-                    caption: data.caption,
+                    description: data.description,
                     current_account: data.current_account,
                     available_accounts: data.available_accounts,
                     account_balance: data.balance,

--- a/wallet/src/actors/app/handlers/update_wallet.rs
+++ b/wallet/src/actors/app/handlers/update_wallet.rs
@@ -9,7 +9,7 @@ pub struct UpdateWalletRequest {
     session_id: types::SessionId,
     wallet_id: String,
     name: Option<String>,
-    caption: Option<String>,
+    description: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -26,7 +26,7 @@ impl Handler<UpdateWalletRequest> for app::App {
 
     fn handle(&mut self, req: UpdateWalletRequest, _ctx: &mut Self::Context) -> Self::Result {
         let f = self
-            .update_wallet(req.session_id, req.wallet_id, req.name, req.caption)
+            .update_wallet(req.session_id, req.wallet_id, req.name, req.description)
             .map(|(), _, _| UpdateWalletResponse { success: true });
 
         Box::new(f)

--- a/wallet/src/actors/app/methods.rs
+++ b/wallet/src/actors/app/methods.rs
@@ -247,7 +247,7 @@ impl App {
         password: types::Password,
         seed_source: types::SeedSource,
         name: Option<String>,
-        caption: Option<String>,
+        description: Option<String>,
         overwrite: bool,
     ) -> ResponseFuture<String> {
         let f = self
@@ -255,7 +255,7 @@ impl App {
             .worker
             .send(worker::CreateWallet(
                 name,
-                caption,
+                description,
                 password,
                 seed_source,
                 overwrite,
@@ -277,7 +277,7 @@ impl App {
         session_id: types::SessionId,
         wallet_id: String,
         name: Option<String>,
-        caption: Option<String>,
+        description: Option<String>,
     ) -> ResponseActFuture<()> {
         let f = fut::result(
             self.state
@@ -287,14 +287,18 @@ impl App {
             let wallet_update = slf
                 .params
                 .worker
-                .send(worker::UpdateWallet(wallet, name.clone(), caption.clone()))
+                .send(worker::UpdateWallet(
+                    wallet,
+                    name.clone(),
+                    description.clone(),
+                ))
                 .flatten()
                 .map_err(From::from);
 
             let info_update = slf
                 .params
                 .worker
-                .send(worker::UpdateWalletInfo(wallet_id, name, caption))
+                .send(worker::UpdateWalletInfo(wallet_id, name, description))
                 .flatten()
                 .map_err(From::from);
 

--- a/wallet/src/actors/app/methods.rs
+++ b/wallet/src/actors/app/methods.rs
@@ -298,7 +298,7 @@ impl App {
             let info_update = slf
                 .params
                 .worker
-                .send(worker::UpdateWalletInfo(wallet_id, name, description))
+                .send(worker::UpdateWalletInfo(wallet_id, name))
                 .flatten()
                 .map_err(From::from);
 

--- a/wallet/src/actors/worker/handlers/create_wallet.rs
+++ b/wallet/src/actors/worker/handlers/create_wallet.rs
@@ -6,7 +6,7 @@ use crate::types;
 pub struct CreateWallet(
     /// Wallet name
     pub Option<String>,
-    /// Wallet deescription
+    /// Wallet description
     pub Option<String>,
     /// Wallet user-defined password
     pub types::Password,
@@ -28,6 +28,12 @@ impl Handler<CreateWallet> for worker::Worker {
         CreateWallet(name, description, password, seed_source, overwrite): CreateWallet,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        self.create_wallet(name, description, password.as_ref(), &seed_source, overwrite)
+        self.create_wallet(
+            name,
+            description,
+            password.as_ref(),
+            &seed_source,
+            overwrite,
+        )
     }
 }

--- a/wallet/src/actors/worker/handlers/create_wallet.rs
+++ b/wallet/src/actors/worker/handlers/create_wallet.rs
@@ -6,7 +6,7 @@ use crate::types;
 pub struct CreateWallet(
     /// Wallet name
     pub Option<String>,
-    /// Wallet caption
+    /// Wallet deescription
     pub Option<String>,
     /// Wallet user-defined password
     pub types::Password,
@@ -25,9 +25,9 @@ impl Handler<CreateWallet> for worker::Worker {
 
     fn handle(
         &mut self,
-        CreateWallet(name, caption, password, seed_source, overwrite): CreateWallet,
+        CreateWallet(name, description, password, seed_source, overwrite): CreateWallet,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        self.create_wallet(name, caption, password.as_ref(), &seed_source, overwrite)
+        self.create_wallet(name, description, password.as_ref(), &seed_source, overwrite)
     }
 }

--- a/wallet/src/actors/worker/handlers/update_wallet.rs
+++ b/wallet/src/actors/worker/handlers/update_wallet.rs
@@ -7,7 +7,7 @@ pub struct UpdateWallet(
     pub types::SessionWallet,
     /// Wallet name
     pub Option<String>,
-    /// Wallet caption
+    /// Wallet description
     pub Option<String>,
 );
 
@@ -20,9 +20,9 @@ impl Handler<UpdateWallet> for worker::Worker {
 
     fn handle(
         &mut self,
-        UpdateWallet(wallet, name, caption): UpdateWallet,
+        UpdateWallet(wallet, name, description): UpdateWallet,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        self.update_wallet(&wallet, name, caption)
+        self.update_wallet(&wallet, name, description)
     }
 }

--- a/wallet/src/actors/worker/handlers/update_wallet_info.rs
+++ b/wallet/src/actors/worker/handlers/update_wallet_info.rs
@@ -7,7 +7,7 @@ pub struct UpdateWalletInfo(
     pub String,
     /// Wallet name
     pub Option<String>,
-    /// Wallet caption
+    /// Wallet description
     pub Option<String>,
 );
 
@@ -20,9 +20,9 @@ impl Handler<UpdateWalletInfo> for worker::Worker {
 
     fn handle(
         &mut self,
-        UpdateWalletInfo(wallet_id, name, caption): UpdateWalletInfo,
+        UpdateWalletInfo(wallet_id, name, description): UpdateWalletInfo,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        self.update_wallet_info(&wallet_id, name, caption)
+        self.update_wallet_info(&wallet_id, name, description)
     }
 }

--- a/wallet/src/actors/worker/handlers/update_wallet_info.rs
+++ b/wallet/src/actors/worker/handlers/update_wallet_info.rs
@@ -7,8 +7,6 @@ pub struct UpdateWalletInfo(
     pub String,
     /// Wallet name
     pub Option<String>,
-    /// Wallet description
-    pub Option<String>,
 );
 
 impl Message for UpdateWalletInfo {
@@ -20,9 +18,9 @@ impl Handler<UpdateWalletInfo> for worker::Worker {
 
     fn handle(
         &mut self,
-        UpdateWalletInfo(wallet_id, name, description): UpdateWalletInfo,
+        UpdateWalletInfo(wallet_id, name): UpdateWalletInfo,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        self.update_wallet_info(&wallet_id, name, description)
+        self.update_wallet_info(&wallet_id, name)
     }
 }

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -62,7 +62,7 @@ impl Worker {
     pub fn create_wallet(
         &mut self,
         name: Option<String>,
-        caption: Option<String>,
+        description: Option<String>,
         password: &[u8],
         source: &types::SeedSource,
         overwrite: bool,
@@ -110,7 +110,7 @@ impl Worker {
             &wallet_db,
             types::CreateWalletData {
                 name,
-                caption,
+                description,
                 iv,
                 salt,
                 id: &id,
@@ -149,9 +149,9 @@ impl Worker {
         &self,
         wallet: &types::Wallet,
         name: Option<String>,
-        caption: Option<String>,
+        description: Option<String>,
     ) -> Result<()> {
-        wallet.update(name, caption)?;
+        wallet.update(name, description)?;
 
         Ok(())
     }
@@ -161,9 +161,9 @@ impl Worker {
         &self,
         wallet_id: &str,
         name: Option<String>,
-        caption: Option<String>,
+        description: Option<String>,
     ) -> Result<()> {
-        self.wallets.update_info(wallet_id, name, caption)?;
+        self.wallets.update_info(wallet_id, name, description)?;
 
         Ok(())
     }

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -157,13 +157,8 @@ impl Worker {
     }
 
     /// Update the wallet information in the infos database.
-    pub fn update_wallet_info(
-        &self,
-        wallet_id: &str,
-        name: Option<String>,
-        description: Option<String>,
-    ) -> Result<()> {
-        self.wallets.update_info(wallet_id, name, description)?;
+    pub fn update_wallet_info(&self, wallet_id: &str, name: Option<String>) -> Result<()> {
+        self.wallets.update_info(wallet_id, name)?;
 
         Ok(())
     }

--- a/wallet/src/model.rs
+++ b/wallet/src/model.rs
@@ -10,13 +10,13 @@ use crate::{account, types};
 pub struct Wallet {
     pub id: String,
     pub name: Option<String>,
-    pub caption: Option<String>,
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct UnlockedWallet {
     pub name: Option<String>,
-    pub caption: Option<String>,
+    pub description: Option<String>,
     pub current_account: u32,
     pub session_id: String,
     pub available_accounts: Vec<u32>,

--- a/wallet/src/model.rs
+++ b/wallet/src/model.rs
@@ -10,7 +10,6 @@ use crate::{account, types};
 pub struct Wallet {
     pub id: String,
     pub name: Option<String>,
-    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/wallet/src/repository/keys.rs
+++ b/wallet/src/repository/keys.rs
@@ -12,10 +12,10 @@ pub fn wallet_name() -> &'static str {
     "name"
 }
 
-/// A wallet's caption.
+/// A wallet's description.
 #[inline]
-pub fn wallet_caption() -> &'static str {
-    "caption"
+pub fn wallet_description() -> &'static str {
+    "description"
 }
 
 /// A wallet's name.
@@ -24,10 +24,10 @@ pub fn wallet_id_name(id: &str) -> String {
     format!("{}name", id)
 }
 
-/// A wallet's caption.
+/// A wallet's description.
 #[inline]
-pub fn wallet_id_caption(id: &str) -> String {
-    format!("{}caption", id)
+pub fn wallet_id_description(id: &str) -> String {
+    format!("{}description", id)
 }
 
 /// A wallet's encryption salt.

--- a/wallet/src/repository/keys.rs
+++ b/wallet/src/repository/keys.rs
@@ -24,12 +24,6 @@ pub fn wallet_id_name(id: &str) -> String {
     format!("{}name", id)
 }
 
-/// A wallet's description.
-#[inline]
-pub fn wallet_id_description(id: &str) -> String {
-    format!("{}description", id)
-}
-
 /// A wallet's encryption salt.
 #[inline]
 pub fn wallet_id_salt(wallet_id: &str) -> String {

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -156,7 +156,7 @@ where
     ) -> Result<Self> {
         let id = id.to_owned();
         let name = db.get_opt(keys::wallet_name())?;
-        let caption = db.get_opt(keys::wallet_caption())?;
+        let description = db.get_opt(keys::wallet_description())?;
         let account = db.get_or_default(keys::wallet_default_account())?;
         let available_accounts = db
             .get_opt(keys::wallet_accounts())?
@@ -219,7 +219,7 @@ where
 
         let state = RwLock::new(State {
             name,
-            caption,
+            description,
             account,
             keychains,
             next_external_index,
@@ -264,7 +264,7 @@ where
         Ok(types::WalletData {
             id: self.id.clone(),
             name: state.name.clone(),
-            caption: state.caption.clone(),
+            description: state.description.clone(),
             balance,
             current_account,
             available_accounts: state.available_accounts.clone(),
@@ -577,8 +577,8 @@ where
         Ok(())
     }
 
-    /// Update a wallet's name and/or caption
-    pub fn update(&self, name: Option<String>, caption: Option<String>) -> Result<()> {
+    /// Update a wallet's name and/or description
+    pub fn update(&self, name: Option<String>, description: Option<String>) -> Result<()> {
         let mut batch = self.db.batch();
         let mut state = self.state.write()?;
 
@@ -587,9 +587,9 @@ where
             batch.put(keys::wallet_name(), name)?;
         }
 
-        state.caption = caption;
-        if let Some(ref caption) = state.caption {
-            batch.put(keys::wallet_caption(), caption)?;
+        state.description = description;
+        if let Some(ref description) = state.description {
+            batch.put(keys::wallet_description(), description)?;
         }
 
         self.db.write(batch)?;

--- a/wallet/src/repository/wallet/state.rs
+++ b/wallet/src/repository/wallet/state.rs
@@ -30,8 +30,8 @@ pub struct State {
     pub available_accounts: Vec<u32>,
     /// Current wallet balance (including pending movements)
     pub balance: model::WalletBalance,
-    /// Wallet caption
-    pub caption: Option<String>,
+    /// Wallet description
+    pub description: Option<String>,
     /// List of already existing DB balance movements that need to be updated upon superblock
     /// confirmation
     pub db_movements_to_update: HashMap<String, Vec<model::BalanceMovement>>,

--- a/wallet/src/repository/wallet/tests/factories.rs
+++ b/wallet/src/repository/wallet/tests/factories.rs
@@ -39,7 +39,7 @@ pub fn wallet(data: Option<HashMap<Vec<u8>, Vec<u8>>>) -> (Wallet<db::HashMapDb>
                 salt,
                 id,
                 name: None,
-                caption: None,
+                description: None,
                 account: &default_account,
             },
         )

--- a/wallet/src/repository/wallet/tests/mod.rs
+++ b/wallet/src/repository/wallet/tests/mod.rs
@@ -14,7 +14,7 @@ fn test_wallet_public_data() {
     let data = wallet.public_data().unwrap();
 
     assert!(data.name.is_none());
-    assert!(data.caption.is_none());
+    assert!(data.description.is_none());
     assert_eq!(0, data.balance.local);
     assert_eq!(0, data.balance.unconfirmed.available);
     assert_eq!(0, data.balance.unconfirmed.locked);
@@ -864,18 +864,18 @@ fn test_update_wallet_with_empty_values() {
     let wallet_data = wallet.public_data().unwrap();
 
     assert!(wallet_data.name.is_none());
-    assert!(wallet_data.caption.is_none());
+    assert!(wallet_data.description.is_none());
     assert!(!db.contains(&keys::wallet_name()).unwrap());
-    assert!(!db.contains(&keys::wallet_caption()).unwrap());
+    assert!(!db.contains(&keys::wallet_description()).unwrap());
 
     wallet.update(None, None).unwrap();
 
     let wallet_data = wallet.public_data().unwrap();
 
     assert!(wallet_data.name.is_none());
-    assert!(wallet_data.caption.is_none());
+    assert!(wallet_data.description.is_none());
     assert!(!db.contains(&keys::wallet_name()).unwrap());
-    assert!(!db.contains(&keys::wallet_caption()).unwrap());
+    assert!(!db.contains(&keys::wallet_description()).unwrap());
 }
 
 #[test]
@@ -884,23 +884,24 @@ fn test_update_wallet_with_values() {
     let wallet_data = wallet.public_data().unwrap();
 
     assert!(wallet_data.name.is_none());
-    assert!(wallet_data.caption.is_none());
+    assert!(wallet_data.description.is_none());
     assert!(!db.contains(&keys::wallet_name()).unwrap());
-    assert!(!db.contains(&keys::wallet_caption()).unwrap());
+    assert!(!db.contains(&keys::wallet_description()).unwrap());
 
     let name = Some("wallet name".to_string());
-    let caption = Some("wallet caption".to_string());
+    let description = Some("wallet description".to_string());
 
-    wallet.update(name.clone(), caption.clone()).unwrap();
+    wallet.update(name.clone(), description.clone()).unwrap();
 
     let wallet_data = wallet.public_data().unwrap();
 
     assert_eq!(name, wallet_data.name);
-    assert_eq!(caption, wallet_data.caption);
+    assert_eq!(description, wallet_data.description);
     assert_eq!(name, db.get_opt::<_, String>(&keys::wallet_name()).unwrap());
     assert_eq!(
-        caption,
-        db.get_opt::<_, String>(&keys::wallet_caption()).unwrap()
+        description,
+        db.get_opt::<_, String>(&keys::wallet_description())
+            .unwrap()
     );
 }
 

--- a/wallet/src/repository/wallets/tests/mod.rs
+++ b/wallet/src/repository/wallets/tests/mod.rs
@@ -40,28 +40,17 @@ fn test_update_wallet_info() {
     let wallet_info = &wallets.infos().unwrap()[0];
 
     assert!(wallet_info.name.is_none());
-    assert!(wallet_info.description.is_none());
     assert!(!db.contains(&keys::wallet_id_name(&id)).unwrap());
-    assert!(!db.contains(&keys::wallet_id_description(&id)).unwrap());
 
     let name = Some("Testing".to_string());
-    let description = Some("A testing wallet".to_string());
 
-    wallets
-        .update_info(&id, name.clone(), description.clone())
-        .unwrap();
+    wallets.update_info(&id, name.clone()).unwrap();
 
     let wallet_info = &wallets.infos().unwrap()[0];
 
     assert_eq!(name, wallet_info.name);
-    assert_eq!(description, wallet_info.description);
     assert_eq!(
         name,
         db.get_opt::<_, String>(&keys::wallet_id_name(&id)).unwrap()
-    );
-    assert_eq!(
-        description,
-        db.get_opt::<_, String>(&keys::wallet_id_description(&id))
-            .unwrap()
     );
 }

--- a/wallet/src/repository/wallets/tests/mod.rs
+++ b/wallet/src/repository/wallets/tests/mod.rs
@@ -40,28 +40,28 @@ fn test_update_wallet_info() {
     let wallet_info = &wallets.infos().unwrap()[0];
 
     assert!(wallet_info.name.is_none());
-    assert!(wallet_info.caption.is_none());
+    assert!(wallet_info.description.is_none());
     assert!(!db.contains(&keys::wallet_id_name(&id)).unwrap());
-    assert!(!db.contains(&keys::wallet_id_caption(&id)).unwrap());
+    assert!(!db.contains(&keys::wallet_id_description(&id)).unwrap());
 
     let name = Some("Testing".to_string());
-    let caption = Some("A testing wallet".to_string());
+    let description = Some("A testing wallet".to_string());
 
     wallets
-        .update_info(&id, name.clone(), caption.clone())
+        .update_info(&id, name.clone(), description.clone())
         .unwrap();
 
     let wallet_info = &wallets.infos().unwrap()[0];
 
     assert_eq!(name, wallet_info.name);
-    assert_eq!(caption, wallet_info.caption);
+    assert_eq!(description, wallet_info.description);
     assert_eq!(
         name,
         db.get_opt::<_, String>(&keys::wallet_id_name(&id)).unwrap()
     );
     assert_eq!(
-        caption,
-        db.get_opt::<_, String>(&keys::wallet_id_caption(&id))
+        description,
+        db.get_opt::<_, String>(&keys::wallet_id_description(&id))
             .unwrap()
     );
 }

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -129,7 +129,7 @@ pub struct Account {
 pub struct WalletData {
     pub id: String,
     pub name: Option<String>,
-    pub caption: Option<String>,
+    pub description: Option<String>,
     pub balance: model::WalletBalance,
     pub current_account: u32,
     pub available_accounts: Vec<u32>,
@@ -140,7 +140,7 @@ pub struct WalletData {
 pub struct CreateWalletData<'a> {
     pub id: &'a str,
     pub name: Option<String>,
-    pub caption: Option<String>,
+    pub description: Option<String>,
     pub iv: Vec<u8>,
     pub salt: Vec<u8>,
     pub account: &'a Account,


### PR DESCRIPTION
This PR modfies how wallet infos is retrieved. The caption field is renamed to description, and wallet_infos only returns the name. The description is only stored in the private encrypted section of the wallet DB.