### PR TITLE
chore: fix clippy warnings for rust 1.48

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -561,7 +561,7 @@ impl Log {
                 .level
                 .to_owned()
                 .unwrap_or_else(|| defaults.log_level()),
-            sentry_telemetry: config.sentry_telemetry.unwrap_or_else(|| false),
+            sentry_telemetry: config.sentry_telemetry.unwrap_or(false),
         }
     }
 

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1247,7 +1247,7 @@ impl DataRequestOutput {
             .checked_add(self.commit_and_reveal_fee)
             .and_then(|res| res.checked_add(self.commit_and_reveal_fee))
             .and_then(|res| res.checked_mul(u64::from(self.witnesses)))
-            .ok_or_else(|| TransactionError::FeeOverflow)
+            .ok_or(TransactionError::FeeOverflow)
     }
 
     /// Returns the DataRequestOutput weight

--- a/data_structures/src/transaction_factory.rs
+++ b/data_structures/src/transaction_factory.rs
@@ -70,7 +70,7 @@ pub trait OutputsCollection {
             let value = self.get_value(op).unwrap();
             total = total
                 .checked_add(value)
-                .ok_or_else(|| TransactionError::OutputValueOverflow)?;
+                .ok_or(TransactionError::OutputValueOverflow)?;
 
             if let Some(time_lock) = self.get_time_lock(op) {
                 if time_lock > timestamp {
@@ -134,7 +134,7 @@ pub trait OutputsCollection {
                     .map(|o| o.checked_total_value().unwrap_or(u64::max_value()))
                     .unwrap_or_default(),
             )
-            .ok_or_else(|| TransactionError::OutputValueOverflow)?;
+            .ok_or(TransactionError::OutputValueOverflow)?;
 
         // For the first estimation: 1 input and 1 output more for the change address
         let mut current_weight = calculate_weight(1, outputs.len() + 1, dr_output, max_weight)?;
@@ -143,7 +143,7 @@ pub trait OutputsCollection {
             FeeType::Absolute => {
                 let amount = output_value
                     .checked_add(fee)
-                    .ok_or_else(|| TransactionError::FeeOverflow)?;
+                    .ok_or(TransactionError::FeeOverflow)?;
 
                 let (output_pointers, input_value) =
                     self.take_enough_utxos(amount, timestamp, block_number_limit, utxo_strategy)?;
@@ -162,11 +162,11 @@ pub trait OutputsCollection {
                 for _i in 0..max_iterations {
                     let weighted_fee = fee
                         .checked_mul(u64::from(current_weight))
-                        .ok_or_else(|| TransactionError::FeeOverflow)?;
+                        .ok_or(TransactionError::FeeOverflow)?;
 
                     let amount = output_value
                         .checked_add(weighted_fee)
-                        .ok_or_else(|| TransactionError::FeeOverflow)?;
+                        .ok_or(TransactionError::FeeOverflow)?;
 
                     let (output_pointers, input_value) = self.take_enough_utxos(
                         amount,

--- a/p2p/src/peers/mod.rs
+++ b/p2p/src/peers/mod.rs
@@ -215,7 +215,7 @@ impl Peers {
                         // If the source address that sent us this peer addresses is None, use the same address
                         // that we want to add. This will make all the peer addresses that were added using manual methods
                         // go to the same bucket that if it was announced by that address.
-                        let src_address = src_address.unwrap_or_else(|| address);
+                        let src_address = src_address.unwrap_or(address);
                         let index = self.new_bucket_index(&address, &src_address);
 
                         self.new_bucket

--- a/rad/src/reducers/mode.rs
+++ b/rad/src/reducers/mode.rs
@@ -17,10 +17,7 @@ pub fn mode(input: &RadonArray) -> Result<RadonTypes, RadError> {
     let temp_counter = counter.clone();
 
     // Compute how many times does the most frequent item appear
-    let max_count = temp_counter
-        .values()
-        .max()
-        .ok_or_else(|| RadError::ModeEmpty)?;
+    let max_count = temp_counter.values().max().ok_or(RadError::ModeEmpty)?;
 
     // Collect items that appear as many times as the one that appears the most
     let mode_vector: Vec<RadonTypes> = counter

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -885,7 +885,7 @@ pub fn validate_reveal_transaction(
         .info
         .commits
         .get(&pkh)
-        .ok_or_else(|| TransactionError::CommitNotFound)?;
+        .ok_or(TransactionError::CommitNotFound)?;
 
     if commit.body.commitment != reveal_signature.signature.hash() {
         return Err(TransactionError::MismatchedCommitment.into());

--- a/wallet/src/actors/app/handlers/get_addresses.rs
+++ b/wallet/src/actors/app/handlers/get_addresses.rs
@@ -23,12 +23,8 @@ impl Handler<GetAddressesRequest> for app::App {
     type Result = app::ResponseActFuture<GetAddressesResponse>;
 
     fn handle(&mut self, msg: GetAddressesRequest, _ctx: &mut Self::Context) -> Self::Result {
-        let offset = msg
-            .offset
-            .unwrap_or_else(|| constants::DEFAULT_PAGINATION_OFFSET);
-        let limit = msg
-            .limit
-            .unwrap_or_else(|| constants::DEFAULT_PAGINATION_LIMIT);
+        let offset = msg.offset.unwrap_or(constants::DEFAULT_PAGINATION_OFFSET);
+        let limit = msg.limit.unwrap_or(constants::DEFAULT_PAGINATION_LIMIT);
         let external = msg.external.unwrap_or(true);
         let f = self.get_addresses(msg.session_id, msg.wallet_id, offset, limit, external);
 

--- a/wallet/src/actors/app/handlers/get_transactions.rs
+++ b/wallet/src/actors/app/handlers/get_transactions.rs
@@ -22,12 +22,8 @@ impl Handler<GetTransactionsRequest> for app::App {
     type Result = app::ResponseActFuture<GetTransactionsResponse>;
 
     fn handle(&mut self, msg: GetTransactionsRequest, _ctx: &mut Self::Context) -> Self::Result {
-        let offset = msg
-            .offset
-            .unwrap_or_else(|| constants::DEFAULT_PAGINATION_OFFSET);
-        let limit = msg
-            .limit
-            .unwrap_or_else(|| constants::DEFAULT_PAGINATION_LIMIT);
+        let offset = msg.offset.unwrap_or(constants::DEFAULT_PAGINATION_OFFSET);
+        let limit = msg.limit.unwrap_or(constants::DEFAULT_PAGINATION_LIMIT);
         let f = self.get_transactions(msg.session_id, msg.wallet_id, offset, limit);
 
         Box::new(f)

--- a/wallet/src/actors/app/state.rs
+++ b/wallet/src/actors/app/state.rs
@@ -74,7 +74,7 @@ impl State {
         Ok(&self
             .sessions
             .get(session_id)
-            .ok_or_else(|| Error::SessionNotFound)?
+            .ok_or(Error::SessionNotFound)?
             .wallets)
     }
 
@@ -89,7 +89,7 @@ impl State {
         let wallet = wallets
             .get(wallet_id)
             .cloned()
-            .ok_or_else(|| Error::WalletNotFound)?;
+            .ok_or(Error::WalletNotFound)?;
 
         Ok(wallet)
     }
@@ -133,7 +133,7 @@ impl State {
         self.sessions
             .remove(session_id)
             .map(|_| ())
-            .ok_or_else(|| Error::SessionNotFound)
+            .ok_or(Error::SessionNotFound)
     }
 
     /// Remove a wallet completely.
@@ -141,7 +141,7 @@ impl State {
         let session = self
             .sessions
             .get_mut(session_id)
-            .ok_or_else(|| Error::SessionNotFound)?;
+            .ok_or(Error::SessionNotFound)?;
 
         session.wallets.remove(wallet_id);
         self.wallets.remove(wallet_id);

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -267,7 +267,7 @@ where
 
         let last_sync = db
             .get(&keys::wallet_last_sync())
-            .unwrap_or_else(|_| CheckpointBeacon {
+            .unwrap_or(CheckpointBeacon {
                 checkpoint: 0,
                 hash_prev_block: params.genesis_prev_hash,
             });
@@ -375,7 +375,7 @@ where
             last_payment_date: None,
         };
 
-        let next_index = index.checked_add(1).ok_or_else(|| Error::IndexOverflow)?;
+        let next_index = index.checked_add(1).ok_or(Error::IndexOverflow)?;
         if persist_db {
             // Persist changes and new address in database
             let mut batch = self.db.batch();
@@ -1238,7 +1238,7 @@ where
                 .balance
                 .local
                 .checked_sub(local_movement.amount)
-                .ok_or_else(|| Error::TransactionValueOverflow)?;
+                .ok_or(Error::TransactionValueOverflow)?;
         }
 
         // Update memory state: `utxo_set`
@@ -1254,7 +1254,7 @@ where
         state.transaction_next_id = state
             .transaction_next_id
             .checked_add(1)
-            .ok_or_else(|| Error::TransactionIdOverflow)?;
+            .ok_or(Error::TransactionIdOverflow)?;
 
         // Update addresses (externals/internals) and their information if there were payments (new UTXOs)
         //
@@ -1335,7 +1335,7 @@ where
                 .balance
                 .local
                 .checked_add(account_mutation.balance_movement.amount)
-                .ok_or_else(|| Error::TransactionValueOverflow)?;
+                .ok_or(Error::TransactionValueOverflow)?;
 
             return Ok(Some(account_mutation.balance_movement));
         }
@@ -1456,7 +1456,7 @@ where
             if let Some(model::OutputInfo { amount, .. }) = state.utxo_set.get(&out_ptr) {
                 input_amount = input_amount
                     .checked_add(*amount)
-                    .ok_or_else(|| Error::TransactionBalanceOverflow)?;
+                    .ok_or(Error::TransactionBalanceOverflow)?;
                 utxo_removals.push(out_ptr);
             }
         }
@@ -1492,7 +1492,7 @@ where
                 };
                 output_amount = output_amount
                     .checked_add(output.value)
-                    .ok_or_else(|| Error::TransactionBalanceOverflow)?;
+                    .ok_or(Error::TransactionBalanceOverflow)?;
 
                 let address = output.pkh.bech32(if self.params.testnet {
                     Environment::Testnet


### PR DESCRIPTION
This time this is the only new lint:

https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations