### PR TITLE
Allow to resync node using blocks from storage

### DIFF
--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -25,8 +25,8 @@ use crate::{
         chain_manager::{handlers::BlockBatches::*, BlockCandidate},
         messages::{
             AddBlocks, AddCandidates, AddCommitReveal, AddSuperBlock, AddSuperBlockVote,
-            AddTransaction, Broadcast, BuildDrt, BuildVtt, EpochNotification, GetBalance,
-            GetBlocksEpochRange, GetDataRequestInfo, GetHighestCheckpointBeacon,
+            AddTransaction, Broadcast, BuildDrt, BuildVtt, DeleteChainState, EpochNotification,
+            GetBalance, GetBlocksEpochRange, GetDataRequestInfo, GetHighestCheckpointBeacon,
             GetMemoryTransaction, GetMempool, GetMempoolResult, GetNodeStats, GetReputation,
             GetReputationResult, GetState, GetSuperBlockVotes, GetUtxoInfo, IsConfirmedBlock,
             PeersBeacons, ReputationStats, SendLastBeacon, SessionUnitResult, SetLastBeacon,
@@ -1644,6 +1644,15 @@ where
         candidate_blocks,
         remaining_blocks,
     ))
+}
+
+impl Handler<DeleteChainState> for ChainManager {
+    type Result = Result<(), failure::Error>;
+
+    fn handle(&mut self, _msg: DeleteChainState, ctx: &mut Self::Context) -> Self::Result {
+        self.delete_chain_state_and_reinitialize(ctx);
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -314,6 +314,7 @@ impl ChainManager {
         .into_actor(self)
         .and_then(|(), act, ctx| {
             log::info!("Successfully persisted empty chain state into storage");
+            act.update_state_machine(StateMachine::WaitingConsensus);
             act.initialize_from_storage(ctx);
             fut::ok(())
         })

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -366,6 +366,14 @@ impl Message for IsConfirmedBlock {
     type Result = Result<bool, failure::Error>;
 }
 
+/// Returns true if the provided block hash is the consolidated block for the provided epoch, and
+/// there exists a superblock with a majority of votes to confirm that.
+pub struct DeleteChainState;
+
+impl Message for DeleteChainState {
+    type Result = Result<(), failure::Error>;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // MESSAGES FROM CONNECTIONS MANAGER
 ////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR has two parts:

* Do not request blocks that are already in storage when synchronizing

Check if the node already has the blocks in the database and only request the missing ones. This alone is not very useful because the database only contains consolidated blocks, but it can be useful if we implement another way to add blocks to the database.

* Create deleteChainState JSON-RPC method

This new JSON-RPC method allows to reset the `ChainState` of the node, triggering a full resynchronization. This can be used to recover nodes that have a corrupted `ChainState`, or are missing some blocks or transactions. Note that all the blocks will be validated again so this process will take many hours, being only slightly faster than a normal re-sync.

This feature can also be useful to recover nodes that have consolidated a forked chain and cannot sync automatically.

Performance-wise this is not a good trade-off because it introduces a redundant read from the database that will never succeed for nodes that have never used deleteChainState.