### PR TITLE
fix(radon): remove unwrap in CBOR encode hash function to avoid panics

### DIFF
--- a/node/tests/data_request_examples.rs
+++ b/node/tests/data_request_examples.rs
@@ -45,6 +45,7 @@ fn run_dr_locally_with_data(
     data: &[&str],
 ) -> Result<RadonTypes, failure::Error> {
     let mut retrieval_results = vec![];
+    assert_eq!(dr.data_request.retrieve.len(), data.len());
     for (r, d) in dr.data_request.retrieve.iter().zip(data.iter()) {
         log::info!("Running retrieval for {}", r.url);
         retrieval_results.push(witnet_rad::run_retrieval_with_data(

--- a/rad/src/reducers/mode.rs
+++ b/rad/src/reducers/mode.rs
@@ -164,4 +164,17 @@ mod tests {
         let output = mode(&input).unwrap();
         assert_eq!(output, expected);
     }
+
+    #[test]
+    fn test_mode_big_number() {
+        let input = RadonArray::from(vec![
+            RadonInteger::from(18446744073709551616).into(),
+            RadonInteger::from(18446744073709551616).into(),
+            RadonInteger::from(2).into(),
+        ]);
+
+        let expected = RadonTypes::from(RadonInteger::from(18446744073709551616));
+        let output = mode(&input).unwrap();
+        assert_eq!(output, expected);
+    }
 }


### PR DESCRIPTION
Co-authored-by: Tomasz Polaczyk <tmpolaczyk@gmail.com>