### PR TITLE
fix(rad): fix deserialization of nested JSON booleans

### DIFF
--- a/rad/src/operators/string.rs
+++ b/rad/src/operators/string.rs
@@ -156,7 +156,8 @@ fn json_to_cbor(value: &json::JsonValue) -> Value {
             }
         }
         json::JsonValue::String(value) => Value::Text(String::from(value.as_str())),
-        _ => Value::Null,
+        json::JsonValue::Boolean(b) => Value::Bool(*b),
+        json::JsonValue::Null => Value::Null,
     }
 }
 
@@ -671,6 +672,21 @@ mod tests {
         assert_eq!(expected_f64, 0.0);
         // And the expected CBOR value is a float, not an integer
         let expected_cbor = serde_cbor::Value::Float(expected_f64);
+        assert_eq!(resulting_cbor, expected_cbor);
+    }
+
+    #[test]
+    fn test_json_numbers_to_cbor_booleans() {
+        use json::JsonValue;
+
+        let json = JsonValue::Boolean(false);
+        let resulting_cbor = json_to_cbor(&json);
+        let expected_cbor = serde_cbor::Value::Bool(false);
+        assert_eq!(resulting_cbor, expected_cbor);
+
+        let json = JsonValue::Boolean(true);
+        let resulting_cbor = json_to_cbor(&json);
+        let expected_cbor = serde_cbor::Value::Bool(true);
         assert_eq!(resulting_cbor, expected_cbor);
     }
 }

--- a/rad/src/operators/string.rs
+++ b/rad/src/operators/string.rs
@@ -182,6 +182,21 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_json_map_with_null_entries() {
+        // When parsing a JSON map, any keys with value `null` are ignored
+        let json_map = RadonString::from(r#"{ "Hello": "world", "Bye": null }"#);
+        let output = parse_json_map(&json_map).unwrap();
+
+        let key = "Hello";
+        let value = RadonTypes::String(RadonString::from("world"));
+        let mut map = HashMap::new();
+        map.insert(key.to_string(), value);
+        let expected_output = RadonMap::from(map);
+
+        assert_eq!(output, expected_output);
+    }
+
+    #[test]
     fn test_parse_json_map_fail() {
         let invalid_json = RadonString::from(r#"{ "Hello":  }"#);
         let output = parse_json_map(&invalid_json).unwrap_err();
@@ -203,6 +218,21 @@ mod tests {
     #[test]
     fn test_parse_json_array() {
         let json_array = RadonString::from(r#"[1,2,3]"#);
+        let output = parse_json_array(&json_array).unwrap();
+
+        let expected_output = RadonArray::from(vec![
+            RadonTypes::Integer(RadonInteger::from(1)),
+            RadonTypes::Integer(RadonInteger::from(2)),
+            RadonTypes::Integer(RadonInteger::from(3)),
+        ]);
+
+        assert_eq!(output, expected_output);
+    }
+
+    #[test]
+    fn test_parse_json_array_with_null_entries() {
+        // When parsing a JSON array, any elements with value `null` are ignored
+        let json_array = RadonString::from(r#"[null, 1, null, null, 2, 3, null]"#);
         let output = parse_json_array(&json_array).unwrap();
 
         let expected_output = RadonArray::from(vec![


### PR DESCRIPTION
Before this PR, a data request that tries to parse `"[true]"` using `StringParseJSONArray` will return an empty RadonArray. That's because booleans are mapped to null because of a missing conversion. This PR fixes this by adding that missing conversion.

Since there is no RadonNull type, all null fields are silently ignored when parsing arrays and maps using `StringParseJSON`. Added a few tests to document this behavior.