### PR TITLE
feat(jsonrpc): add confirmed flag to getTransaction method

### DIFF
--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -566,7 +566,7 @@ pub struct GetItemTransaction {
 }
 
 impl Message for GetItemTransaction {
-    type Result = Result<(Transaction, PointerToBlock), InventoryManagerError>;
+    type Result = Result<(Transaction, PointerToBlock, Epoch), InventoryManagerError>;
 }
 
 /// Ask for a superblock identified by its index


### PR DESCRIPTION
Close #1828 

Just like the `getBlock` method, now the result of `getTransaction` includes a "confirmed" field. This field is set to `true` if the block that includes this transaction has been confirmed by a superblock, and `false` otherwise.