### PR TITLE
fix(wallet): avoid recursive read lock

### DIFF
--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -467,7 +467,7 @@ where
             total
         );
         for index in range.rev() {
-            let address = self.get_address(account, keychain, index)?;
+            let address = self._get_address(&state, account, keychain, index)?;
             addresses.push((*address).clone());
         }
 
@@ -578,6 +578,7 @@ where
         })
     }
 
+    #[cfg(test)]
     /// Get an address if it exists in memory or storage.
     pub fn get_address(
         &self,


### PR DESCRIPTION
To avoid deadlock.

Close #1761

The issue was:

Thread 1 takes read lock here:

https://github.com/witnet/witnet-rust/blob/5a58020df717b843d61ba87af3a308d13f13e284/wallet/src/repository/wallet/mod.rs#L449

Thread 2 takes write lock (anywhere). This blocks because the lock is held by thread 1.

Thread 1 takes read lock again inside `get_address`. This blocks because the thread 2 has priority.

The fix is to avoid the second read lock, which is redundant.