### PR TITLE
feat(wallet): support multiple outputs in create_vtt

### DIFF
--- a/wallet/src/actors/app/error.rs
+++ b/wallet/src/actors/app/error.rs
@@ -8,7 +8,7 @@ use crate::{actors, crypto, repository};
 
 #[derive(Debug, Fail)]
 pub enum Error {
-    #[fail(display = "validation error")]
+    #[fail(display = "validation error ({:?})", _0)]
     Validation(ValidationErrors),
     #[fail(display = "internal error: {}", _0)]
     Internal(#[cause] failure::Error),

--- a/wallet/src/actors/app/handlers/create_vtt.rs
+++ b/wallet/src/actors/app/handlers/create_vtt.rs
@@ -5,27 +5,30 @@ use crate::actors::app;
 use crate::types;
 use crate::types::{Hashable as _, ProtobufConvert as _};
 
-use witnet_data_structures::chain::{Environment, PublicKeyHash};
+use witnet_data_structures::chain::Environment;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VttOutputParams {
+    pub address: String,
+    pub amount: u64,
+    pub time_lock: Option<u64>,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateVttRequest {
+    fee: u64,
+    label: Option<String>,
+    outputs: Vec<VttOutputParams>,
     session_id: types::SessionId,
     wallet_id: String,
-    address: String,
-    label: Option<String>,
-    amount: u64,
-    fee: u64,
-    time_lock: u64,
 }
 
-#[derive(Debug, Serialize)]
 /// Part of CreateVttResponse struct, containing additional data to be displayed in clients
 /// (e.g. in a confirmation screen)
+#[derive(Debug, Serialize)]
 pub struct VttMetadata {
-    to: String,
-    value: u64,
     fee: u64,
-    time_lock: u64,
+    outputs: Vec<VttOutputParams>,
 }
 
 #[derive(Debug, Serialize)]
@@ -45,14 +48,13 @@ impl Handler<CreateVttRequest> for app::App {
 
     fn handle(&mut self, msg: CreateVttRequest, _ctx: &mut Self::Context) -> Self::Result {
         let testnet = self.params.testnet;
-        let validated = validate(testnet, &msg.address).map_err(app::validation_error);
+        let validated =
+            validate_output_addresses(testnet, &msg.outputs).map_err(app::validation_error);
 
-        let f = fut::result(validated).and_then(move |pkh, act: &mut Self, _ctx| {
+        let f = fut::result(validated).and_then(move |outputs, act: &mut Self, _ctx| {
             let params = types::VttParams {
-                pkh,
-                value: msg.amount,
                 fee: msg.fee,
-                time_lock: msg.time_lock,
+                outputs,
             };
 
             act.create_vtt(&msg.session_id, &msg.wallet_id, params)
@@ -65,10 +67,8 @@ impl Handler<CreateVttRequest> for app::App {
                         transaction,
                         bytes,
                         metadata: VttMetadata {
-                            to: msg.address,
-                            value: msg.amount,
                             fee: msg.fee,
-                            time_lock: msg.time_lock,
+                            outputs: msg.outputs,
                         },
                     }
                 })
@@ -78,28 +78,35 @@ impl Handler<CreateVttRequest> for app::App {
     }
 }
 
-/// Validate `CreateVttRequest`.
+/// Validate output addresses and transform addresses to `ValueTransferOutputs`
 ///
 /// To be valid it must pass these checks:
-/// - destination address must be in the same network (test/main)
-/// - source account must have enough balance
-fn validate(testnet: bool, address: &str) -> Result<PublicKeyHash, app::ValidationErrors> {
-    let pkh = validate_address(testnet, address)?;
+/// - destination address must be in the same network (testnet/mainnet)
+fn validate_output_addresses(
+    testnet: bool,
+    outputs: &[VttOutputParams],
+) -> Result<Vec<types::ValueTransferOutput>, app::ValidationErrors> {
+    outputs.iter().try_fold(vec![], |mut acc, output| {
+        types::PublicKeyHash::from_bech32(
+            if testnet {
+                Environment::Testnet
+            } else {
+                Environment::Mainnet
+            },
+            &output.address,
+        )
+        .map(|pkh| {
+            acc.push(types::ValueTransferOutput {
+                pkh,
+                value: output.amount,
+                time_lock: output.time_lock.unwrap_or_default(),
+            });
+        })
+        .map_err(|err| {
+            log::warn!("Invalid address: {}", err);
+            app::field_error("address", "Address failed to deserialize.")
+        })?;
 
-    Ok(pkh)
-}
-
-fn validate_address(testnet: bool, address: &str) -> Result<PublicKeyHash, app::ValidationErrors> {
-    PublicKeyHash::from_bech32(
-        if testnet {
-            Environment::Testnet
-        } else {
-            Environment::Mainnet
-        },
-        address,
-    )
-    .map_err(|err| {
-        log::warn!("Invalid address: {}", err);
-        app::field_error("address", "Address failed to deserialize.")
+        Ok(acc)
     })
 }

--- a/wallet/src/actors/app/handlers/create_vtt.rs
+++ b/wallet/src/actors/app/handlers/create_vtt.rs
@@ -72,6 +72,11 @@ impl Handler<CreateVttRequest> for app::App {
                         },
                     }
                 })
+                .map_err(|err, _, _| {
+                    log::error!("Failed to create a VTT: {}", err);
+
+                    err
+                })
         });
 
         Box::new(f)

--- a/wallet/src/actors/app/methods.rs
+++ b/wallet/src/actors/app/methods.rs
@@ -362,7 +362,7 @@ impl App {
         &self,
         session_id: &types::SessionId,
         wallet_id: &str,
-        vtt_params: types::VttParams,
+        params: types::VttParams,
     ) -> ResponseActFuture<types::Transaction> {
         let f = fut::result(
             self.state
@@ -371,7 +371,7 @@ impl App {
         .and_then(move |wallet, slf: &mut Self, _| {
             slf.params
                 .worker
-                .send(worker::CreateVtt(wallet, vtt_params))
+                .send(worker::CreateVtt(wallet, params))
                 .flatten()
                 .map_err(From::from)
                 .into_actor(slf)

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -988,23 +988,10 @@ where
     /// Create a new value transfer transaction using available UTXOs.
     pub fn create_vtt(
         &self,
-        types::VttParams {
-            pkh,
-            value,
-            fee,
-            time_lock,
-        }: types::VttParams,
+        types::VttParams { fee, outputs }: types::VttParams,
     ) -> Result<types::VTTransaction> {
         let mut state = self.state.write()?;
-        let (inputs, outputs) = self.create_vt_transaction_components(
-            &mut state,
-            vec![ValueTransferOutput {
-                pkh,
-                value,
-                time_lock,
-            }],
-            fee,
-        )?;
+        let (inputs, outputs) = self.create_vt_transaction_components(&mut state, outputs, fee)?;
 
         let body = types::VTTransactionBody::new(inputs.clone(), outputs);
         let sign_data = body.hash();

--- a/wallet/src/repository/wallet/tests/mod.rs
+++ b/wallet/src/repository/wallet/tests/mod.rs
@@ -548,10 +548,12 @@ fn test_create_vtt_does_not_spend_utxos() {
 
     let vtt = wallet
         .create_vtt(types::VttParams {
-            pkh,
-            value,
             fee,
-            time_lock,
+            outputs: vec![types::ValueTransferOutput {
+                pkh,
+                value,
+                time_lock,
+            }],
         })
         .unwrap();
 
@@ -838,10 +840,12 @@ fn test_index_transaction_vtt_created_by_wallet() {
     // spend those funds to create a new transaction which is pending (it has no block)
     let vtt = wallet
         .create_vtt(types::VttParams {
-            pkh: their_pkh,
-            value: 1,
             fee: 0,
-            time_lock: 0,
+            outputs: vec![types::ValueTransferOutput {
+                pkh: their_pkh,
+                value: 1,
+                time_lock: 0,
+            }],
         })
         .unwrap();
 
@@ -949,10 +953,12 @@ fn test_get_transaction() {
     // spend those funds to create a new transaction which is pending (it has no block)
     let vtt = wallet
         .create_vtt(types::VttParams {
-            pkh: their_pkh,
-            value: 1,
             fee: 0,
-            time_lock: 0,
+            outputs: vec![types::ValueTransferOutput {
+                pkh: their_pkh,
+                value: 1,
+                time_lock: 0,
+            }],
         })
         .unwrap();
 
@@ -1018,10 +1024,12 @@ fn test_get_transactions() {
     // spend those funds to create a new transaction which is pending (it has no block)
     let vtt = wallet
         .create_vtt(types::VttParams {
-            pkh: their_pkh,
-            value: 1,
             fee: 0,
-            time_lock: 0,
+            outputs: vec![types::ValueTransferOutput {
+                pkh: their_pkh,
+                value: 1,
+                time_lock: 0,
+            }],
         })
         .unwrap();
 
@@ -1087,10 +1095,12 @@ fn test_create_vtt_with_locked_balance() {
     // try to spend locked funds to create a new transaction
     let err = wallet
         .create_vtt(types::VttParams {
-            pkh: their_pkh,
-            value: 1,
             fee: 0,
-            time_lock: 0,
+            outputs: vec![types::ValueTransferOutput {
+                pkh: their_pkh,
+                value: 1,
+                time_lock: 0,
+            }],
         })
         .unwrap_err();
 

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -147,10 +147,8 @@ pub struct CreateWalletData<'a> {
 }
 
 pub struct VttParams {
-    pub pkh: PublicKeyHash,
-    pub value: u64,
     pub fee: u64,
-    pub time_lock: u64,
+    pub outputs: Vec<ValueTransferOutput>,
 }
 
 pub struct DataReqParams {


### PR DESCRIPTION
This PR allows creating VTT with multiple outputs (address, value, time_lock).