### PR TITLE
fix(node): do not clear all reveals on new consolidated block

### DIFF
--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -803,7 +803,8 @@ pub fn build_block(
     let (commit_txns, commits_fees, solved_dr_pointers) = transactions_pool.remove_commits(dr_pool);
     transaction_fees += commits_fees;
 
-    let (reveal_txns, reveals_fees) = transactions_pool.remove_reveals(dr_pool);
+    let (reveal_txns, reveals_fees) = transactions_pool.get_reveals(dr_pool);
+    let reveal_txns: Vec<RevealTransaction> = reveal_txns.into_iter().cloned().collect();
     transaction_fees += reveals_fees;
 
     // Calculate data request not solved weight

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -2122,6 +2122,8 @@ fn update_pools(
         if let Err(e) = data_request_pool.process_tally(&ta_tx, &block.hash()) {
             log::error!("Error processing tally transaction:\n{}", e);
         }
+
+        transactions_pool.clear_reveals_from_finished_dr(&ta_tx.dr_pointer);
     }
 
     for vt_tx in &block.txns.value_transfer_txns {
@@ -2162,10 +2164,8 @@ fn update_pools(
         if let Err(e) = data_request_pool.process_reveal(&re_tx, &block.hash()) {
             log::error!("Error processing reveal transaction:\n{}", e);
         }
+        transactions_pool.remove_one_reveal(&re_tx.body.dr_pointer, &re_tx.body.pkh, &re_tx.hash());
     }
-
-    // Remove reveals because they expire every consolidated block
-    transactions_pool.clear_reveals();
 
     // Update own_utxos
     utxo_diff.visit(


### PR DESCRIPTION
This implements the fix described in https://github.com/witnet/witnet-rust/issues/1827#issuecomment-762849747