### PR TITLE
feat(error): return timeout event if timeout error

### DIFF
--- a/wallet/src/actors/app/error.rs
+++ b/wallet/src/actors/app/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     Validation(ValidationErrors),
     #[fail(display = "internal error: {}", _0)]
     Internal(#[cause] failure::Error),
+    #[fail(display = "JsonRPC timeout error")]
+    JsonRpcTimeoutError,
     #[fail(display = "node error: {}", _0)]
     Node(#[cause] failure::Error),
     #[fail(display = "wallet is not connected to a node")]
@@ -48,6 +50,10 @@ impl Error {
                     "Node Error",
                     Some(json!({ "cause": format!("{}", e) })),
                 )
+            }
+            Error::JsonRpcTimeoutError => {
+                log::error!("Timeout Error");
+                (408, "Timeout Error", None)
             }
             Error::NodeNotConnected => (520, "Node Not Connected", None),
             Error::Internal(e) => {
@@ -115,6 +121,7 @@ impl From<actors::worker::Error> for Error {
                     "Wallet account has not enough balance",
                 ))
             }
+            actors::worker::Error::JsonRpcTimeoutError => Error::JsonRpcTimeoutError,
             _ => internal_error(err),
         }
     }

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -681,9 +681,12 @@ impl Worker {
                 sync_end,
                 e
             );
-
-            let events = Some(vec![types::Event::SyncError(sync_start, sync_end)]);
-            self.notify_client(&wallet, sink, events).ok();
+            if let Error::JsonRpcTimeoutError = e {
+                log::error!("JsonRpc timeout error during synchronization");
+            } else {
+                let events = Some(vec![types::Event::SyncError(sync_start, sync_end)]);
+                self.notify_client(&wallet, sink, events).ok();
+            }
         }
 
         sync_result


### PR DESCRIPTION
This PR solves the issue about getting a timeout while receiving blocks, as this might trigger an inconsistent state in the wallet. The solution provided sets the node state to 'None' when we receive a timeout, so as to trigger a new sync when the periodic ping pong request detects is online again

Closes #1750 