### PR TITLE
feat(wallet): allow to avoid using unconfirmed UTXOs in transactions

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -899,6 +899,8 @@ pub struct Wallet {
     /// Length of the batch of transient addresses to be used for synchronization purposes
     /// (e.g. for re-importing a wallet with seed phrase).
     pub sync_address_batch_length: u16,
+    /// Allow to use outputs that have not been confirmed by a superblock in new transactions
+    pub use_unconfirmed_utxos: bool,
 }
 
 impl Wallet {
@@ -945,6 +947,9 @@ impl Wallet {
             sync_address_batch_length: config
                 .sync_address_batch_length
                 .unwrap_or_else(|| defaults.wallet_sync_address_batch_length()),
+            use_unconfirmed_utxos: config
+                .use_unconfirmed_utxos
+                .unwrap_or_else(|| defaults.wallet_use_unconfirmed_utxos()),
         }
     }
 
@@ -967,6 +972,7 @@ impl Wallet {
             session_expires_in: Some(self.session_expires_in),
             requests_timeout: Some(self.requests_timeout),
             sync_address_batch_length: Some(self.sync_address_batch_length),
+            use_unconfirmed_utxos: Some(self.use_unconfirmed_utxos),
         }
     }
 }

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -373,6 +373,10 @@ pub trait Defaults {
         20
     }
 
+    fn wallet_use_unconfirmed_utxos(&self) -> bool {
+        true
+    }
+
     fn rocksdb_create_if_missing(&self) -> bool {
         true
     }

