### PR TITLE
feat(node): stop validating commits on witness limit

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -2403,6 +2403,14 @@ impl TransactionsPool {
                     .map(|rt| Transaction::Reveal(rt.clone()))
             })
     }
+
+    /// Return the number of commits for the given data request
+    pub fn num_commits_for_data_request(&self, dr_hash: &Hash) -> usize {
+        self.co_transactions
+            .get(dr_hash)
+            .map(|x| x.len())
+            .unwrap_or(0)
+    }
 }
 
 /// Unspent output data structure (equivalent of Bitcoin's UTXO)


### PR DESCRIPTION
* Commit validation is expensive because of the VRF proof.
* If a data request does not reach the desired amount of commits, it is retried on the next epoch with a backup factor, which means more commits.

We currently validate all those extra commits, even though only some of them may be eventually included in a block. This PR tries to improve that by validating only the required amount of commits. Any extra commits will be ignored and will not be broadcasted.

This changes the commit priority in blocks: previously, each node uses hashmap iteration to decide which commits are included in a block, which is supposed to be random. But with this PR, each node will use the first commits that arrive to them, which means prioritizing faster nodes or nodes geographically close to them.