### PR TITLE
[Wallet]: send note status notification from the periodic request

### DIFF
--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -261,9 +261,6 @@ pub fn jsonrpc_io_handler(
                     "superblocks" => {
                         add_subscription("superblocks", subscriber);
                     }
-                    "status" => {
-                        add_subscription("status", subscriber);
-                    }
                     e => {
                         log::debug!("Unknown subscription method: {}", e);
                         // Ignore errors with `.ok()` because an error here means the connection was closed

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -261,6 +261,9 @@ pub fn jsonrpc_io_handler(
                     "superblocks" => {
                         add_subscription("superblocks", subscriber);
                     }
+                    "status" => {
+                        add_subscription("status", subscriber);
+                    }
                     e => {
                         log::debug!("Unknown subscription method: {}", e);
                         // Ignore errors with `.ok()` because an error here means the connection was closed

--- a/wallet/src/actors/app/methods.rs
+++ b/wallet/src/actors/app/methods.rs
@@ -512,7 +512,6 @@ impl App {
         match topic.as_str() {
             "blocks" => self.handle_block_notification(value),
             "superblocks" => self.handle_superblock_notification(value),
-            "status" => self.handle_node_status_notification(value),
             _ => {
                 log::debug!("Unhandled `{}` notification", topic);
                 log::trace!("Payload is {:?}", value);
@@ -568,27 +567,6 @@ impl App {
         Ok(())
     }
 
-    /// Handle node status notifications received from a Witnet node.
-    pub fn handle_node_status_notification(&mut self, value: types::Json) -> Result<()> {
-        let status = serde_json::from_value::<types::StateMachine>(value).map_err(node_error)?;
-
-        // This iterator is collected early so as to free the immutable reference to `self`.
-        let wallets: Vec<types::SessionWallet> = self
-            .state
-            .wallets
-            .iter()
-            .map(|(_, wallet)| wallet.clone())
-            .collect();
-
-        for wallet in &wallets {
-            let sink = self.state.get_sink(&wallet.session_id);
-            self.handle_node_status_in_worker(&status, wallet, sink.clone());
-        }
-        self.state.update_node_state(status);
-
-        Ok(())
-    }
-
     /// Offload block processing into a worker that operates on a different Arbiter than the main
     /// server thread, so as not to lock the rest of the application.
     pub fn handle_block_in_worker(
@@ -615,21 +593,6 @@ impl App {
         self.params.worker.do_send(HandleSuperBlockRequest {
             superblock_notification,
             wallet,
-            sink,
-        });
-    }
-
-    /// Offload node status into a worker that operates on a different Arbiter than the main
-    /// server thread, so as not to lock the rest of the application.
-    pub fn handle_node_status_in_worker(
-        &self,
-        status: &types::StateMachine,
-        wallet: &types::SessionWallet,
-        sink: types::DynamicSink,
-    ) {
-        self.params.worker.do_send(NodeStatusRequest {
-            status: *status,
-            wallet: wallet.clone(),
             sink,
         });
     }

--- a/wallet/src/actors/app/mod.rs
+++ b/wallet/src/actors/app/mod.rs
@@ -38,7 +38,6 @@ impl Actor for App {
         // Subscribe to new blocks and blocks consolidation notifications from a Witnet node
         self.node_subscribe("blocks", ctx);
         self.node_subscribe("superblocks", ctx);
-        self.node_subscribe("status", ctx);
         self.periodic_node_request(ctx);
 
         let mut handler =

--- a/wallet/src/actors/app/state.rs
+++ b/wallet/src/actors/app/state.rs
@@ -171,9 +171,4 @@ impl State {
     ) -> Option<&types::SessionWallet> {
         self.wallets.get(&wallet_id)
     }
-
-    /// Updates the node state
-    pub fn update_node_state(&mut self, node_state: StateMachine) {
-        self.node_state = Some(node_state);
-    }
 }

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -1074,7 +1074,7 @@ impl Worker {
         wallet: types::SessionWallet,
         sink: types::DynamicSink,
     ) -> Result<()> {
-        log::info!("The node has changed its status into {:?}", status);
+        log::debug!("The current node status is {:?}", status);
         // Notify about the changed node status.
         let events = vec![types::Event::NodeStatus(status)];
         self.notify_client(&wallet, sink.clone(), Some(events)).ok();


### PR DESCRIPTION
This PR removes the wallet status subscription and sends the node status changed from the periodic request. 
Since the periodic request is returning the node status, the wallet can know when the node status has changed and send the NodeStatusRequest. 