### PR TITLE
feat(node): Show unconfirmed balance

### DIFF
--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -23,6 +23,7 @@ use witnet_data_structures::{
     },
     radon_report::RadonReport,
     transaction::{CommitTransaction, RevealTransaction, Transaction},
+    transaction_factory::NodeBalance,
     types::LastBeacon,
     utxo_pool::{UtxoInfo, UtxoSelectionStrategy},
 };
@@ -245,7 +246,7 @@ pub struct GetBalance {
 }
 
 impl Message for GetBalance {
-    type Result = Result<u64, failure::Error>;
+    type Result = Result<NodeBalance, failure::Error>;
 }
 
 /// Get Balance

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -345,7 +345,12 @@ pub enum Command {
     #[structopt(
         name = "balance",
         alias = "getBalance",
-        about = "Get total balance of the given account"
+        about = "Get the balance of the given account",
+        long_about = "Get the confirmed and pending balance of the given account:\n\n\
+                      
+                      Confirmed balance: balance that has been confirmed in a superblock by a majority of the network.\n\n\
+                      
+                      Pending balance: balance that is waiting to be confirmed. Negative amount corresponds to transactions sent by the given account."
     )]
     GetBalance {
         /// Socket address of the Witnet node to query


### PR DESCRIPTION
The cli command `balance` now shows the balance that has been confirmed (tx included in the superblock) and the balance that has not been confirmed yet.

It includes tests for get_total_balance

Closes #1814 