### PR TITLE
fix(net): add cooldown to jsonrpc client reconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "async-jsonrpc-client"
 version = "0.1.0"
-source = "git+https://github.com/witnet/async-jsonrpc-client#db42be175031677b910efa129f42b23d6a000d41"
+source = "git+https://github.com/witnet/async-jsonrpc-client?branch=fix-tcp-leak#600a2d696af265511868f77c01e448c1d678650e"
 dependencies = [
  "error-chain",
  "futures 0.1.30",
@@ -171,8 +171,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "tokio 0.1.22",
  "tokio-codec",
- "tokio-core",
  "tokio-timer 0.2.13",
 ]
 

--- a/bridges/ethereum/Cargo.toml
+++ b/bridges/ethereum/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
 
 [dependencies]
-async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"] }
+async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"], branch = "fix-tcp-leak" }
 env_logger = "0.7.1"
 ethabi = "9.0.0"
 futures = "0.1.28"

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -7,7 +7,7 @@ workspace = ".."
 
 [dependencies]
 actix = { version = "0.8.3", default-features = false }
-async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"] }
+async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"], branch = "fix-tcp-leak" }
 failure = "0.1.8"
 futures = "0.1.29"
 jsonrpc-core = "15.1.0"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.3.2"
 workspace = ".."
 
 [dependencies]
-async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"] }
+async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"], branch = "fix-tcp-leak" }
 bincode = "1.2.1"
 log = "0.4.8"
 jsonrpc-core = "15.1.0"


### PR DESCRIPTION
Fix #1707 

The issue was that the jsonrpc client library was leaking sockets. I fixed this in https://github.com/witnet/async-jsonrpc-client/tree/fix-tcp-leak but note that this changes the way the jsonrpc client works, so we should make sure this does not break anything.

Also, added a cooldown to the reconnect method, because otherwise the wallet enters in a sort of infinite loop. But the "too many open files" error should be fixed, even without the cooldown.