### PR TITLE
fix(node): drop all peers after changing peers limit

### DIFF
--- a/node/src/actors/sessions_manager/handlers.rs
+++ b/node/src/actors/sessions_manager/handlers.rs
@@ -482,11 +482,12 @@ impl Handler<DropOutboundPeers> for SessionsManager {
 }
 
 impl Handler<SetPeersLimits> for SessionsManager {
-    type Result = <DropOutboundPeers as Message>::Result;
+    type Result = <SetPeersLimits as Message>::Result;
 
     fn handle(&mut self, msg: SetPeersLimits, _ctx: &mut Context<Self>) -> Self::Result {
         self.sessions.set_limits(msg.inbound, msg.outbound);
         // Drop all inbound and outbound peers to avoid being above the new limit
+        self.drop_all_peers();
     }
 }
 


### PR DESCRIPTION
This bug happened in the rebase of PR #1867 on top of #1865, because two new handlers ended with the same line.