### PR TITLE
fix(wallet): ignore handle superblock if syncing

### DIFF
--- a/wallet/src/actors/worker/error.rs
+++ b/wallet/src/actors/worker/error.rs
@@ -34,8 +34,6 @@ pub enum Error {
     TransactionTypeNotSupported,
     #[fail(display = "epoch calculation error {}", _0)]
     EpochCalculation(#[cause] witnet_data_structures::error::EpochCalculationError),
-    #[fail(display = "failed because wallet is still syncing: {}", _0)]
-    StillSyncing(String),
     #[fail(display = "wallet already exists: {}", _0)]
     WalletAlreadyExists(String),
 }
@@ -83,10 +81,7 @@ impl From<witnet_rad::error::RadError> for Error {
 
 impl From<repository::Error> for Error {
     fn from(err: repository::Error) -> Self {
-        match err {
-            repository::Error::StillSyncing(e) => Error::StillSyncing(e),
-            _ => Error::Repository(err),
-        }
+        Error::Repository(err)
     }
 }
 

--- a/wallet/src/actors/worker/error.rs
+++ b/wallet/src/actors/worker/error.rs
@@ -36,6 +36,11 @@ pub enum Error {
     EpochCalculation(#[cause] witnet_data_structures::error::EpochCalculationError),
     #[fail(display = "wallet already exists: {}", _0)]
     WalletAlreadyExists(String),
+    #[fail(
+        display = "error while syncing: node is behind our local tip (#{} < #{})",
+        _0, _1
+    )]
+    NodeBehindLocalTip(u32, u32),
 }
 
 #[derive(Debug, Fail)]

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -674,6 +674,14 @@ impl Worker {
         // Store the tip into the worker in form of beacon
         self.node.update_last_beacon(tip);
 
+        // Return error if the node's tip of the chain is behind ours
+        if tip.checkpoint < since_beacon.checkpoint {
+            return Err(Error::NodeBehindLocalTip(
+                tip.checkpoint,
+                since_beacon.checkpoint,
+            ));
+        }
+
         // Notify wallet about initial synchronization status (the wallet most likely has an old
         // chain tip)
         let events = Some(vec![types::Event::SyncStart(

--- a/wallet/src/repository/error.rs
+++ b/wallet/src/repository/error.rs
@@ -41,8 +41,6 @@ pub enum Error {
     BlockConsolidation(String),
     #[fail(display = "hash parsing failed: {}", _0)]
     HashParseError(#[cause] types::HashParseError),
-    #[fail(display = "failed because wallet is still syncing: {}", _0)]
-    StillSyncing(String),
 }
 
 impl From<failure::Error> for Error {

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -4,7 +4,7 @@ use std::{
     convert::TryFrom,
     ops::Range,
     str::FromStr,
-    sync::{Arc, RwLock, RwLockWriteGuard, RwLockReadGuard},
+    sync::{Arc, RwLock, RwLockReadGuard},
 };
 
 use state::State;
@@ -50,7 +50,7 @@ where
     T: Database,
 {
     /// Generate transient addresses for synchronization purposes
-    /// This function only creates and inserts addreses
+    /// This function only creates and inserts addresses
     pub fn initialize_transient_addresses(
         &self,
         external_addresses: u16,
@@ -1658,16 +1658,8 @@ where
         Ok(())
     }
 
-    /// Run a predicate on the state of a wallet in a thread safe manner, thanks to a write lock.
-    pub fn _lock_and_update_state<P, O>(&self, predicate: P) -> Result<O>
-    where
-        P: FnOnce(RwLockWriteGuard<'_, State>) -> O,
-    {
-        Ok(predicate(self.state.write()?))
-    }
-
     /// Run a predicate on the state of a wallet in a thread safe manner, thanks to a read lock.
-    pub fn _lock_and_read_state<P, O>(&self, predicate: P) -> Result<O>
+    pub fn lock_and_read_state<P, O>(&self, predicate: P) -> Result<O>
     where
         P: FnOnce(RwLockReadGuard<'_, State>) -> O,
     {

--- a/wallet/src/repository/wallet/state.rs
+++ b/wallet/src/repository/wallet/state.rs
@@ -74,8 +74,6 @@ pub struct State {
     pub transient_internal_addresses: HashMap<types::PublicKeyHash, model::Address>,
     /// Transient external addresses
     pub transient_external_addresses: HashMap<types::PublicKeyHash, model::Address>,
-    /// Synchronization info and status
-    pub synchronization: SynchronizationState,
 }
 
 impl State {
@@ -109,38 +107,5 @@ impl State {
         self.utxo_set.clear();
         self.transient_internal_addresses.clear();
         self.transient_external_addresses.clear();
-    }
-}
-
-/// The synchronization state and information for a wallet.
-///
-/// TODO: refactor all synchronization-related fields (e.g. transient addresses) from `State` into
-///  `SynchronizationState` structure so that the number of fields in `State` does not keep
-///  growing.
-#[derive(Debug)]
-pub struct SynchronizationState {
-    is_resyncing: bool,
-}
-
-impl SynchronizationState {
-    /// Tell whether a wallet is resyncing.
-    pub fn is_resyncing(&self) -> bool {
-        self.is_resyncing
-    }
-
-    /// Set the resynchronization status. Returns the old status.
-    pub fn set_resyncing(&mut self, new_status: bool) -> bool {
-        let old_status = self.is_resyncing;
-        self.is_resyncing = new_status;
-
-        old_status
-    }
-}
-
-impl Default for SynchronizationState {
-    fn default() -> Self {
-        Self {
-            is_resyncing: false,
-        }
     }
 }

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -240,6 +240,8 @@ pub enum Event {
     SyncProgress(u32, u32, u32),
     /// The start of a synchronization progress.
     SyncStart(u32, u32),
+    /// An error occurred during the synchronization.
+    SyncError(u32, u32),
 }
 
 /// Format of the output of getTransaction


### PR DESCRIPTION
This PR fixes 2 things:
 - Sync wrapper to clear state if synchronization fails
 - Ignore `handle_superblock` if wallet is syncing