### PR TITLE
fix(config): change ice period to 4 h

### DIFF
--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -84,7 +84,7 @@ pub trait Defaults {
     /// Period in seconds for a potential peer address to be kept "iced", i.e. will not be tried
     /// again before that amount of time.
     fn connections_bucketing_ice_period(&self) -> Duration {
-        Duration::from_secs(86400) // 24 hours
+        Duration::from_secs(14400) // 4 hours
     }
 
     /// Period that indicate the validity of a checked peer


### PR DESCRIPTION
this PR changes the `bucketing_ice_period_duration` to 4 hours