### PR TITLE
Send only superblocks containing drs from ethereum

### DIFF
--- a/bridges/ethereum/src/actors/block_relay_and_poi.rs
+++ b/bridges/ethereum/src/actors/block_relay_and_poi.rs
@@ -5,10 +5,10 @@ use crate::{actors::handle_receipt, actors::WitnetSuperBlock, config::Config, et
 
 use async_jsonrpc_client::{transports::tcp::TcpSocket, Transport};
 use ethabi::Bytes;
-use futures::{future::Either, sink::Sink, stream::Stream};
+use futures::{future::Either, sink::Sink, stream::Stream, sync::oneshot};
 use serde_json::json;
 use std::sync::Arc;
-use tokio::{sync::mpsc, sync::oneshot};
+use tokio::sync::mpsc;
 use web3::{contract, futures::Future, types::U256};
 use witnet_data_structures::{
     chain::{Block, Hash, Hashable},

--- a/bridges/ethereum/src/actors/block_relay_and_poi.rs
+++ b/bridges/ethereum/src/actors/block_relay_and_poi.rs
@@ -74,41 +74,133 @@ pub fn block_relay_and_poi(
 
             let superblock = superblock_notification.superblock;
             let confirmed_block_hashes = superblock_notification.consolidated_block_hashes;
-            let empty_hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".parse().unwrap();
 
             let superblock_hash: U256 = match superblock.hash() {
                 Hash::SHA256(x) => x.into(),
             };
-
+            let superblock_epoch: U256 = superblock.index.into();
+            let dr_merkle_root: U256 =
+                match superblock.data_request_root {
+                    Hash::SHA256(x) => x.into(),
+                };
+            let tally_merkle_root: U256 =
+                match superblock.tally_root {
+                    Hash::SHA256(x) => x.into(),
+                };
             get_blocks(confirmed_block_hashes, witnet_client)
+                .and_then({
+
+                    let eth_state = Arc::clone(&eth_state);
+                    move |confirmed_blocks| {
+                        eth_state.wrb_requests.read()
+                            .and_then({
+                                move |wrb_requests| {
+                                    let block_hash: U256 = match superblock.hash() {
+                                        Hash::SHA256(x) => x.into(),
+                                    };
+                                    let dr_txs: Vec<DRTransaction> = confirmed_blocks.iter().flat_map(|block| {
+                                        block.txns.data_request_txns.clone()
+                                    }).collect();
+                                    let tally_txs: Vec<TallyTransaction> = confirmed_blocks.iter().flat_map(|block| {
+                                        block.txns.tally_txns.clone()
+                                    }).collect();
+
+                                    let block_epoch: U256 = superblock.index.into();
+
+                                    let mut including = vec![];
+                                    let mut resolving = vec![];
+
+                                    let claimed_drs = wrb_requests.claimed();
+                                    let waiting_for_tally = wrb_requests.included();
+
+                                    if enable_claim_and_inclusion {
+                                        for dr in &dr_txs {
+                                            for dr_id in claimed_drs.get_by_right(&dr.body.dr_output.hash())
+                                            {
+                                                let dr_inclusion_proof = match superblock.dr_proof_of_inclusion(&confirmed_blocks, &dr) {
+                                                    Some(x) => x,
+                                                    None => {
+                                                        log::error!("Error creating data request proof of inclusion");
+                                                        continue;
+                                                    }
+                                                };
+
+                                                let poi: Vec<U256> = dr_inclusion_proof
+                                                    .lemma
+                                                    .iter()
+                                                    .map(|x| match x {
+                                                        Hash::SHA256(x) => x.into(),
+                                                    })
+                                                    .collect();
+                                                let poi_index = U256::from(dr_inclusion_proof.index);
+
+                                                log::debug!(
+                                                    "Proof of inclusion for data request {}:\nPoi: {:x?}\nPoi index: {}",
+                                                    dr.hash(),
+                                                    poi,
+                                                    poi_index,
+                                                );
+                                                log::info!("[{}] Claimed dr got included in witnet block!", dr_id);
+                                                log::info!("[{}] Sending proof of inclusion to WRB wrb_contract", dr_id);
+
+                                                including.push((*dr_id, poi.clone(), poi_index, block_hash, block_epoch));
+                                            }
+                                        }
+                                    }
+
+                                    if enable_result_reporting {
+                                        for tally in &tally_txs {
+                                            for dr_id in waiting_for_tally.get_by_right(&tally.dr_pointer)
+                                            {
+                                                let Hash::SHA256(dr_pointer_bytes) = tally.dr_pointer;
+                                                log::info!("[{}] Found tally for data request, posting to WRB", dr_id);
+                                                let tally_inclusion_proof = match superblock.tally_proof_of_inclusion(&confirmed_blocks, &tally) {
+                                                    Some(x) => x,
+                                                    None => {
+                                                        log::error!("Error creating tally data proof of inclusion");
+                                                        continue;
+                                                    }
+                                                };
+                                                log::debug!(
+                                                    "Proof of inclusion for tally        {}:\nData: {:?}\n{:?}",
+                                                    tally.hash(),
+                                                    [&dr_pointer_bytes[..], &tally.tally].concat(),
+                                                    tally_inclusion_proof
+                                                );
+
+                                                // Call report_result
+                                                let poi: Vec<U256> = tally_inclusion_proof
+                                                    .lemma
+                                                    .iter()
+                                                    .map(|x| match x {
+                                                        Hash::SHA256(x) => x.into(),
+                                                    })
+                                                    .collect();
+                                                let poi_index = U256::from(tally_inclusion_proof.index);
+                                                let result: Bytes = tally.tally.clone();
+                                                resolving.push((*dr_id, poi.clone(), poi_index, block_hash, block_epoch, result.clone()));
+                                            }
+                                        }
+                                    }
+                                    futures::future::finished((including, resolving))
+                                }
+                            })
+                    }
+                })
                 .and_then({
                     let config = Arc::clone(&config);
                     let eth_state = Arc::clone(&eth_state);
+                    move |(including, resolving)| {
 
-
-                    move |confirmed_blocks| {
-                        // Optimization: do not process empty blocks
-                        let is_non_empty = confirmed_blocks.iter().any(|block| {
-                            block.block_header.merkle_roots.dr_hash_merkle_root != empty_hash || block.block_header.merkle_roots.tally_hash_merkle_root != empty_hash
-                        });
-                        if !is_non_empty {
+                        // Optimization: do not process blocks that do not contain requests coming from ethereum
+                        if including.is_empty() && resolving.is_empty() {
                             log::debug!("Skipping empty superblock");
                             return futures::finished(());
                         }
 
                         if (is_new_block && config.enable_block_relay_new_blocks) || (!is_new_block && config.enable_block_relay_old_blocks) {
-                            let superblock_epoch: U256 = superblock.index.into();
-                            let dr_merkle_root: U256 =
-                                match superblock.data_request_root {
-                                    Hash::SHA256(x) => x.into(),
-                                };
-                            let tally_merkle_root: U256 =
-                                match superblock.tally_root {
-                                    Hash::SHA256(x) => x.into(),
-                                };
 
                             let block_relay_contract2 = block_relay_contract.clone();
-
                             // Post witnet superblock to BlockRelay wrb_contract
                             tokio::spawn(
                                 block_relay_contract
@@ -167,103 +259,9 @@ pub fn block_relay_and_poi(
                                 })
                             })
                             .and_then({
-                                let eth_state = Arc::clone(&eth_state);
-                                move |()| {
-                                    eth_state.wrb_requests.read()
-                                }
-                            })
-                            .and_then({
                                 let config = Arc::clone(&config);
                                 let eth_state = Arc::clone(&eth_state);
-                                move |wrb_requests| {
-                                    let block_hash: U256 = match superblock.hash() {
-                                        Hash::SHA256(x) => x.into(),
-                                    };
-                                    let dr_txs: Vec<DRTransaction> = confirmed_blocks.iter().flat_map(|block| {
-                                        block.txns.data_request_txns.clone()
-                                    }).collect();
-                                    let tally_txs: Vec<TallyTransaction> = confirmed_blocks.iter().flat_map(|block| {
-                                        block.txns.tally_txns.clone()
-                                    }).collect();
-
-                                    let block_epoch: U256 = superblock.index.into();
-
-                                    let mut including = vec![];
-                                    let mut resolving = vec![];
-
-                                    let claimed_drs = wrb_requests.claimed();
-                                    let waiting_for_tally = wrb_requests.included();
-
-                                    if enable_claim_and_inclusion {
-                                        for dr in &dr_txs {
-                                            for dr_id in claimed_drs.get_by_right(&dr.body.dr_output.hash())
-                                            {
-                                                let dr_inclusion_proof = match superblock.dr_proof_of_inclusion(&confirmed_blocks, &dr) {
-                                                    Some(x) => x,
-                                                    None => {
-                                                        log::error!("Error creating data request proof of inclusion");
-                                                        continue;
-                                                    }
-                                                };
-
-                                                let poi: Vec<U256> = dr_inclusion_proof
-                                                    .lemma
-                                                    .iter()
-                                                    .map(|x| match x {
-                                                        Hash::SHA256(x) => x.into(),
-                                                    })
-                                                    .collect();
-                                                let poi_index = U256::from(dr_inclusion_proof.index);
-
-                                                log::debug!(
-                                    "Proof of inclusion for data request {}:\nPoi: {:x?}\nPoi index: {}",
-                                    dr.hash(),
-                                    poi,
-                                    poi_index,
-                                );
-                                                log::info!("[{}] Claimed dr got included in witnet block!", dr_id);
-                                                log::info!("[{}] Sending proof of inclusion to WRB wrb_contract", dr_id);
-
-                                                including.push((*dr_id, poi.clone(), poi_index, block_hash, block_epoch));
-                                            }
-                                        }
-                                    }
-
-                                    if enable_result_reporting {
-                                        for tally in &tally_txs {
-                                            for dr_id in waiting_for_tally.get_by_right(&tally.dr_pointer)
-                                            {
-                                                let Hash::SHA256(dr_pointer_bytes) = tally.dr_pointer;
-                                                log::info!("[{}] Found tally for data request, posting to WRB", dr_id);
-                                                let tally_inclusion_proof = match superblock.tally_proof_of_inclusion(&confirmed_blocks, &tally) {
-                                                    Some(x) => x,
-                                                    None => {
-                                                        log::error!("Error creating tally data proof of inclusion");
-                                                        continue;
-                                                    }
-                                                };
-                                                log::debug!(
-                                    "Proof of inclusion for tally        {}:\nData: {:?}\n{:?}",
-                                    tally.hash(),
-                                    [&dr_pointer_bytes[..], &tally.tally].concat(),
-                                    tally_inclusion_proof
-                                );
-
-                                                // Call report_result
-                                                let poi: Vec<U256> = tally_inclusion_proof
-                                                    .lemma
-                                                    .iter()
-                                                    .map(|x| match x {
-                                                        Hash::SHA256(x) => x.into(),
-                                                    })
-                                                    .collect();
-                                                let poi_index = U256::from(tally_inclusion_proof.index);
-                                                let result: Bytes = tally.tally.clone();
-                                                resolving.push((*dr_id, poi.clone(), poi_index, block_hash, block_epoch, result.clone()));
-                                            }
-                                        }
-                                    }
-
+                                move |()| {
                                     // Check if we need to acquire a write lock
                                     if !including.is_empty() || !resolving.is_empty() {
                                         Either::A(eth_state.wrb_requests.write().map(move |mut wrb_requests| {

--- a/bridges/ethereum/src/actors/block_relay_check.rs
+++ b/bridges/ethereum/src/actors/block_relay_check.rs
@@ -2,13 +2,13 @@
 
 use crate::{config::Config, eth::EthState};
 use async_jsonrpc_client::futures::Stream;
-use futures::{future::Either, sink::Sink};
+use futures::{future::Either, sink::Sink, sync::oneshot};
 use std::{
     collections::HashMap,
     sync::Arc,
     time::{Duration, Instant},
 };
-use tokio::{sync::mpsc, sync::oneshot, timer::Interval};
+use tokio::{sync::mpsc, timer::Interval};
 use web3::{
     contract,
     futures::{future, Future},

--- a/bridges/ethereum/src/actors/claim_and_post.rs
+++ b/bridges/ethereum/src/actors/claim_and_post.rs
@@ -389,7 +389,7 @@ fn claim_and_post_dr(
                     let witnet_client = Arc::clone(&witnet_client);
 
                     move |mut wrb_requests| {
-                        if wrb_requests.posted().contains(&dr_id) {
+                        if wrb_requests.posted().contains_key(&dr_id) {
                             wrb_requests.set_claiming(dr_id);
                             Either::A(futures::finished(()))
                         } else if post_to_witnet_more_than_once && wrb_requests.claimed().contains_left(&dr_id) {
@@ -537,7 +537,7 @@ pub fn claim_and_post(
                                 (true, true) => Either::B(futures::finished(())),
                                 (false, _) => {
                                     let i = thread_rng().gen_range(0, known_dr_ids_posted.len());
-                                    let dr_id = *known_dr_ids_posted.iter().nth(i).unwrap();
+                                    let dr_id = *known_dr_ids_posted.keys().nth(i).unwrap();
                                     std::mem::drop(known_dr_ids);
 
                                     Either::A(claim_and_post_dr(

--- a/bridges/ethereum/src/config.rs
+++ b/bridges/ethereum/src/config.rs
@@ -26,6 +26,8 @@ pub struct Config {
     /// Enable block relay from witnet to ethereum, relay only old blocks
     /// (old blocks that were never posted to the block relay)
     pub enable_block_relay_old_blocks: bool,
+    /// Relay all superblocks
+    pub relay_all_superblocks_even_the_empty_ones: bool,
     /// Enable data request claim + inclusion
     pub enable_claim_and_inclusion: bool,
     /// Enable data request result reporting

--- a/bridges/ethereum/src/eth.rs
+++ b/bridges/ethereum/src/eth.rs
@@ -136,8 +136,8 @@ impl WrbRequests {
                 *x = address;
                 self.requests.insert(dr_id, DrState::Posted { address });
             } else {
-                log::warn!(
-                    "Cannot update posted state because dr is in an inconsistent state: [{}]",
+                log::debug!(
+                    "Cannot update claimer address because dr is not in posted state: [{}]",
                     dr_id
                 );
             }

--- a/bridges/ethereum/src/main.rs
+++ b/bridges/ethereum/src/main.rs
@@ -199,6 +199,19 @@ fn run() -> Result<(), String> {
                 if config.subscribe_to_witnet_blocks {
                     tokio::spawn(witnet_event_fut);
                 }
+                // This should only be instantiated if this node is planning on doing claims and inclusions
+                if config.enable_claim_and_inclusion {
+                    tokio::spawn(claim_and_post_fut);
+                    tokio::spawn(claim_ticker_fut);
+                }
+
+                tokio::spawn(block_relay_and_poi_fut);
+                tokio::spawn(block_relay_check_fut);
+
+                // This should only be instantiated if this node is planning on doing result reporting
+                if config.enable_result_reporting {
+                    tokio::spawn(tally_finder_fut);
+                }
                 tokio::spawn(
                     Interval::new(Instant::now(), Duration::from_millis(10_000))
                         .map_err(|e| log::error!("Error creating interval: {:?}", e))
@@ -208,11 +221,6 @@ fn run() -> Result<(), String> {
                         .then(|_| Ok(()))
                         .for_each(|_| Ok(())),
                 );
-                tokio::spawn(claim_and_post_fut);
-                tokio::spawn(block_relay_and_poi_fut);
-                tokio::spawn(claim_ticker_fut);
-                tokio::spawn(block_relay_check_fut);
-                tokio::spawn(tally_finder_fut);
             }));
         }
     }

--- a/witnet_ethereum_bridge.toml
+++ b/witnet_ethereum_bridge.toml
@@ -14,6 +14,8 @@ enable_block_relay_new_blocks = true
 # Enable block relay from witnet to ethereum, relay only old blocks
 # (old blocks that were never posted to the block relay, but contain a posted tally)
 enable_block_relay_old_blocks = true
+# Relay all superblocks
+relay_all_superblocks_even_the_empty_ones = false
 # Enable data request claim + inclusion
 enable_claim_and_inclusion = true
 # Enable data request result reporting


### PR DESCRIPTION
This PR changes the code so as to only send superblocks to the block relay that contain DRs that were sent from Ethereum. It also changes the oneshot channel to use the one provided by futures due to an error after rust 1.48.0