### PR TITLE
[Wallet]: Add periodic node request to know if node disconnected

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -91,6 +91,19 @@ impl Default for StateMachine {
     }
 }
 
+/// Node synchronization status
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct SyncStatus {
+    /// The hash of the top consolidated block and the epoch of that block
+    pub chain_beacon: CheckpointBeacon,
+    /// The current epoch, or None if the epoch 0 is in the future
+    pub current_epoch: Option<u32>,
+    /// Is the node synchronized?
+    pub synchronized: bool,
+    /// Node State
+    pub node_state: Option<StateMachine>,
+}
+
 /// Possible values for the "environment" configuration param.
 // The variants are explicitly tagged so that bincode serialization does not break
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq)]

--- a/net/src/client/tcp/actors/jsonrpc.rs
+++ b/net/src/client/tcp/actors/jsonrpc.rs
@@ -82,7 +82,7 @@ impl JsonRpcClient {
         self.socket = socket;
 
         // Recover active subscriptions
-        let mut active_subscriptions = self
+        let active_subscriptions = self
             .active_subscriptions
             .lock()
             .map(|x| x.clone())
@@ -113,7 +113,9 @@ impl JsonRpcClient {
             });
 
         // Clear up all subscriptions (will be pushed again if they keep failing)
-        active_subscriptions.clear();
+        if let Ok(mut x) = self.active_subscriptions.lock() {
+            x.clear()
+        }
         self.pending_subscriptions.clear();
     }
 

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use witnet_crypto::key::KeyPath;
 use witnet_data_structures::{
-    chain::{Block, CheckpointBeacon, Hash, Hashable, PublicKeyHash, StateMachine},
+    chain::{Block, Hash, Hashable, PublicKeyHash, StateMachine, SyncStatus},
     transaction::Transaction,
     vrf::VrfMessage,
 };
@@ -887,46 +887,23 @@ pub fn send_value(params: Result<BuildVtt, jsonrpc_core::Error>) -> JsonRpcResul
     }
 }
 
