### PR TITLE
fix(node): panic on deserialization error instead of overwriting chain state

### DIFF
--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -109,8 +109,7 @@ impl ChainManager {
                         let result = match chain_state_from_storage {
                             Ok(x) => (x, config),
                             Err(e) => {
-                                log::error!("Error while getting chain state from storage: {}", e);
-                                (None, config)
+                                panic!("Error while getting chain state from storage: {}", e);
                             }
                         };
 


### PR DESCRIPTION
This error can happen while developing: we can accidentally break compatibility of some data structure. Prior to this PR, the chain state was replaced with a new chain state and there was no way to recover the old chain state. Now, the node panics so we can detect this error.

This was not a panic before because we wanted to make the transition from one testnet to the next as smooth as possible.