### PR TITLE
feat(jsonrpc): Add transaction size in bytes to getTransaction method

### DIFF
--- a/data_structures/src/transaction.rs
+++ b/data_structures/src/transaction.rs
@@ -172,6 +172,15 @@ impl Transaction {
     pub fn size(&self) -> u32 {
         u32::try_from(self.to_pb().write_to_bytes().unwrap().len()).unwrap()
     }
+
+    /// Get the weight of the transaction
+    pub fn weight(&self) -> u32 {
+        match self {
+            Transaction::ValueTransfer(vt_txn) => vt_txn.weight(),
+            Transaction::DataRequest(dr_txn) => dr_txn.weight(),
+            _ => 0,
+        }
+    }
 }
 
 pub fn mint(tx: &Transaction) -> Option<&MintTransaction> {

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -653,6 +653,8 @@ pub fn get_block(hash: Result<(Hash,), jsonrpc_core::Error>) -> JsonRpcResultAsy
 pub struct GetTransactionOutput {
     /// Transaction
     pub transaction: Transaction,
+    /// Weight of the transaction
+    pub weight: u32,
     /// Hash of the block that contains this transaction in hex format,
     /// or "pending" if the transaction has not been included in any block yet
     pub block_hash: String,
@@ -671,8 +673,10 @@ pub fn get_transaction(hash: Result<(Hash,), jsonrpc_core::Error>) -> JsonRpcRes
             .send(GetItemTransaction { hash })
             .then(move |res| match res {
                 Ok(Ok((transaction, pointer_to_block))) => {
+                    let weight = transaction.weight();
                     let output = GetTransactionOutput {
                         transaction,
+                        weight,
                         block_hash: pointer_to_block.block_hash.to_string(),
                     };
                     let value = match serde_json::to_value(output) {
@@ -691,8 +695,10 @@ pub fn get_transaction(hash: Result<(Hash,), jsonrpc_core::Error>) -> JsonRpcRes
                     Box::new(chain_manager.send(GetMemoryTransaction { hash }).then(
                         |res| match res {
                             Ok(Ok(transaction)) => {
+                                let weight = transaction.weight();
                                 let output = GetTransactionOutput {
                                     transaction,
+                                    weight,
                                     block_hash: "pending".to_string(),
                                 };
                                 let value = match serde_json::to_value(output) {


### PR DESCRIPTION
Added transaction size in bytes to the getTransaction method as that allows me to calculate fee per byte and generate transaction pool fee plots in the explorer.