### PR TITLE
feat(storage): implement iteration support

### DIFF
--- a/node/src/storage_mngr.rs
+++ b/node/src/storage_mngr.rs
@@ -209,7 +209,7 @@ fn create_appropriate_backend(
 
     match conf.backend {
         config::StorageBackend::HashMap => Ok(encrypted_backend!(
-            backends::hashmap::Backend::new(),
+            backends::hashmap::Backend::default(),
             passwd
         )),
         config::StorageBackend::RocksDB => {

--- a/storage/src/backends/crypto.rs
+++ b/storage/src/backends/crypto.rs
@@ -2,7 +2,8 @@
 //!
 //! High-order storage backend that hashes the key and
 //! encrypts/decrypts the value when putting/getting it.
-use crate::storage::{Result, Storage};
+use crate::storage::{Result, Storage, StorageIterator};
+use failure::bail;
 use witnet_crypto::{cipher, hash::calculate_sha256, pbkdf2::pbkdf2_sha256};
 use witnet_protected::Protected;
 
@@ -68,6 +69,10 @@ impl<T: Storage> Storage for Backend<T> {
     fn delete(&self, key: &[u8]) -> Result<()> {
         let hash_key = calculate_sha256(key);
         self.backend.delete(hash_key.as_ref())
+    }
+
+    fn prefix_iterator<'a, 'b: 'a>(&'a self, _prefix: &'b [u8]) -> Result<StorageIterator<'a>> {
+        bail!("Iteration is not supported when using encrypted storage")
     }
 }
 

--- a/storage/src/backends/hashmap.rs
+++ b/storage/src/backends/hashmap.rs
@@ -4,22 +4,23 @@
 use std::collections::HashMap;
 
 use crate::storage::{Result, Storage};
+use std::sync::RwLock;
 
 /// HashMap backend
-pub type Backend = HashMap<Vec<u8>, Vec<u8>>;
+pub type Backend = RwLock<HashMap<Vec<u8>, Vec<u8>>>;
 
 impl Storage for Backend {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        Ok(Backend::get(self, key).map(|slice| slice.to_vec()))
+        Ok(self.read().unwrap().get(key).map(|slice| slice.to_vec()))
     }
 
-    fn put(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
-        Backend::insert(self, key, value);
+    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
+        self.write().unwrap().insert(key, value);
         Ok(())
     }
 
-    fn delete(&mut self, key: &[u8]) -> Result<()> {
-        Backend::remove(self, key);
+    fn delete(&self, key: &[u8]) -> Result<()> {
+        self.write().unwrap().remove(key);
         Ok(())
     }
 }
@@ -29,12 +30,12 @@ mod tests {
     use super::*;
 
     fn backend() -> Box<dyn Storage> {
-        Box::new(Backend::new())
+        Box::new(Backend::default())
     }
 
     #[test]
     fn test_hashmap() {
-        let mut storage = backend();
+        let storage = backend();
 
         assert_eq!(None, storage.get(b"name").unwrap());
         storage.put(b"name".to_vec(), b"john".to_vec()).unwrap();

--- a/storage/src/backends/nobackend.rs
+++ b/storage/src/backends/nobackend.rs
@@ -3,7 +3,7 @@
 //! This backend performs no storage at all and always fails to do any operation.
 use failure::bail;
 
-use crate::storage::{Result, Storage};
+use crate::storage::{Result, Storage, StorageIterator};
 
 /// A Backend that is not persisted
 ///
@@ -21,6 +21,10 @@ impl Storage for Backend {
     }
 
     fn delete(&self, _key: &[u8]) -> Result<()> {
+        bail!("This is a no backend storage")
+    }
+
+    fn prefix_iterator<'a, 'b: 'a>(&'a self, _prefix: &'b [u8]) -> Result<StorageIterator<'a>> {
         bail!("This is a no backend storage")
     }
 }

--- a/storage/src/backends/nobackend.rs
+++ b/storage/src/backends/nobackend.rs
@@ -16,11 +16,11 @@ impl Storage for Backend {
         bail!("This is a no backend storage")
     }
 
-    fn put(&mut self, _key: Vec<u8>, _value: Vec<u8>) -> Result<()> {
+    fn put(&self, _key: Vec<u8>, _value: Vec<u8>) -> Result<()> {
         bail!("This is a no backend storage")
     }
 
-    fn delete(&mut self, _key: &[u8]) -> Result<()> {
+    fn delete(&self, _key: &[u8]) -> Result<()> {
         bail!("This is a no backend storage")
     }
 }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -16,8 +16,8 @@ pub trait Storage {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
 
     /// Put a value in the storage
-    fn put(&mut self, key: Vec<u8>, value: Vec<u8>) -> Result<()>;
+    fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<()>;
 
     /// Delete a value from the storage
-    fn delete(&mut self, key: &[u8]) -> Result<()>;
+    fn delete(&self, key: &[u8]) -> Result<()>;
 }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -20,4 +20,10 @@ pub trait Storage {
 
     /// Delete a value from the storage
     fn delete(&self, key: &[u8]) -> Result<()>;
+
+    /// Create an iterator over all the keys that start with the given prefix
+    fn prefix_iterator<'a, 'b: 'a>(&'a self, prefix: &'b [u8]) -> Result<StorageIterator<'a>>;
 }
+
+/// Iterator over key-value pairs
+pub type StorageIterator<'a> = Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>)> + 'a>;


### PR DESCRIPTION
This PR adds a `prefix_iterator` to the `Storage` trait, which allows iterating over all the storage keys that start with the same prefix.

This can be used to implement storage migrations by iterating over all the existing keys and updating them to the new format. Also it can be used to check if the storage is empty, or assert that there are no keys with some specific prefix. In this PR it is not used anywhere.

TODO: add tests