--- a/wallet/src/actors/app/error.rs
+++ b/wallet/src/actors/app/error.rs
@@ -115,12 +115,18 @@ impl From<actors::worker::Error> for Error {
             actors::worker::Error::KeyGen(e @ crypto::Error::InvalidKeyPath(_)) => {
                 validation_error(field_error("seedData", e.to_string()))
             }
-            actors::worker::Error::Repository(_e @ repository::Error::InsufficientBalance) => {
-                validation_error(field_error(
-                    "balance",
-                    "Wallet account has not enough balance",
-                ))
-            }
+            actors::worker::Error::Repository(repository::Error::InsufficientBalance {
+                total_balance,
+                available_balance,
+                transaction_value,
+            }) => validation_error(field_error(
+                json! {{
+                    "total_balance": total_balance,
+                    "available_balance": available_balance,
+                    "transaction_value": transaction_value,
+                }},
+                "Wallet account has not enough balance",
+            )),
             actors::worker::Error::JsonRpcTimeoutError => Error::JsonRpcTimeoutError,
             _ => internal_error(err),
         }

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -82,6 +82,9 @@ pub fn run(conf: Config) -> Result<(), Error> {
     // Size of the address synchronization batch
     let sync_address_batch_length = conf.wallet.sync_address_batch_length;
 
+    // Allow to use outputs that have not been confirmed by a superblock in new transactions
+    let use_unconfirmed_utxos = conf.wallet.use_unconfirmed_utxos;
+
     let system = System::new();
 
     let node_jsonrpc_server_address = conf.jsonrpc.server_address;
@@ -138,6 +141,7 @@ pub fn run(conf: Config) -> Result<(), Error> {
             max_vt_weight,
             max_dr_weight,
             consensus_constants,
+            use_unconfirmed_utxos,
         };
 
         let last_beacon = Arc::new(RwLock::new(CheckpointBeacon {

--- a/wallet/src/params.rs
+++ b/wallet/src/params.rs
@@ -29,6 +29,7 @@ pub struct Params {
     pub max_vt_weight: u32,
     pub max_dr_weight: u32,
     pub consensus_constants: ConsensusConstants,
+    pub use_unconfirmed_utxos: bool,
 }
 
 #[derive(Clone)]

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -1230,10 +1230,16 @@ where
         utxo_strategy: &UtxoSelectionStrategy,
         max_weight: u32,
     ) -> Result<(Vec<Input>, Vec<ValueTransferOutput>)> {
+        let empty_hashset = HashSet::default();
+        let unconfirmed_transactions = if self.params.use_unconfirmed_utxos {
+            &empty_hashset
+        } else {
+            &state.pending_transactions
+        };
         let mut wallet_utxos = WalletUtxos {
             utxo_set: &state.utxo_set,
             used_outputs: &mut state.used_outputs,
-            unconfirmed_transactions: &state.pending_transactions,
+            unconfirmed_transactions,
         };
 
         let tx_info = wallet_utxos.build_inputs_outputs(
@@ -1403,10 +1409,16 @@ where
             Transaction::Mint(_) => None,
         };
 
+        let empty_hashset = HashSet::default();
+        let unconfirmed_transactions = if self.params.use_unconfirmed_utxos {
+            &empty_hashset
+        } else {
+            &state.pending_transactions
+        };
         let mut wallet_utxos = WalletUtxos {
             utxo_set: &state.utxo_set,
             used_outputs: &mut state.used_outputs,
-            unconfirmed_transactions: &state.pending_transactions,
+            unconfirmed_transactions,
         };
         if let Some(inputs) = inputs {
             wallet_utxos.set_used_output_pointer(inputs, timestamp + tx_pending_timeout);

--- a/wallet/src/repository/wallet/state.rs
+++ b/wallet/src/repository/wallet/state.rs
@@ -67,6 +67,8 @@ pub struct State {
     /// List of pending balance movements, waiting to be confirmed with a superblock
     ///  This is a hashmap from pending_block_hash to (Vec<BalanceMovement).
     pub pending_movements: HashMap<String, Vec<model::BalanceMovement>>,
+    /// Transactions that affect the utxo_set but have not been confirmed with a superblock yet.
+    pub pending_transactions: HashSet<Hash>,
     /// Next transaction identifier of the wallet
     pub transaction_next_id: u32,
     /// Current UTXO set (including pending movements)
@@ -105,6 +107,7 @@ impl State {
         self.pending_blocks.clear();
         self.pending_dr_movements.clear();
         self.pending_movements.clear();
+        self.pending_transactions.clear();
         self.transaction_next_id = Default::default();
         self.utxo_set.clear();
         self.used_outputs.clear();

--- a/wallet/src/repository/wallet/tests/factories.rs
+++ b/wallet/src/repository/wallet/tests/factories.rs
@@ -63,6 +63,7 @@ fn wallet_inner(
             initial_block_reward: 250 * 1_000_000_000,
             halving_period: 3_500_000,
         },
+        use_unconfirmed_utxos: true,
     };
     let mnemonic = mnemonic::MnemonicGen::new()
         .with_len(mnemonic::Length::Words12)

--- a/wallet/src/repository/wallet/tests/mod.rs
+++ b/wallet/src/repository/wallet/tests/mod.rs
@@ -343,9 +343,10 @@ fn test_create_transaction_components_when_wallet_have_no_utxos() {
         )
         .unwrap_err();
 
-    assert_eq!(
-        mem::discriminant(&repository::Error::InsufficientBalance),
-        mem::discriminant(&err)
+    assert!(
+        matches!(err, repository::Error::InsufficientBalance { .. }),
+        "{:?}",
+        err
     );
 }
 
@@ -1244,11 +1245,10 @@ fn test_create_vtt_with_locked_balance() {
         })
         .unwrap_err();
 
-    assert_eq!(
-        mem::discriminant(&repository::Error::InsufficientBalance),
-        mem::discriminant(&err),
+    assert!(
+        matches!(err, repository::Error::InsufficientBalance { .. }),
         "{:?}",
-        err,
+        err
     );
 }
 
@@ -1529,11 +1529,10 @@ fn test_create_vt_components_weighted_fee_3() {
         )
         .unwrap_err();
 
-    assert_eq!(
-        mem::discriminant(&repository::Error::InsufficientBalance),
-        mem::discriminant(&err),
+    assert!(
+        matches!(err, repository::Error::InsufficientBalance { .. }),
         "{:?}",
-        err,
+        err
     );
 }
 
@@ -1841,11 +1840,10 @@ fn test_create_vt_components_weighted_fee_without_outputs() {
         )
         .unwrap_err();
 
-    assert_eq!(
-        mem::discriminant(&repository::Error::InsufficientBalance),
-        mem::discriminant(&err),
+    assert!(
+        matches!(err, repository::Error::InsufficientBalance { .. }),
         "{:?}",
-        err,
+        err
     );
 }
 
@@ -2058,11 +2056,10 @@ fn test_create_dr_components_weighted_fee_2_not_enough_funds() {
         .create_dr_transaction_components(&mut state, request, fee, FeeType::Weighted)
         .unwrap_err();
 
-    assert_eq!(
-        mem::discriminant(&repository::Error::InsufficientBalance),
-        mem::discriminant(&err),
+    assert!(
+        matches!(err, repository::Error::InsufficientBalance { .. }),
         "{:?}",
-        err,
+        err
     );
 }
 
@@ -2201,11 +2198,10 @@ fn test_create_dr_components_weighted_fee_without_outputs() {
         .create_dr_transaction_components(&mut state, request, fee, FeeType::Weighted)
         .unwrap_err();
 
-    assert_eq!(
-        mem::discriminant(&repository::Error::InsufficientBalance),
-        mem::discriminant(&err),
+    assert!(
+        matches!(err, repository::Error::InsufficientBalance { .. }),
         "{:?}",
-        err,
+        err
     );
 }
 
@@ -2523,10 +2519,9 @@ fn test_create_transaction_components_filter_from_address_3() {
         )
         .unwrap_err();
 
-    assert_eq!(
-        mem::discriminant(&repository::Error::InsufficientBalance),
-        mem::discriminant(&err),
+    assert!(
+        matches!(err, repository::Error::InsufficientBalance { .. }),
         "{:?}",
-        err,
+        err
     );
 }


### PR DESCRIPTION
Close #1832 

Keep track of the transactions that modify the utxo set but are not confirmed yet, so that we can ignore unconfirmed utxo when selecting utxos for a new transaction.

This feature is disabled by default, can be enabled by setting

    wallet.use_unconfirmed_utxos = false

in witnet.toml