### PR TITLE
fix(wallet): use non-blocking write to avoid deadlock

### DIFF
--- a/wallet/src/params.rs
+++ b/wallet/src/params.rs
@@ -56,7 +56,7 @@ impl NodeParams {
     /// This is a best-effort method. It will silently do nothing if the write lock on `last_beacon`
     /// cannot be acquired or if the new beacon looks older than the current one.
     pub fn update_last_beacon(&self, new_beacon: CheckpointBeacon) {
-        let lock = (*self.last_beacon).write();
+        let lock = (*self.last_beacon).try_write();
         if let Ok(mut beacon) = lock {
             if new_beacon.checkpoint > beacon.checkpoint {
                 *beacon = new_beacon

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -1642,11 +1642,14 @@ where
             beacon,
         );
 
-        if let Ok(mut write_guard) = self.state.write() {
+        if let Ok(mut write_guard) = self.state.try_write() {
             write_guard.last_sync = beacon;
             if confirmed {
                 write_guard.last_confirmed = beacon;
             }
+        } else {
+            log::error!("Failed to set tip of chain");
+            return Err(());
         }
 
         Ok(())


### PR DESCRIPTION
Close #1761 

[RwLock::write](https://doc.rust-lang.org/stable/std/sync/struct.RwLock.html#method.write) always blocks so it can result in a deadlock, we intended to use [RwLock::try_write](https://doc.rust-lang.org/stable/std/sync/struct.RwLock.html#method.try_write), which does not block.