-/// Node synchronization status
-#[derive(Debug, Default, Deserialize, Serialize)]
-pub struct SyncStatus {
-    /// The hash of the top consolidated block and the epoch of that block
-    pub chain_beacon: CheckpointBeacon,
-    /// The current epoch, or None if the epoch 0 is in the future
-    pub current_epoch: Option<u32>,
-    /// Is the node synchronized?
-    pub synchronized: bool,
-    /// Node State
-    pub node_state: Option<StateMachine>,
-}
-
 /// Get node status
 pub fn status() -> JsonRpcResultAsync {
     let chain_manager = ChainManager::from_registry();
     let epoch_manager = EpochManager::from_registry();
+    let node_state_fut =
+        chain_manager
+            .send(GetState)
+            .map_err(internal_error_s)
+            .then(|res| match res {
+                Ok(Ok(StateMachine::Synced)) => Ok(Some(StateMachine::Synced)),
+                Ok(Ok(StateMachine::AlmostSynced)) => Ok(Some(StateMachine::AlmostSynced)),
+                Ok(Ok(StateMachine::WaitingConsensus)) => Ok(Some(StateMachine::WaitingConsensus)),
+                Ok(Ok(StateMachine::Synchronizing)) => Ok(Some(StateMachine::Synchronizing)),
+                Ok(Err(())) => Err(internal_error(())),
+                Err(e) => Err(internal_error(e)),
+            });
 
-    let synchronized_fut = chain_manager
-        .send(GetState)
-        .map_err(internal_error_s)
-        .then(|res| match res {
-            Ok(Ok(StateMachine::Synced)) => Ok(true),
-            Ok(Ok(..)) => Ok(false),
-            Ok(Err(())) => Err(internal_error(())),
-            Err(e) => Err(internal_error(e)),
-        });
-    let node_state_fut = chain_manager
-        .send(GetState)
-        .map_err(internal_error_s)
-        .then(|res| match res {
-            Ok(Ok(StateMachine::Synced)) => Ok(Some(StateMachine::Synced)),
-            Ok(Ok(StateMachine::AlmostSynced)) => Ok(Some(StateMachine::AlmostSynced)),
-            Ok(Ok(StateMachine::WaitingConsensus)) => Ok(Some(StateMachine::WaitingConsensus)),
-            Ok(Ok(StateMachine::Synchronizing)) => Ok(Some(StateMachine::Synchronizing)),
-            // Ok(Ok(..)) => Ok(None),
-            Ok(Err(())) => Err(internal_error(())),
-            Err(e) => Err(internal_error(e)),
-        });
-        
     let chain_beacon_fut = chain_manager
         .send(GetHighestCheckpointBeacon)
         .then(|res| match res {
@@ -942,11 +919,11 @@ pub fn status() -> JsonRpcResultAsync {
         Err(e) => Err(internal_error_s(e)),
     });
 
-    let j = Future::join4(synchronized_fut, chain_beacon_fut, current_epoch_fut, node_state_fut)
-        .map(|(synchronized, chain_beacon, current_epoch, node_state)| SyncStatus {
+    let j = Future::join3(chain_beacon_fut, current_epoch_fut, node_state_fut)
+        .map(|(chain_beacon, current_epoch, node_state)| SyncStatus {
             chain_beacon,
             current_epoch,
-            synchronized,
+            synchronized: node_state == Some(StateMachine::Synced),
             node_state,
         })
         .and_then(|res| match serde_json::to_value(res) {

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -22,7 +22,7 @@ use witnet_crypto::{
 use witnet_data_structures::{
     chain::{
         Block, ConsensusConstants, DataRequestInfo, DataRequestOutput, Environment, KeyedSignature,
-        NodeStats, OutputPointer, PublicKey, PublicKeyHash, ValueTransferOutput,
+        NodeStats, OutputPointer, PublicKey, PublicKeyHash, SyncStatus, ValueTransferOutput,
     },
     proto::ProtobufConvert,
     transaction::Transaction,
@@ -30,7 +30,7 @@ use witnet_data_structures::{
 };
 use witnet_node::actors::{
     json_rpc::json_rpc_methods::{
-        AddrType, GetBlockChainParams, GetTransactionOutput, PeersResult, SyncStatus,
+        AddrType, GetBlockChainParams, GetTransactionOutput, PeersResult,
     },
     messages::{BuildVtt, GetReputationResult},
 };

--- a/wallet/src/actors/app/methods.rs
+++ b/wallet/src/actors/app/methods.rs
@@ -765,12 +765,11 @@ impl App {
     }
 
     pub fn node_ping_pong(&self, ctx: &mut <Self as Actor>::Context) {
-        let method = "ping".to_string();
-        let params = ();
+        let method = "syncStatus".to_string();
 
         let req = types::RpcRequest::method(method)
             .timeout(self.params.requests_timeout)
-            .params(params)
+            .params(())
             .expect("params failed serialization");
 
         log::debug!("Sending periodic request: {:?}", req);

--- a/wallet/src/actors/app/mod.rs
+++ b/wallet/src/actors/app/mod.rs
@@ -39,7 +39,7 @@ impl Actor for App {
         self.node_subscribe("blocks", ctx);
         self.node_subscribe("superblocks", ctx);
         self.node_subscribe("status", ctx);
-        self.node_ping_pong(ctx);
+        self.periodic_node_request(ctx);
 
         let mut handler =
             jsonrpc_pubsub::PubSubHandler::new(jsonrpc_core::MetaIoHandler::default());

--- a/wallet/src/actors/app/mod.rs
+++ b/wallet/src/actors/app/mod.rs
@@ -39,6 +39,7 @@ impl Actor for App {
         self.node_subscribe("blocks", ctx);
         self.node_subscribe("superblocks", ctx);
         self.node_subscribe("status", ctx);
+        self.node_ping_pong(ctx);
 
         let mut handler =
             jsonrpc_pubsub::PubSubHandler::new(jsonrpc_core::MetaIoHandler::default());

--- a/wallet/src/actors/app/state.rs
+++ b/wallet/src/actors/app/state.rs
@@ -170,6 +170,12 @@ impl State {
         wallet_id: String,
     ) -> Option<&types::SessionWallet> {
         self.wallets.get(&wallet_id)
+
+    }
+    
+    /// Updates the node state
+    pub fn update_node_state(&mut self, node_state: StateMachine) {
+        self.node_state = Some(node_state);
     }
 
     /// Updates the node state

--- a/wallet/src/actors/app/state.rs
+++ b/wallet/src/actors/app/state.rs
@@ -170,12 +170,6 @@ impl State {
         wallet_id: String,
     ) -> Option<&types::SessionWallet> {
         self.wallets.get(&wallet_id)
-
-    }
-    
-    /// Updates the node state
-    pub fn update_node_state(&mut self, node_state: StateMachine) {
-        self.node_state = Some(node_state);
     }
 
     /// Updates the node state

--- a/wallet/src/actors/worker/handlers/notify_status.rs
+++ b/wallet/src/actors/worker/handlers/notify_status.rs
@@ -3,7 +3,11 @@ use actix::prelude::*;
 use crate::actors::worker;
 use crate::types;
 
-pub struct NotifyStatus(pub types::SessionWallet, pub types::DynamicSink);
+pub struct NotifyStatus(
+    pub types::SessionWallet,
+    pub types::DynamicSink,
+    pub Option<Vec<types::Event>>,
+);
 
 impl Message for NotifyStatus {
     type Result = ();
@@ -14,10 +18,10 @@ impl Handler<NotifyStatus> for worker::Worker {
 
     fn handle(
         &mut self,
-        NotifyStatus(wallet, sink): NotifyStatus,
+        NotifyStatus(wallet, sink, event): NotifyStatus,
         _ctx: &mut Self::Context,
     ) -> Self::Result {
-        if let Err(err) = self.notify_client(&wallet, sink, None) {
+        if let Err(err) = self.notify_client(&wallet, sink, event) {
             log::warn!(
                 "failed to notify wallet {} about its status: {}",
                 wallet.id,

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -1075,16 +1075,14 @@ impl Worker {
         sink: types::DynamicSink,
     ) -> Result<()> {
         log::info!("The node has changed its status into {:?}", status);
-        if status == StateMachine::Synced && !wallet.is_syncing()? {
-            wallet.clear_pending_state().ok();
-            self.sync(&wallet.id, &wallet, sink.clone(), true)
-                .map(|_| true)
-                .ok();
-        }
-
         // Notify about the changed node status.
         let events = vec![types::Event::NodeStatus(status)];
-        self.notify_client(&wallet, sink, Some(events)).ok();
+        self.notify_client(&wallet, sink.clone(), Some(events)).ok();
+
+        if status == StateMachine::Synced && !wallet.is_syncing()? {
+            wallet.clear_pending_state().ok();
+            self.sync(&wallet.id, &wallet, sink, true)?;
+        }
 
         Ok(())
     }

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -19,7 +19,7 @@ pub use witnet_data_structures::{
         Block as ChainBlock, CheckpointBeacon, DataRequestInfo, DataRequestOutput, Epoch, Hash,
         HashParseError, Hashable, Input as TransactionInput, KeyedSignature, OutputPointer,
         PublicKey, PublicKeyHash, PublicKeyHashParseError, RADAggregate, RADRequest, RADRetrieve,
-        RADTally, StateMachine, SuperBlock, ValueTransferOutput,
+        RADTally, StateMachine, SuperBlock, SyncStatus, ValueTransferOutput,
     },
     error::EpochCalculationError,
     proto::ProtobufConvert,
@@ -228,7 +228,7 @@ pub type DynamicSink = Arc<RwLock<Option<Sink>>>;
 
 /// Friendly events that can be sent to subscribed clients to let them now about significant
 /// activity related to their wallets.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub enum Event {
     /// The basic information of a new block that has already been processed but is pending
     /// consolidation (anchoring into a future superblock).
@@ -241,6 +241,8 @@ pub enum Event {
     Movement(model::BalanceMovement),
     /// Node status has changed
     NodeStatus(StateMachine),
+    /// Node disconnected
+    NodeDisconnected,
     /// The end of a synchronization progress.
     SyncFinish(u32, u32),
     /// An update on the progress of a the synchronization progress.


### PR DESCRIPTION
Add the function `periodic_node_request` that sends a `syncStatus` request, if returns an error (meaning the node is disconnected) it sends an event.

Closes #1705 