### PR TITLE
chore: fix clippy warnings for rust 1.49

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,6 +18,7 @@ jobs:
         -D clippy::cast-precision-loss
         -D clippy::cast-sign-loss
         -D clippy::checked-conversions
+        -A clippy::field-reassign-with-default
         
     steps:
       - uses: actions/checkout@v1

--- a/Justfile
+++ b/Justfile
@@ -33,6 +33,7 @@ export CLIPPY_LINTS := '-D warnings
     -D clippy::cast-precision-loss
     -D clippy::cast-sign-loss
     -D clippy::checked-conversions
+    -A clippy::field-reassign-with-default
 '
 
 # run clippy

--- a/bridges/ethereum/src/eth.rs
+++ b/bridges/ethereum/src/eth.rs
@@ -1,6 +1,5 @@
-use crate::config::Config;
-use crate::multibimap::MultiBiMap;
-use ethabi::{Bytes, Token};
+use crate::{config::Config, multibimap::MultiBiMap};
+use ethabi::Bytes;
 use futures::Future;
 use futures_locks::RwLock;
 use std::collections::{HashMap, HashSet};
@@ -424,19 +423,6 @@ impl EthState {
             post_tally_event_sig,
             wrb_requests,
         })
-    }
-}
-
-/// Assume the first return value of an event log is a U256 and return it
-pub fn read_u256_from_event_log(value: &web3::types::Log) -> Result<U256, ()> {
-    let event_types = vec![ethabi::ParamType::Uint(0)];
-    let event_data = ethabi::decode(&event_types, &value.data.0);
-    log::debug!("Event data: {:?}", event_data);
-
-    // Errors are handled by the caller, if this fails there is nothing we can do
-    match event_data.map_err(|_| ())?.get(0).ok_or(())? {
-        Token::Uint(x) => Ok(*x),
-        _ => Err(()),
     }
 }
 

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -120,7 +120,8 @@ where
         let seed_bytes = self.seed.as_ref();
         let seed_len = seed_bytes.len();
 
