### PR TITLE
feat: respect min_consensus in data requests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,6 +19,12 @@ jobs:
         -D clippy::cast-sign-loss
         -D clippy::checked-conversions
         -A clippy::field-reassign-with-default
+        -A clippy::upper-case-acronyms
+        -A clippy::from-over-into
+        -A clippy::vec-init-then-push
+        -A clippy::needless-question-mark
+        -A clippy::ptr-arg
+        -A redundant-semicolons
         
     steps:
       - uses: actions/checkout@v1

--- a/Justfile
+++ b/Justfile
@@ -34,6 +34,12 @@ export CLIPPY_LINTS := '-D warnings
     -D clippy::cast-sign-loss
     -D clippy::checked-conversions
     -A clippy::field-reassign-with-default
+    -A clippy::upper-case-acronyms
+    -A clippy::from-over-into
+    -A clippy::vec-init-then-push
+    -A clippy::needless-question-mark
+    -A clippy::ptr-arg
+    -A redundant-semicolons
 '
 
 # run clippy

--- a/data_structures/src/radon_report.rs
+++ b/data_structures/src/radon_report.rs
@@ -272,7 +272,8 @@ where
 {
     fn default() -> Self {
         Self {
-            consensus: 0.0,
+            // Consensus is initialized to 100% because it is only updated when there are some lies
+            consensus: 1.0,
             errors: vec![],
             liars: vec![],
             subscript_partial_results: vec![],
@@ -301,12 +302,13 @@ where
             }
 
             assert!(new_iter.next().is_none());
-
-            self.consensus = self.liars.iter().fold(0., |count, liar| match liar {
-                true => count,
-                false => count + 1.,
-            }) / self.liars.len() as f32;
         }
+
+        // TODO: consensus will be NaN when self.liars.len() == 0
+        self.consensus = self.liars.iter().fold(0., |count, liar| match liar {
+            true => count,
+            false => count + 1.,
+        }) / self.liars.len() as f32;
     }
 }
 

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -692,6 +692,8 @@ pub struct ResolveRA {
     pub rad_request: RADRequest,
     /// Timeout: if the execution does not finish before the timeout, it is cancelled.
     pub timeout: Option<Duration>,
+    /// Current epoch, used to select the correct version of the validation logic
+    pub current_epoch: Epoch,
 }
 
 /// Message for running the tally step of a data request.
@@ -705,6 +707,8 @@ pub struct RunTally {
     pub min_consensus_ratio: f64,
     /// Number of commits
     pub commits_count: usize,
+    /// Epoch of the block that will include this tally, used to select the correct version of the validation logic
+    pub block_epoch: Epoch,
 }
 
 impl Message for ResolveRA {


### PR DESCRIPTION
Data requests have a `min_consensus_percentage` field that is used to ensure that the result of the data request has a minimum quality.

For example, a data request will 100 witnesses and `min_consensus_percentage = 75` needs 75 valid reveals. Valid means that they are not RadonError, and they all have the same type. The problem comes in the next step: after running the tally script some reveals can be marked as "liars" if they deviate too much from the consensus, according to the filter scripts. So for example using a mode filter with 75 values out of which 73 are all different and 2 are equal, the result would be a value that has only been reported by 2 witnesses out of 100, and the remaining 98 witnesses will be penalized.

This PR changes the validation logic to ensure that the `min_consensus_percentage` is applied to the number of honest witnesses. This means that with a `min_consensus_percentage = 51`, which is the minimum, it will be impossible to penalize more than 49% of the participants of a data request. If there is a high number of liars the data request resolves to "InsufficientConsensus". Note that this only applies to tally filters. The mode reducer will keep working as usual so it will be possible to have a result that is only reported by 2 witnesses, but the remaining 73 will not be penalized.

This is a breaking change, so it will be enabled after the second hard fork