### PR TITLE
Rewind

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1067,6 +1067,7 @@ where
     }
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn from_millis<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
 where
     D: Deserializer<'de>,
@@ -1087,6 +1088,7 @@ where
     }
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn from_secs<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
 where
     D: Deserializer<'de>,

--- a/net/src/client/tcp/actors/jsonrpc.rs
+++ b/net/src/client/tcp/actors/jsonrpc.rs
@@ -377,7 +377,10 @@ impl StreamHandler<Result<NotifySubscriptionId, Error>> for JsonRpcClient {
 fn is_connection_error(err: &Error) -> bool {
     match err {
         Error::RequestFailed { error_kind, .. } => {
-            matches!(error_kind, TransportErrorKind::Transport(_) | TransportErrorKind::Unreachable)
+            matches!(
+                error_kind,
+                TransportErrorKind::Transport(_) | TransportErrorKind::Unreachable
+            )
         }
         Error::RequestTimedOut(_) => true,
         Error::Mailbox(_) => true,

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -232,7 +232,7 @@ impl ChainManager {
                 if chain_info.highest_block_checkpoint.hash_prev_block == consensus_constants.bootstrap_hash {
                     // Create genesis block
                     // TODO: consolidating the genesis block is not needed if the chain state has
-                    // been reset because of a rollback
+                    // been reset because of a rewind
                     let info_genesis =
                         GenesisBlockInfo::from_path(&config.mining.genesis_path, consensus_constants.bootstrap_hash, consensus_constants.genesis_hash)
                             .map_err(|e| {

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -32,7 +32,7 @@ use crate::{
             GetBlocksEpochRange, GetDataRequestInfo, GetHighestCheckpointBeacon,
             GetMemoryTransaction, GetMempool, GetMempoolResult, GetNodeStats, GetReputation,
             GetReputationResult, GetState, GetSuperBlockVotes, GetUtxoInfo, IsConfirmedBlock,
-            PeersBeacons, ReputationStats, Rollback, SendLastBeacon, SessionUnitResult,
+            PeersBeacons, ReputationStats, Rewind, SendLastBeacon, SessionUnitResult,
             SetLastBeacon, SetPeersLimits, TryMineBlock,
         },
         sessions_manager::SessionsManager,
@@ -230,7 +230,7 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
             });
         }
 
-        // Include value transfers and data requests that were recovered from a rollback
+        // Include value transfers and data requests that were recovered from a rewind
         if !self.temp_vts_and_drs.is_empty() && self.sm_state == StateMachine::Synced {
             let max_txs = std::cmp::min(
                 self.max_reinserted_transactions,
@@ -1546,10 +1546,10 @@ impl Handler<IsConfirmedBlock> for ChainManager {
     }
 }
 
-impl Handler<Rollback> for ChainManager {
+impl Handler<Rewind> for ChainManager {
     type Result = Result<bool, failure::Error>;
 
-    fn handle(&mut self, msg: Rollback, ctx: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: Rewind, ctx: &mut Self::Context) -> Self::Result {
         // Save list of blocks that are known to be valid
         let old_block_chain: VecDeque<(Epoch, Hash)> = self
             .chain_state

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -355,13 +355,13 @@ impl ChainManager {
                 match res {
                     Ok(Ok(block)) => {
                         log::info!(
-                            "ROLLBACK [{}/{}] Got block {} from storage",
+                            "REWIND [{}/{}] Got block {} from storage",
                             epoch,
                             last_epoch,
                             hash
                         );
                         act.process_requested_block(ctx, block, true)
-                            .expect("sync from storage fail");
+                            .expect("resync from storage fail");
                         // Recursion
                         act.resync_from_storage(block_list, ctx, done);
                     }

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -31,7 +31,7 @@ use crate::{
             GetBlocksEpochRange, GetConsolidatedPeers, GetDataRequestInfo, GetEpoch,
             GetHighestCheckpointBeacon, GetItemBlock, GetItemSuperblock, GetItemTransaction,
             GetKnownPeers, GetMemoryTransaction, GetMempool, GetNodeStats, GetReputation, GetState,
-            GetUtxoInfo, InitializePeers, IsConfirmedBlock, Rollback,
+            GetUtxoInfo, InitializePeers, IsConfirmedBlock, Rewind,
         },
         peers_manager::PeersManager,
         sessions_manager::SessionsManager,
@@ -214,12 +214,12 @@ pub fn jsonrpc_io_handler(
             |_params| initialize_peers(),
         )))
     });
-    io.add_method("rollback", move |params| {
+    io.add_method("rewind", move |params| {
         Compat::new(Box::pin(call_if_authorized(
             enable_sensitive_methods,
-            "rollback",
+            "rewind",
             params,
-            |params| rollback(params.parse()),
+            |params| rewind(params.parse()),
         )))
     });
 
@@ -1451,8 +1451,8 @@ pub async fn get_consensus_constants(params: Result<(), jsonrpc_core::Error>) ->
         .await
 }
 
-/// Initialize peers
-pub async fn rollback(params: Result<(Epoch,), jsonrpc_core::Error>) -> JsonRpcResult {
+/// Rewind
+pub async fn rewind(params: Result<(Epoch,), jsonrpc_core::Error>) -> JsonRpcResult {
     let epoch = match params {
         Ok((epoch,)) => epoch,
         Err(e) => return Err(e),
@@ -1460,7 +1460,7 @@ pub async fn rollback(params: Result<(Epoch,), jsonrpc_core::Error>) -> JsonRpcR
 
     let chain_manager_addr = ChainManager::from_registry();
     chain_manager_addr
-        .send(Rollback { epoch })
+        .send(Rewind { epoch })
         .map(|res| {
             res.map_err(internal_error)
                 .and_then(|success| match success {
@@ -1873,7 +1873,7 @@ mod tests {
                 "masterKeyExport",
                 "nodeStats",
                 "peers",
-                "rollback",
+                "rewind",
                 "sendRequest",
                 "sendValue",
                 "sign",
@@ -1905,7 +1905,7 @@ mod tests {
             "getUtxoInfo",
             "initializePeers",
             "masterKeyExport",
-            "rollback",
+            "rewind",
             "sendRequest",
             "sendValue",
             "sign",

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -1023,6 +1023,19 @@ impl Message for SetLastBeacon {
     type Result = ();
 }
 
+/// Set the outbound limit
+#[derive(Clone, Debug)]
+pub struct SetPeersLimits {
+    /// Inbound peers limit
+    pub inbound: u16,
+    /// Outbound peers limit
+    pub outbound: u16,
+}
+
+impl Message for SetPeersLimits {
+    type Result = ();
+}
+
 // JsonRpcServer messages (notifications)
 
 /// New block notification

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -366,13 +366,13 @@ impl Message for IsConfirmedBlock {
     type Result = Result<bool, failure::Error>;
 }
 
-/// Rollback
-pub struct Rollback {
+/// Rewind
+pub struct Rewind {
     /// Epoch
     pub epoch: u32,
 }
 
-impl Message for Rollback {
+impl Message for Rewind {
     type Result = Result<bool, failure::Error>;
 }
 

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -366,6 +366,16 @@ impl Message for IsConfirmedBlock {
     type Result = Result<bool, failure::Error>;
 }
 
+/// Rollback
+pub struct Rollback {
+    /// Epoch
+    pub epoch: u32,
+}
+
+impl Message for Rollback {
+    type Result = Result<bool, failure::Error>;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // MESSAGES FROM CONNECTIONS MANAGER
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/node/src/actors/sessions_manager/handlers.rs
+++ b/node/src/actors/sessions_manager/handlers.rs
@@ -19,7 +19,7 @@ use crate::actors::{
         AddConsolidatedPeer, AddPeers, Anycast, Broadcast, Consolidate, Create, DropOutboundPeers,
         EpochNotification, GetConsolidatedPeers, LogMessage, NumSessions, NumSessionsResult,
         PeerBeacon, Register, RemoveAddressesFromTried, SessionsUnitResult, SetLastBeacon,
-        TryMineBlock, Unregister,
+        SetPeersLimits, TryMineBlock, Unregister,
     },
     peers_manager::PeersManager,
     session::Session,
@@ -478,5 +478,14 @@ impl Handler<DropOutboundPeers> for SessionsManager {
 
     fn handle(&mut self, msg: DropOutboundPeers, _ctx: &mut Context<Self>) -> Self::Result {
         self.drop_outbound_peers(msg.peers_to_drop.as_ref());
+    }
+}
+impl Handler<SetPeersLimits> for SessionsManager {
+    type Result = <DropOutboundPeers as Message>::Result;
+
+    fn handle(&mut self, msg: SetPeersLimits, _ctx: &mut Context<Self>) -> Self::Result {
+        self.sessions.set_limits(msg.inbound, msg.outbound);
+        // Drop all inbound and outbound peers to avoid being above the new limit
+        self.drop_all_peers();
     }
 }

--- a/node/src/actors/sessions_manager/mod.rs
+++ b/node/src/actors/sessions_manager/mod.rs
@@ -289,6 +289,16 @@ impl SessionsManager {
             }
         }
     }
+
+    /// Drop all peers
+    fn drop_all_peers(&mut self) {
+        for (_peer, a) in self.sessions.inbound_consolidated.collection.iter() {
+            a.reference.do_send(CloseSession);
+        }
+        for (_peer, a) in self.sessions.outbound_consolidated.collection.iter() {
+            a.reference.do_send(CloseSession);
+        }
+    }
 }
 
 /// Required traits for being able to retrieve SessionsManager address from registry

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -476,7 +476,7 @@ mod tests {
         fn ignore_invalid_fn(_: RadError, _: &[u8], _: &()) -> Option<RadonReport<RadonTypes>> {
             None
         }
-        #[allow(clippy::trivially_copy_pass_by_ref)]
+        #[allow(clippy::trivially_copy_pass_by_ref, clippy::unnecessary_wraps)]
         fn malformed_reveal_fn(_: RadError, _: &[u8], _: &()) -> Option<RadonReport<RadonTypes>> {
             Some(RadonReport::from_result(
                 Err(RadError::MalformedReveal),

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -21,9 +21,9 @@ use witnet_crypto::{
 };
 use witnet_data_structures::{
     chain::{
-        Block, ConsensusConstants, DataRequestInfo, DataRequestOutput, Environment, KeyedSignature,
-        NodeStats, OutputPointer, PublicKey, PublicKeyHash, StateMachine, SyncStatus,
-        ValueTransferOutput,
+        Block, ConsensusConstants, DataRequestInfo, DataRequestOutput, Environment, Epoch,
+        KeyedSignature, NodeStats, OutputPointer, PublicKey, PublicKeyHash, StateMachine,
+        SyncStatus, ValueTransferOutput,
     },
     proto::ProtobufConvert,
     transaction::Transaction,
@@ -1132,6 +1132,27 @@ pub fn initialize_peers(addr: SocketAddr) -> Result<(), failure::Error> {
         println!("Successfully cleared peers from buckets and initialized to config");
     } else {
         bail!("Failed to clear and initializepeers");
+    }
+
+    Ok(())
+}
+
+pub fn rollback(addr: SocketAddr, epoch: Epoch) -> Result<(), failure::Error> {
+    let mut stream = start_client(addr)?;
+
+    let params = (epoch,);
+    let request = format!(
+        r#"{{"jsonrpc": "2.0","method": "rollback", "params": {}, "id": "1"}}"#,
+        serde_json::to_string(&params)?
+    );
+
+    let response = send_request(&mut stream, &request)?;
+    let response: bool = parse_response(&response)?;
+    if response {
+        println!("Started rollback process up to epoch {}.", params.0);
+        println!("Use the nodeStats command to check the progress.");
+    } else {
+        bail!("Failed to rollback chain");
     }
 
     Ok(())

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -1137,22 +1137,22 @@ pub fn initialize_peers(addr: SocketAddr) -> Result<(), failure::Error> {
     Ok(())
 }
 
-pub fn rollback(addr: SocketAddr, epoch: Epoch) -> Result<(), failure::Error> {
+pub fn rewind(addr: SocketAddr, epoch: Epoch) -> Result<(), failure::Error> {
     let mut stream = start_client(addr)?;
 
     let params = (epoch,);
     let request = format!(
-        r#"{{"jsonrpc": "2.0","method": "rollback", "params": {}, "id": "1"}}"#,
+        r#"{{"jsonrpc": "2.0","method": "rewind", "params": {}, "id": "1"}}"#,
         serde_json::to_string(&params)?
     );
 
     let response = send_request(&mut stream, &request)?;
     let response: bool = parse_response(&response)?;
     if response {
-        println!("Started rollback process up to epoch {}.", params.0);
+        println!("Started rewind process up to epoch {}.", params.0);
         println!("Use the nodeStats command to check the progress.");
     } else {
-        bail!("Failed to rollback chain");
+        bail!("Failed to rewind chain");
     }
 
     Ok(())

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -8,6 +8,7 @@ use std::{
 use structopt::StructOpt;
 
 use witnet_config::config::Config;
+use witnet_data_structures::chain::Epoch;
 use witnet_node as node;
 
 use super::json_rpc_client as rpc;
@@ -231,6 +232,9 @@ pub fn exec_cmd(
         }
         Command::InitializePeers { node } => {
             rpc::initialize_peers(node.unwrap_or(config.jsonrpc.server_address))
+        }
+        Command::Rollback { node, epoch } => {
+            rpc::rollback(node.unwrap_or(config.jsonrpc.server_address), epoch)
         }
     }
 }
@@ -605,6 +609,15 @@ pub enum Command {
         /// Socket address of the Witnet node to query
         #[structopt(short = "n", long = "node")]
         node: Option<SocketAddr>,
+    },
+    #[structopt(name = "rollback", about = "Rollback blockchain to this epoch")]
+    Rollback {
+        /// Socket address of the Witnet node to query
+        #[structopt(short = "n", long = "node")]
+        node: Option<SocketAddr>,
+        /// Epoch
+        #[structopt(short = "e", long = "epoch")]
+        epoch: Epoch,
     },
 }
 

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -233,8 +233,8 @@ pub fn exec_cmd(
         Command::InitializePeers { node } => {
             rpc::initialize_peers(node.unwrap_or(config.jsonrpc.server_address))
         }
-        Command::Rollback { node, epoch } => {
-            rpc::rollback(node.unwrap_or(config.jsonrpc.server_address), epoch)
+        Command::Rewind { node, epoch } => {
+            rpc::rewind(node.unwrap_or(config.jsonrpc.server_address), epoch)
         }
     }
 }
@@ -610,12 +610,12 @@ pub enum Command {
         #[structopt(short = "n", long = "node")]
         node: Option<SocketAddr>,
     },
-    #[structopt(name = "rollback", about = "Rollback blockchain to this epoch")]
-    Rollback {
+    #[structopt(name = "rewind", about = "Rewind blockchain to this epoch")]
+    Rewind {
         /// Socket address of the Witnet node to query
         #[structopt(short = "n", long = "node")]
         node: Option<SocketAddr>,
-        /// Epoch
+        /// The epoch of the top block of the chain after the rewind has completed.
         #[structopt(short = "e", long = "epoch")]
         epoch: Epoch,
     },

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -2872,10 +2872,7 @@ fn commitment_collateral_zero_value_output() {
 
     let err = x.unwrap_err().downcast::<TransactionError>().unwrap();
     assert!(
-        matches!(
-            err,
-            TransactionError::ZeroValueOutput { output_id: 0, .. }
-        ),
+        matches!(err, TransactionError::ZeroValueOutput { output_id: 0, .. }),
         "assertion failed: `(left == right)`\n  left: `{:?}`,\n right: `ZeroValueOutput`",
         err
     );


### PR DESCRIPTION
This allows to recover nodes that have consolidated a wrong chain.

Usage: to go back to block 248839, use this command:

```
witnet node rewind --epoch 248839
```

TODO:

* What should happen if the node stops during a rewind? Save progress to storage?
* Fix panic if rewind command is called twice before the first one finishes.
* Allow to rewind with validations enabled (CLI flag --validate)? Currently all the blocks are assumed to be valid.
* Allow to rewind with an epoch that is greater than the current epoch? Currently it works (it processes all the blocks), but we could optimize it and not rewind in that case.
* [x] ~~Persist chain state after rewind success! Otherwise, if there is no superblock consensus, the node will revert to epoch 0.~~
* When setting the peer limit to 0, any open connections will result in iced peers.