### PR TITLE
fix(wallet): fix show transactions after resync

### DIFF
--- a/wallet/src/actors/worker/handlers/handle_block.rs
+++ b/wallet/src/actors/worker/handlers/handle_block.rs
@@ -18,6 +18,6 @@ impl Handler<HandleBlockRequest> for worker::Worker {
     type Result = <HandleBlockRequest as Message>::Result;
 
     fn handle(&mut self, msg: HandleBlockRequest, _ctx: &mut Self::Context) -> Self::Result {
-        self.handle_block(msg.block, false, false, msg.wallet, msg.sink)
+        self.handle_block(msg.block, false, msg.wallet, msg.sink)
     }
 }

--- a/wallet/src/actors/worker/handlers/sync.rs
+++ b/wallet/src/actors/worker/handlers/sync.rs
@@ -17,6 +17,6 @@ impl Handler<SyncRequest> for worker::Worker {
     type Result = <SyncRequest as Message>::Result;
 
     fn handle(&mut self, msg: SyncRequest, _ctx: &mut Self::Context) -> Self::Result {
-        self.sync(&msg.wallet_id, &msg.wallet, msg.sink, false)
+        self.sync(&msg.wallet_id, &msg.wallet, msg.sink)
     }
 }

--- a/wallet/src/repository/wallet/tests/mod.rs
+++ b/wallet/src/repository/wallet/tests/mod.rs
@@ -677,7 +677,7 @@ fn test_index_transaction_output_affects_balance() {
     let body = VTTransactionBody::new(inputs, outputs);
 
     wallet
-        .index_block_transactions(&block, &[vtt_from_body(body)], true, false)
+        .index_block_transactions(&block, &[vtt_from_body(body)], true)
         .unwrap();
 
     assert_eq!(
@@ -729,10 +729,10 @@ fn test_index_transaction_input_affects_balance() {
     );
 
     wallet
-        .index_block_transactions(&a_block, &[vtt_from_body(txn1)], true, false)
+        .index_block_transactions(&a_block, &[vtt_from_body(txn1)], true)
         .unwrap();
     wallet
-        .index_block_transactions(&a_block, &[vtt_from_body(txn2)], true, false)
+        .index_block_transactions(&a_block, &[vtt_from_body(txn2)], true)
         .unwrap();
 
     assert_eq!(
@@ -742,43 +742,6 @@ fn test_index_transaction_input_affects_balance() {
         },
         db.get(&keys::account_balance(0)).unwrap()
     );
-}
-
-#[test]
-fn test_index_transaction_does_not_duplicate_transactions() {
-    let account = 0;
-    let (wallet, db) = factories::wallet(None);
-
-    assert_eq!(
-        0,
-        db.get_or_default(&keys::transaction_next_id(account))
-            .unwrap()
-    );
-
-    let value = 1u64;
-    let address = wallet.gen_external_address(None).unwrap();
-    let block = factories::BlockInfo::default().create();
-    let inputs = vec![Input::default()];
-    let outputs = vec![ValueTransferOutput {
-        pkh: address.pkh,
-        value,
-        time_lock: 0,
-    }];
-    let txn = VTTransactionBody::new(inputs, outputs);
-
-    wallet
-        .index_block_transactions(
-            &block,
-            &[factories::vtt_from_body(txn.clone())],
-            true,
-            false,
-        )
-        .unwrap();
-    wallet
-        .index_block_transactions(&block, &[factories::vtt_from_body(txn)], true, false)
-        .unwrap();
-
-    assert_eq!(1, db.get(&keys::transaction_next_id(account)).unwrap());
 }
 
 #[test]
@@ -807,7 +770,7 @@ fn test_index_transaction_updates_address_info() {
     let vtt0_hash = vtt0.transaction.hash();
 
     wallet
-        .index_block_transactions(&block, &[vtt0], true, false)
+        .index_block_transactions(&block, &[vtt0], true)
         .unwrap();
 
     let address_updated = wallet
@@ -852,7 +815,7 @@ fn test_index_transaction_updates_address_info_two_outputs_same_address() {
     let vtt0_hash = vtt0.transaction.hash();
 
     wallet
-        .index_block_transactions(&block, &[vtt0], true, false)
+        .index_block_transactions(&block, &[vtt0], true)
         .unwrap();
 
     let address_updated = wallet
@@ -910,7 +873,7 @@ fn test_index_transaction_updates_address_info_two_transactions_same_address() {
     assert_ne!(vtt0_hash, vtt1_hash);
 
     wallet
-        .index_block_transactions(&block, &[vtt0, vtt1], true, false)
+        .index_block_transactions(&block, &[vtt0, vtt1], true)
         .unwrap();
 
     let address_updated = wallet
@@ -946,7 +909,7 @@ fn test_index_transaction_errors_if_balance_overflow() {
     let txn = VTTransactionBody::new(inputs, outputs);
 
     let err = wallet
-        .index_block_transactions(&block, &[factories::vtt_from_body(txn)], true, false)
+        .index_block_transactions(&block, &[factories::vtt_from_body(txn)], true)
         .unwrap_err();
 
     assert_eq!(
@@ -976,7 +939,6 @@ fn test_index_transaction_vtt_created_by_wallet() {
                 }],
             ))],
             true,
-            false,
         )
         .unwrap();
 
@@ -1002,7 +964,7 @@ fn test_index_transaction_vtt_created_by_wallet() {
 
     // index another block confirming the previously created vtt
     wallet
-        .index_block_transactions(&a_block, &[factories::vtt_from_body(vtt.body)], true, false)
+        .index_block_transactions(&a_block, &[factories::vtt_from_body(vtt.body)], true)
         .unwrap();
 
     // check that indeed, the previously created vtt now has a block associated with it
@@ -1082,7 +1044,6 @@ fn test_get_transaction() {
                 }],
             ))],
             true,
-            false,
         )
         .unwrap();
 
@@ -1115,7 +1076,7 @@ fn test_get_transaction() {
 
     // index another block confirming the previously created vtt
     wallet
-        .index_block_transactions(&a_block, &[factories::vtt_from_body(vtt.body)], true, false)
+        .index_block_transactions(&a_block, &[factories::vtt_from_body(vtt.body)], true)
         .unwrap();
     assert!(wallet.get_transaction(0, 1).is_ok());
 }
@@ -1149,7 +1110,6 @@ fn test_get_transactions() {
                 }],
             ))],
             true,
-            false,
         )
         .unwrap();
 
@@ -1189,7 +1149,7 @@ fn test_get_transactions() {
 
     // index another block confirming the previously created vtt
     wallet
-        .index_block_transactions(&a_block, &[factories::vtt_from_body(vtt.body)], true, false)
+        .index_block_transactions(&a_block, &[factories::vtt_from_body(vtt.body)], true)
         .unwrap();
     let x = wallet.transactions(0, 2).unwrap();
     assert_eq!(x.transactions.len(), 2);
@@ -1226,7 +1186,6 @@ fn test_create_vtt_with_locked_balance() {
                 }],
             ))],
             true,
-            false,
         )
         .unwrap();
 
@@ -1280,7 +1239,6 @@ fn test_create_vtt_with_multiple_outputs() {
                 }],
             ))],
             true,
-            false,
         )
         .unwrap();
 


### PR DESCRIPTION
Closes #1818

- Removes `resynchronization` flag
- Reuses a `needs_indexing` flag in `handle_block` function (single entry point for sync, resync and new block from node)
- Updates tests