-        if seed_len < 16 || seed_len > 64 {
+        // Seed length must be between 16 and 64 bytes (128 and 512 bits)
+        if !(16..=64).contains(&seed_len) {
             return Err(MasterKeyGenError::InvalidSeedLength);
         }
 
@@ -148,7 +149,7 @@ pub enum KeyDerivationError {
     #[fail(display = "The length of the hmac key is invalid")]
     InvalidKeyLength,
     /// Invalid seed length
-    #[fail(display = "The length of the seed is invalid, must be between 128/256 bits")]
+    #[fail(display = "The length of the seed is invalid, must be between 128/512 bits")]
     InvalidSeedLength,
     /// Secp256k1 internal error
     #[fail(display = "Error in secp256k1 crate")]

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -5404,14 +5404,22 @@ mod tests {
 
     #[test]
     fn test_sort_own_utxos() {
-        let mut vto1 = ValueTransferOutput::default();
-        vto1.value = 100;
-        let mut vto2 = ValueTransferOutput::default();
-        vto2.value = 500;
-        let mut vto3 = ValueTransferOutput::default();
-        vto3.value = 200;
-        let mut vto4 = ValueTransferOutput::default();
-        vto4.value = 300;
+        let vto1 = ValueTransferOutput {
+            value: 100,
+            ..ValueTransferOutput::default()
+        };
+        let vto2 = ValueTransferOutput {
+            value: 500,
+            ..ValueTransferOutput::default()
+        };
+        let vto3 = ValueTransferOutput {
+            value: 200,
+            ..ValueTransferOutput::default()
+        };
+        let vto4 = ValueTransferOutput {
+            value: 300,
+            ..ValueTransferOutput::default()
+        };
 
         let vt = Transaction::ValueTransfer(VTTransaction::new(
             VTTransactionBody::new(vec![], vec![vto1, vto2, vto3, vto4]),
@@ -5461,9 +5469,9 @@ mod tests {
     fn test_ordered_alts_no_tie() {
         let mut alt_keys = AltKeys::default();
 
-        let p1 = PublicKeyHash::from_bytes(&[0x01 as u8; 20]).unwrap();
-        let p2 = PublicKeyHash::from_bytes(&[0x02 as u8; 20]).unwrap();
-        let p3 = PublicKeyHash::from_bytes(&[0x03 as u8; 20]).unwrap();
+        let p1 = PublicKeyHash::from_bytes(&[0x01; 20]).unwrap();
+        let p2 = PublicKeyHash::from_bytes(&[0x02; 20]).unwrap();
+        let p3 = PublicKeyHash::from_bytes(&[0x03; 20]).unwrap();
 
         let p1_bls =
             Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[1; 32]).unwrap())
@@ -5505,9 +5513,9 @@ mod tests {
     fn test_ordered_alts_with_tie() {
         let mut alt_keys = AltKeys::default();
 
-        let p1 = PublicKeyHash::from_bytes(&[0x01 as u8; 20]).unwrap();
-        let p2 = PublicKeyHash::from_bytes(&[0x02 as u8; 20]).unwrap();
-        let p3 = PublicKeyHash::from_bytes(&[0x03 as u8; 20]).unwrap();
+        let p1 = PublicKeyHash::from_bytes(&[0x01; 20]).unwrap();
+        let p2 = PublicKeyHash::from_bytes(&[0x02; 20]).unwrap();
+        let p3 = PublicKeyHash::from_bytes(&[0x03; 20]).unwrap();
 
         let p1_bls =
             Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[1; 32]).unwrap())
@@ -5547,11 +5555,11 @@ mod tests {
     fn test_ordered_alts_with_tie_2() {
         let mut alt_keys = AltKeys::default();
 
-        let p1 = PublicKeyHash::from_bytes(&[0x01 as u8; 20]).unwrap();
-        let p2 = PublicKeyHash::from_bytes(&[0x02 as u8; 20]).unwrap();
-        let p3 = PublicKeyHash::from_bytes(&[0x03 as u8; 20]).unwrap();
-        let p4 = PublicKeyHash::from_bytes(&[0x04 as u8; 20]).unwrap();
-        let p5 = PublicKeyHash::from_bytes(&[0x05 as u8; 20]).unwrap();
+        let p1 = PublicKeyHash::from_bytes(&[0x01; 20]).unwrap();
+        let p2 = PublicKeyHash::from_bytes(&[0x02; 20]).unwrap();
+        let p3 = PublicKeyHash::from_bytes(&[0x03; 20]).unwrap();
+        let p4 = PublicKeyHash::from_bytes(&[0x04; 20]).unwrap();
+        let p5 = PublicKeyHash::from_bytes(&[0x05; 20]).unwrap();
 
         let p1_bls =
             Bn256PublicKey::from_secret_key(&Bn256SecretKey::from_slice(&[1; 32]).unwrap())

--- a/net/src/client/tcp/actors/jsonrpc.rs
+++ b/net/src/client/tcp/actors/jsonrpc.rs
@@ -357,11 +357,9 @@ impl StreamHandler<NotifySubscriptionId, Error> for JsonRpcClient {
 
 fn is_connection_error(err: &Error) -> bool {
     match err {
-        Error::RequestFailed { error_kind, .. } => match error_kind {
-            TransportErrorKind::Transport(_) => true,
-            TransportErrorKind::Unreachable => true,
-            _ => false,
-        },
+        Error::RequestFailed { error_kind, .. } => {
+            matches!(error_kind, TransportErrorKind::Transport(_) | TransportErrorKind::Unreachable)
+        }
         Error::RequestTimedOut(_) => true,
         Error::Mailbox(_) => true,
         _ => false,

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -651,7 +651,9 @@ impl Handler<AddSuperBlockVote> for ChainManager {
         AddSuperBlockVote { superblock_vote }: AddSuperBlockVote,
         ctx: &mut Context<Self>,
     ) -> Self::Result {
-        self.add_superblock_vote(superblock_vote, ctx)
+        self.add_superblock_vote(superblock_vote, ctx);
+
+        Ok(())
     }
 }
 
@@ -670,7 +672,7 @@ impl Handler<GetBlocksEpochRange> for ChainManager {
     type Result = Result<Vec<(Epoch, Hash)>, ChainManagerError>;
 
     fn handle(&mut self, msg: GetBlocksEpochRange, _ctx: &mut Context<Self>) -> Self::Result {
-        self.get_blocks_epoch_range(msg)
+        Ok(self.get_blocks_epoch_range(msg))
     }
 }
 
@@ -1040,7 +1042,7 @@ impl Handler<PeersBeacons> for ChainManager {
                             // This is the only point in the whole base code for the state
                             // machine to move into `Synced` state.
                             self.update_state_machine(StateMachine::Synced);
-                            self.add_temp_superblock_votes(ctx).unwrap();
+                            self.add_temp_superblock_votes(ctx);
                         }
                         Ok(peers_to_unregister)
                     }

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -1070,8 +1070,10 @@ mod tests {
         // Fields required to mine a block
         let block_beacon = CheckpointBeacon::default();
 
-        let mut vrf_input = CheckpointVRF::default();
-        vrf_input.hash_prev_vrf = LAST_VRF_INPUT.parse().unwrap();
+        let vrf_input = CheckpointVRF {
+            hash_prev_vrf: LAST_VRF_INPUT.parse().unwrap(),
+            checkpoint: 0,
+        };
 
         // Add valid vrf proof
         let vrf = &mut VrfCtx::secp256k1().unwrap();
@@ -1573,7 +1575,7 @@ mod tests {
             probs.push(calculate_mining_probability(&rep_engine, id, rf, bf))
         }
 
-        let new_pkh = PublicKeyHash::from_bytes(&[0xFF as u8; 20]).unwrap();
+        let new_pkh = PublicKeyHash::from_bytes(&[0xFF; 20]).unwrap();
         let new_prob = calculate_mining_probability(&rep_engine, new_pkh, rf, bf);
 
         (probs, new_prob)
@@ -1589,20 +1591,20 @@ mod tests {
         for &prob in &probs[0..8] {
             assert_eq!(
                 (prob * 10_000.0).round() as u32,
-                (7.12 as f64 * 100.0).round() as u32
+                (7.12_f64 * 100.0).round() as u32
             );
         }
 
         for &prob in &probs[8..10] {
             assert_eq!(
                 (prob * 10_000.0).round() as u32,
-                (4.09 as f64 * 100.0).round() as u32
+                (4.09_f64 * 100.0).round() as u32
             );
         }
 
         assert_eq!(
             (new_prob * 10_000.0).round() as u32,
-            (3.89 as f64 * 100.0).round() as u32
+            (3.89_f64 * 100.0).round() as u32
         );
     }
 
@@ -1616,13 +1618,13 @@ mod tests {
         for prob in probs {
             assert_eq!(
                 (prob * 10_000.0).round() as u32,
-                (9.04 as f64 * 100.0).round() as u32
+                (9.04_f64 * 100.0).round() as u32
             );
         }
 
         assert_eq!(
             (new_prob * 10_000.0).round() as u32,
-            (4.56 as f64 * 100.0).round() as u32
+            (4.56_f64 * 100.0).round() as u32
         );
     }
 
@@ -1636,13 +1638,13 @@ mod tests {
         for prob in probs {
             assert_eq!(
                 (prob * 10_000.0).round() as u32,
-                (8.93 as f64 * 100.0).round() as u32
+                (8.93_f64 * 100.0).round() as u32
             );
         }
 
         assert_eq!(
             (new_prob * 10_000.0).round() as u32,
-            (2.15 as f64 * 100.0).round() as u32
+            (2.15_f64 * 100.0).round() as u32
         );
     }
 
@@ -1656,13 +1658,13 @@ mod tests {
         for prob in probs {
             assert_eq!(
                 (prob * 10_000.0).round() as u32,
-                (10.02 as f64 * 100.0).round() as u32
+                (10.02_f64 * 100.0).round() as u32
             );
         }
 
         assert_eq!(
             (new_prob * 10_000.0).round() as u32,
-            (0.25 as f64 * 100.0).round() as u32
+            (0.25_f64 * 100.0).round() as u32
         );
     }
 
@@ -1675,12 +1677,12 @@ mod tests {
 
         assert_eq!(
             (probs[0] * 10_000.0).round() as u32,
-            (6.51 as f64 * 100.0).round() as u32
+            (6.51_f64 * 100.0).round() as u32
         );
 
         assert_eq!(
             (new_prob * 10_000.0).round() as u32,
-            (3.49 as f64 * 100.0).round() as u32
+            (3.49_f64 * 100.0).round() as u32
         );
     }
 
@@ -1693,12 +1695,12 @@ mod tests {
 
         assert_eq!(
             (probs[0] * 10_000.0).round() as u32,
-            (0.63 as f64 * 100.0).round() as u32
+            (0.63_f64 * 100.0).round() as u32
         );
 
         assert_eq!(
             (new_prob * 10_000.0).round() as u32,
-            (0.37 as f64 * 100.0).round() as u32
+            (0.37_f64 * 100.0).round() as u32
         );
     }
 
@@ -1711,12 +1713,12 @@ mod tests {
 
         assert_eq!(
             (probs[0] * 10_000.0).round() as u32,
-            (1.0 as f64 * 100.0).round() as u32
+            (1.0_f64 * 100.0).round() as u32
         );
 
         assert_eq!(
             (new_prob * 10_000.0).round() as u32,
-            (0.08 as f64 * 100.0).round() as u32
+            (0.08_f64 * 100.0).round() as u32
         );
     }
 
@@ -1749,7 +1751,7 @@ mod tests {
 
         assert_eq!(
             (new_prob * 10_000.0).round() as u32,
-            (0.08 as f64 * 100.0).round() as u32
+            (0.08_f64 * 100.0).round() as u32
         );
     }
 
@@ -1769,7 +1771,7 @@ mod tests {
 
         assert_eq!(
             (new_prob * 10_000.0).round() as u32,
-            (0.0 as f64 * 100.0).round() as u32
+            (0_f64 * 100.0).round() as u32
         );
     }
 }

--- a/node/src/actors/inventory_manager/handlers.rs
+++ b/node/src/actors/inventory_manager/handlers.rs
@@ -396,8 +396,10 @@ mod tests {
         let dr_pool = DataRequestPool::default();
 
         // Fields required to mine a block
-        let mut block_beacon = CheckpointBeacon::default();
-        block_beacon.checkpoint = block_epoch;
+        let block_beacon = CheckpointBeacon {
+            checkpoint: block_epoch,
+            hash_prev_block: Hash::default(),
+        };
         let block_number = 1;
         let block_proof = BlockEligibilityClaim::default();
         let collateral_minimum = 1_000_000_000;

--- a/p2p/src/sessions/mod.rs
+++ b/p2p/src/sessions/mod.rs
@@ -73,7 +73,7 @@ where
             inbound_consolidated: BoundedSessions::default(),
             inbound_network_ranges: Default::default(),
             inbound_unconsolidated: BoundedSessions::default(),
-            magic_number: 0 as u16,
+            magic_number: 0,
             outbound_consolidated: BoundedSessions::default(),
             outbound_consolidated_consensus: BoundedSessions::default(),
             outbound_unconsolidated: BoundedSessions::default(),

--- a/rad/src/filters/deviation.rs
+++ b/rad/src/filters/deviation.rs
@@ -50,7 +50,7 @@ pub fn standard_filter(
             }
             let bool_matrix = boolean_standard_filter(&input, sigmas_float)?;
 
-            keep_rows(input, &bool_matrix, context)
+            Ok(keep_rows(input, &bool_matrix, context))
         }
         Some(_rad_types) => {
             // 1D array
@@ -87,7 +87,7 @@ fn keep_rows(
     input: &RadonArray,
     keep: &RadonArray,
     context: &mut ReportContext<RadonTypes>,
-) -> Result<RadonTypes, RadError> {
+) -> RadonTypes {
     let mut result = vec![];
     let mut bool_vec = vec![];
     for (item, keep_array) in input.value().into_iter().zip(keep.value()) {
@@ -115,7 +115,7 @@ fn keep_rows(
         metadata.update_liars(bool_vec);
     }
 
-    Ok(RadonTypes::from(RadonArray::from(result)))
+    RadonTypes::from(RadonArray::from(result))
 }
 
 // Return an array with the same dimensions as the input, with a boolean indicating
@@ -314,8 +314,10 @@ mod tests {
             vec![RadonTypes::Array(expected1), RadonTypes::Array(expected2)];
         let expected = RadonTypes::Array(RadonArray::from(expected_vec));
 
-        let mut context = ReportContext::default();
-        context.stage = Stage::Tally(TallyMetaData::default());
+        let mut context = ReportContext {
+            stage: Stage::Tally(TallyMetaData::default()),
+            ..ReportContext::default()
+        };
 
         let output = standard_filter(&input, &extra_args, &mut context).unwrap();
 
@@ -348,8 +350,10 @@ mod tests {
             vec![RadonTypes::Array(expected1), RadonTypes::Array(expected2)];
         let expected = RadonTypes::Array(RadonArray::from(expected_vec));
 
-        let mut context = ReportContext::default();
-        context.stage = Stage::Tally(TallyMetaData::default());
+        let mut context = ReportContext {
+            stage: Stage::Tally(TallyMetaData::default()),
+            ..ReportContext::default()
+        };
 
         let output = standard_filter(&input, &extra_args, &mut context).unwrap();
 
@@ -380,8 +384,10 @@ mod tests {
         let expected_vec: Vec<RadonTypes> = vec![RadonTypes::Array(expected1)];
         let expected = RadonTypes::Array(RadonArray::from(expected_vec));
 
-        let mut context = ReportContext::default();
-        context.stage = Stage::Tally(TallyMetaData::default());
+        let mut context = ReportContext {
+            stage: Stage::Tally(TallyMetaData::default()),
+            ..ReportContext::default()
+        };
 
         let output = standard_filter(&input, &extra_args, &mut context).unwrap();
 
@@ -410,8 +416,10 @@ mod tests {
         let expected_vec: Vec<RadonTypes> = vec![];
         let expected = RadonTypes::Array(RadonArray::from(expected_vec));
 
-        let mut context = ReportContext::default();
-        context.stage = Stage::Tally(TallyMetaData::default());
+        let mut context = ReportContext {
+            stage: Stage::Tally(TallyMetaData::default()),
+            ..ReportContext::default()
+        };
 
         let output = standard_filter(&input, &extra_args, &mut context).unwrap();
 

--- a/rad/src/filters/mode.rs
+++ b/rad/src/filters/mode.rs
@@ -68,8 +68,10 @@ mod tests {
         let input = vec![];
         let expected = RadError::ModeEmpty;
 
-        let mut ctx = ReportContext::default();
-        ctx.stage = Stage::Tally(TallyMetaData::default());
+        let mut ctx = ReportContext {
+            stage: Stage::Tally(TallyMetaData::default()),
+            ..ReportContext::default()
+        };
         let output = imode(&input, &mut ctx).unwrap_err();
         assert_eq!(output, expected);
     }
@@ -79,8 +81,10 @@ mod tests {
         let input = vec![1];
         let expected = input.clone();
 
-        let mut ctx = ReportContext::default();
-        ctx.stage = Stage::Tally(TallyMetaData::default());
+        let mut ctx = ReportContext {
+            stage: Stage::Tally(TallyMetaData::default()),
+            ..ReportContext::default()
+        };
         let output = imode(&input, &mut ctx).unwrap();
         assert_eq!(output, expected);
 
@@ -102,8 +106,10 @@ mod tests {
             max_count: 1,
         };
 
-        let mut ctx = ReportContext::default();
-        ctx.stage = Stage::Tally(TallyMetaData::default());
+        let mut ctx = ReportContext {
+            stage: Stage::Tally(TallyMetaData::default()),
+            ..ReportContext::default()
+        };
         let output = imode(&input, &mut ctx).unwrap_err();
         assert_eq!(output, expected);
     }
@@ -113,8 +119,10 @@ mod tests {
         let input = vec![1, 2, 2, 2, 3, 1];
         let expected = vec![2, 2, 2];
 
-        let mut ctx = ReportContext::default();
-        ctx.stage = Stage::Tally(TallyMetaData::default());
+        let mut ctx = ReportContext {
+            stage: Stage::Tally(TallyMetaData::default()),
+            ..ReportContext::default()
+        };
         let output = imode(&input, &mut ctx).unwrap();
         assert_eq!(output, expected);
 
@@ -158,8 +166,10 @@ mod tests {
         let input = vec!["Hello".to_string()];
         let expected = input.clone();
 
-        let mut ctx = ReportContext::default();
-        ctx.stage = Stage::Tally(TallyMetaData::default());
+        let mut ctx = ReportContext {
+            stage: Stage::Tally(TallyMetaData::default()),
+            ..ReportContext::default()
+        };
         let output = strmode(&input, &mut ctx).unwrap();
         assert_eq!(output, expected);
 
@@ -181,8 +191,10 @@ mod tests {
             max_count: 1,
         };
 
-        let mut ctx = ReportContext::default();
-        ctx.stage = Stage::Tally(TallyMetaData::default());
+        let mut ctx = ReportContext {
+            stage: Stage::Tally(TallyMetaData::default()),
+            ..ReportContext::default()
+        };
         let output = strmode(&input, &mut ctx).unwrap_err();
         assert_eq!(output, expected);
     }
@@ -202,8 +214,10 @@ mod tests {
         ];
         let expected = vec![str2.clone(), str2.clone(), str2];
 
-        let mut ctx = ReportContext::default();
-        ctx.stage = Stage::Tally(TallyMetaData::default());
+        let mut ctx = ReportContext {
+            stage: Stage::Tally(TallyMetaData::default()),
+            ..ReportContext::default()
+        };
         let output = strmode(&input, &mut ctx).unwrap();
         assert_eq!(output, expected);
 

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -459,7 +459,7 @@ mod tests {
             Value::Integer(RadonOpCodes::StringParseJSONArray as i128),
             Value::Array(vec![
                 Value::Integer(RadonOpCodes::ArrayGetMap as i128),
-                Value::Integer(0 as i128),
+                Value::Integer(0_i128),
             ]),
             Value::Array(vec![
                 Value::Integer(RadonOpCodes::MapGetMap as i128),

--- a/rad/src/operators/array.rs
+++ b/rad/src/operators/array.rs
@@ -232,10 +232,12 @@ pub fn sort(
     let mapped_array = match map(input, map_args, context)? {
         RadonTypes::Array(x) => x,
         RadonTypes::RadonError(error) => {
-            if let RadError::UnhandledIntercept { inner, message: _ } = error.inner() {
-                if let Some(super_inner) = inner {
-                    return Err(*super_inner.clone());
-                }
+            if let RadError::UnhandledIntercept {
+                inner: Some(super_inner),
+                message: _,
+            } = error.inner()
+            {
+                return Err(*super_inner.clone());
             }
             return Err(error.inner().clone());
         }

--- a/reputation/src/trs.rs
+++ b/reputation/src/trs.rs
@@ -349,6 +349,10 @@ where
     }
 }
 
+/// Tried to decrement a cache entry when there is not enough to subtract.
+#[derive(Copy, Clone, Debug)]
+pub struct InconsistentCacheError;
+
 /// Increment a cache entry
 pub fn increment_cache<K, V, S>(map: &mut HashMap<K, V, S>, k: K, v: V)
 where
@@ -365,7 +369,11 @@ where
 /// Decrement a cache entry.
 /// This function returns an error when there is not enough to subtract,
 /// or the identity does not exist
-pub fn decrement_cache<K, V, S>(map: &mut HashMap<K, V, S>, k: K, v: V) -> Result<(), ()>
+pub fn decrement_cache<K, V, S>(
+    map: &mut HashMap<K, V, S>,
+    k: K,
+    v: V,
+) -> Result<(), InconsistentCacheError>
 where
     K: Eq + Hash,
     V: Default + SubAssign + Ord,
@@ -389,12 +397,12 @@ where
             }
             Ordering::Less => {
                 // Error: not enough to subtract
-                Err(())
+                Err(InconsistentCacheError)
             }
         }
     } else {
         // Error: identity does not exist
-        Err(())
+        Err(InconsistentCacheError)
     }
 }
 

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -5345,8 +5345,10 @@ fn block_signatures() {
     };
 
     let last_vrf_input = LAST_VRF_INPUT.parse().unwrap();
-    let mut vrf_input = CheckpointVRF::default();
-    vrf_input.hash_prev_vrf = last_vrf_input;
+    let vrf_input = CheckpointVRF {
+        hash_prev_vrf: last_vrf_input,
+        checkpoint: 0,
+    };
 
     b.block_header.proof = BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap();
 
@@ -5532,15 +5534,17 @@ fn test_block_with_drpool_and_utxo_set<F: FnMut(&mut Block) -> bool>(
 
     let my_pkh = PublicKeyHash::default();
 
-    let mut txns = BlockTransactions::default();
-    txns.mint = MintTransaction::new(
-        current_epoch,
-        vec![ValueTransferOutput {
-            time_lock: 0,
-            pkh: my_pkh,
-            value: block_reward(current_epoch, INITIAL_BLOCK_REWARD, HALVING_PERIOD),
-        }],
-    );
+    let txns = BlockTransactions {
+        mint: MintTransaction::new(
+            current_epoch,
+            vec![ValueTransferOutput {
+                time_lock: 0,
+                pkh: my_pkh,
+                value: block_reward(current_epoch, INITIAL_BLOCK_REWARD, HALVING_PERIOD),
+            }],
+        ),
+        ..BlockTransactions::default()
+    };
 
     let mut block_header = BlockHeader::default();
     build_merkle_tree(&mut block_header, &txns);
@@ -5800,15 +5804,17 @@ fn block_difficult_proof() {
     };
     let my_pkh = PublicKeyHash::default();
 
-    let mut txns = BlockTransactions::default();
-    txns.mint = MintTransaction::new(
-        current_epoch,
-        vec![ValueTransferOutput {
-            time_lock: 0,
-            pkh: my_pkh,
-            value: block_reward(current_epoch, INITIAL_BLOCK_REWARD, HALVING_PERIOD),
-        }],
-    );
+    let txns = BlockTransactions {
+        mint: MintTransaction::new(
+            current_epoch,
+            vec![ValueTransferOutput {
+                time_lock: 0,
+                pkh: my_pkh,
+                value: block_reward(current_epoch, INITIAL_BLOCK_REWARD, HALVING_PERIOD),
+            }],
+        ),
+        ..BlockTransactions::default()
+    };
 
     let mut block_header = BlockHeader::default();
     build_merkle_tree(&mut block_header, &txns);
@@ -7253,15 +7259,17 @@ fn validate_block_transactions_uses_block_number_in_utxo_diff() {
         };
         let my_pkh = PublicKeyHash::default();
 
-        let mut txns = BlockTransactions::default();
-        txns.mint = MintTransaction::new(
-            current_epoch,
-            vec![ValueTransferOutput {
-                time_lock: 0,
-                pkh: my_pkh,
-                value: block_reward(current_epoch, INITIAL_BLOCK_REWARD, HALVING_PERIOD),
-            }],
-        );
+        let txns = BlockTransactions {
+            mint: MintTransaction::new(
+                current_epoch,
+                vec![ValueTransferOutput {
+                    time_lock: 0,
+                    pkh: my_pkh,
+                    value: block_reward(current_epoch, INITIAL_BLOCK_REWARD, HALVING_PERIOD),
+                }],
+            ),
+            ..BlockTransactions::default()
+        };
 
         let mut block_header = BlockHeader::default();
         build_merkle_tree(&mut block_header, &txns);
@@ -7483,8 +7491,10 @@ fn validate_commit_transactions_included_in_utxo_diff() {
 #[test]
 fn validate_required_tally_not_found() {
     let dr_pointer = Hash::default();
-    let mut dr_state = DataRequestState::default();
-    dr_state.stage = DataRequestStage::TALLY;
+    let dr_state = DataRequestState {
+        stage: DataRequestStage::TALLY,
+        ..DataRequestState::default()
+    };
 
     let mut dr_pool = DataRequestPool::default();
     dr_pool.data_request_pool.insert(dr_pointer, dr_state);

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -246,7 +246,7 @@ pub fn validate_rad_request(rad_request: &RADRequest) -> Result<(), failure::Err
     }
     for path in retrieval_paths {
         // If the sources are empty the data request is set as invalid
-        if path.url == "" {
+        if path.url.is_empty() {
             return Err(DataRequestError::NoRetrievalSources.into());
         }
         unpack_radon_script(path.script.as_slice())?;


### PR DESCRIPTION
Run `cargo +nightly clippy --all` and fix all the warnings. The Rust 1.49 update is scheduled for December 31st, but this PR can be merged now.

These are the new lints fixed by this PR:

https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_match
https://rust-lang.github.io/rust-clippy/master/index.html#comparison_to_empty
https://rust-lang.github.io/rust-clippy/master/index.html#field_reassign_with_default
https://rust-lang.github.io/rust-clippy/master/index.html#manual_range_contains
https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro
https://rust-lang.github.io/rust-clippy/master/index.html#result_unit_err
https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_wraps
