### PR TITLE
Update actix to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,19 +2,18 @@
 # It is not intended for manual editing.
 [[package]]
 name = "actix"
-version = "0.11.0-beta.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37700c469661b14d50ad53dfd6fff215fe7496e8cf87484b9c8a809d5e922543"
+checksum = "543c47e7827f8fcc9d1445bd98ba402137bfce80ee2187429de49c52b5131bd3"
 dependencies = [
- "actix-macros",
  "actix-rt",
  "bitflags 1.2.1",
  "bytes 1.0.0",
  "crossbeam-channel 0.5.0",
- "derive_more",
  "futures-core",
  "futures-sink",
  "futures-task",
+ "futures-util",
  "log 0.4.11",
  "once_cell",
  "parking_lot 0.11.0",
@@ -25,22 +24,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-macros"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ca8ce00b267af8ccebbd647de0d61e0674b6e61185cc7a592ff88772bed655"
-dependencies = [
- "quote 1.0.7",
- "syn 1.0.48",
-]
-
-[[package]]
 name = "actix-rt"
-version = "2.0.0-beta.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dfadca59a1d7755a3828708977a2de80b51af0381bd0002ce8f0df3f6091928"
+checksum = "bc7d7cd957c9ed92288a7c3c96af81fa5291f65247a76a34dac7b6af74e52ba0"
 dependencies = [
- "actix-macros",
+ "futures-core",
  "tokio 1.5.0",
 ]
 
@@ -4457,7 +4446,6 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project-lite 0.2.6",
- "slab 0.4.2",
  "tokio 1.5.0",
  "tokio-stream",
 ]

--- a/bridges/centralized-ethereum/Cargo.toml
+++ b/bridges/centralized-ethereum/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Witnet Foundation <info@witnet.foundation>"]
 edition = "2018"
 
 [dependencies]
-actix = { version = "0.11.0-beta.1", default-features = false }
+actix = { version = "0.11.1", default-features = false }
 async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"], branch = "fix-tcp-leak" }
 ctrlc = "3.1.3"
 env_logger = "0.7.1"

--- a/bridges/centralized-ethereum/src/main.rs
+++ b/bridges/centralized-ethereum/src/main.rs
@@ -89,7 +89,7 @@ fn run(callback: fn()) -> Result<(), String> {
     .map_err(|e| format!("Error reading configuration file: {}", e))?;
 
     // Init system
-    let system = System::new("bridge");
+    let system = System::new();
     let condition = app.post_dr;
 
     // Init actors

--- a/futures_utils/Cargo.toml
+++ b/futures_utils/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 workspace = ".."
 
 [dependencies]
-actix = { version = "0.11.0-beta.1", default-features = false }
+actix = { version = "0.11.1", default-features = false }
 futures = "0.3.8"
 pin-project-lite = "0.2"

--- a/futures_utils/src/lib.rs
+++ b/futures_utils/src/lib.rs
@@ -8,85 +8,90 @@
 //! https://github.com/actix/actix/blob/fdaa5d50e25ffc892f5c1c6fcc51097796debecf/src/fut/map.rs
 //! https://github.com/actix/actix/blob/fdaa5d50e25ffc892f5c1c6fcc51097796debecf/src/fut/then.rs
 
-use actix::{fut::IntoActorFuture, Actor, ActorFuture};
+use actix::{Actor, ActorFuture};
+use futures::future::{Either, Ready};
 use pin_project_lite::pin_project;
-use std::{future::Future, pin::Pin, task, task::Poll};
+use std::{future::Future, marker::PhantomData, pin::Pin, task, task::Poll};
 
 /// `ActorFuture` helpers
-pub trait ActorFutureExt: ActorFuture {
-    fn and_then<F, B, T, T2, E>(self, f: F) -> AndThen<Self, B, F, T2, E>
+pub trait ActorFutureExt2<A: Actor>: ActorFuture<A> {
+    fn and_then<F, B, T, T2, E>(self, f: F) -> AndThen<A, Self, B, F, T2, E>
     where
-        Self: ActorFuture<Output = Result<T, E>> + Sized,
-        F: FnOnce(T, &mut Self::Actor, &mut <Self::Actor as Actor>::Context) -> B,
-        B: IntoActorFuture<Actor = Self::Actor, Output = Result<T2, E>>,
+        Self: ActorFuture<A, Output = Result<T, E>> + Sized,
+        F: FnOnce(T, &mut A, &mut <A as Actor>::Context) -> B,
+        B: ActorFuture<A, Output = Result<T2, E>>,
     {
         AndThen::new(self, f)
     }
 
-    fn map_ok<F, T, T2, E>(self, f: F) -> MapOk<Self, F>
+    fn map_ok<F, T, T2, E>(self, f: F) -> MapOk<A, Self, F>
     where
-        Self: ActorFuture<Output = Result<T, E>> + Sized,
-        F: FnOnce(T, &mut Self::Actor, &mut <Self::Actor as Actor>::Context) -> T2,
+        Self: ActorFuture<A, Output = Result<T, E>> + Sized,
+        F: FnOnce(T, &mut A, &mut <A as Actor>::Context) -> T2,
     {
         MapOk::new(self, f)
     }
 
-    fn map_err<F, T, T2, E>(self, f: F) -> MapErr<Self, F>
+    fn map_err<F, T, T2, E>(self, f: F) -> MapErr<A, Self, F>
     where
-        Self: ActorFuture<Output = Result<E, T>> + Sized,
-        F: FnOnce(T, &mut Self::Actor, &mut <Self::Actor as Actor>::Context) -> T2,
+        Self: ActorFuture<A, Output = Result<E, T>> + Sized,
+        F: FnOnce(T, &mut A, &mut <A as Actor>::Context) -> T2,
     {
         MapErr::new(self, f)
     }
 }
 
-impl<A: ActorFuture> ActorFutureExt for A {}
+impl<Act: Actor, A: ActorFuture<Act>> ActorFutureExt2<Act> for A {}
 
 pin_project! {
     #[derive(Debug)]
     #[must_use = "futures do nothing unless polled"]
-    pub struct AndThen<A, B, F: 'static, T2, E>
+    pub struct AndThen<Act, A, B, F: 'static, T2, E>
         where
-            A: ActorFuture,
-            B: IntoActorFuture<Actor = A::Actor, Output = Result<T2, E>>,
+            Act: Actor,
+            A: ActorFuture<Act>,
+            B: ActorFuture<Act, Output = Result<T2, E>>,
     {
         #[pin]
-        state: Chain<A, actix::fut::Either<B::Future, actix::fut::FutureResult<T2, E, A::Actor>>, F>,
+        state: Chain<Act, A, Either<B, Ready<Result<T2, E>>>, F>,
+        _phantom: PhantomData<Act>,
     }
 }
 
-impl<A, B, F: 'static, T2, E> AndThen<A, B, F, T2, E>
+impl<Act, A, B, F: 'static, T2, E> AndThen<Act, A, B, F, T2, E>
 where
-    A: ActorFuture,
-    B: IntoActorFuture<Actor = A::Actor, Output = Result<T2, E>>,
+    Act: Actor,
+    A: ActorFuture<Act>,
+    B: ActorFuture<Act, Output = Result<T2, E>>,
 {
-    pub fn new(future: A, f: F) -> AndThen<A, B, F, T2, E> {
+    pub fn new(future: A, f: F) -> AndThen<Act, A, B, F, T2, E> {
         Self {
             state: Chain::new(future, f),
+            _phantom: PhantomData,
         }
     }
 }
 
-impl<A, B, F, T, T2, E> ActorFuture for AndThen<A, B, F, T2, E>
+impl<Act, A, B, F, T, T2, E> ActorFuture<Act> for AndThen<Act, A, B, F, T2, E>
 where
-    A: ActorFuture<Output = Result<T, E>>,
-    B: IntoActorFuture<Actor = A::Actor, Output = Result<T2, E>>,
-    F: FnOnce(T, &mut A::Actor, &mut <A::Actor as Actor>::Context) -> B,
+    Act: Actor,
+    A: ActorFuture<Act, Output = Result<T, E>>,
+    B: ActorFuture<Act, Output = Result<T2, E>>,
+    F: FnOnce(T, &mut Act, &mut <Act as Actor>::Context) -> B,
 {
     type Output = B::Output;
-    type Actor = A::Actor;
 
     fn poll(
         self: Pin<&mut Self>,
-        act: &mut A::Actor,
-        ctx: &mut <A::Actor as Actor>::Context,
+        act: &mut Act,
+        ctx: &mut <Act as Actor>::Context,
         task: &mut task::Context<'_>,
     ) -> Poll<B::Output> {
         self.project()
             .state
             .poll(act, ctx, task, |item, f, act, ctx| match item {
-                Ok(item) => actix::fut::Either::left(f(item, act, ctx).into_future()),
-                Err(e) => actix::fut::Either::right(actix::fut::result(Err(e))),
+                Ok(item) => Either::Left(f(item, act, ctx)),
+                Err(e) => Either::Right(actix::fut::result(Err(e))),
             })
     }
 }
@@ -95,41 +100,52 @@ pin_project! {
     #[project = ChainProj]
     #[must_use = "futures do nothing unless polled"]
     #[derive(Debug)]
-    pub enum Chain<A, B, C> {
-        First { #[pin] fut1: A, data: Option<C> },
+    pub enum Chain<Act, A, B, C>
+    where
+        Act: Actor,
+        A: ActorFuture<Act>,
+        B: ActorFuture<Act>,
+    {
+        First { #[pin] fut1: A, data: Option<C>, _phantom: PhantomData<Act>, },
         Second { #[pin] fut2: B },
         Empty,
     }
 }
 
-impl<A, B, C> Chain<A, B, C>
+impl<Act, A, B, C> Chain<Act, A, B, C>
 where
-    A: ActorFuture,
-    B: ActorFuture<Actor = A::Actor>,
+    Act: Actor,
+    A: ActorFuture<Act>,
+    B: ActorFuture<Act>,
 {
-    pub fn new(fut1: A, data: C) -> Chain<A, B, C> {
+    pub fn new(fut1: A, data: C) -> Chain<Act, A, B, C> {
         Chain::First {
             fut1,
             data: Some(data),
+            _phantom: PhantomData,
         }
     }
 
     pub fn poll<F>(
         mut self: Pin<&mut Self>,
-        srv: &mut A::Actor,
-        ctx: &mut <A::Actor as Actor>::Context,
+        srv: &mut Act,
+        ctx: &mut <Act as Actor>::Context,
         task: &mut task::Context,
         f: F,
     ) -> Poll<B::Output>
     where
-        F: FnOnce(A::Output, C, &mut A::Actor, &mut <A::Actor as Actor>::Context) -> B,
+        F: FnOnce(A::Output, C, &mut Act, &mut <Act as Actor>::Context) -> B,
     {
         let mut f = Some(f);
 
         loop {
             let this = self.as_mut().project();
             let (output, data) = match this {
-                ChainProj::First { fut1, data } => {
+                ChainProj::First {
+                    fut1,
+                    data,
+                    _phantom,
+                } => {
                     let output = match fut1.poll(srv, ctx, task) {
                         Poll::Ready(t) => t,
                         Poll::Pending => return Poll::Pending,
@@ -152,36 +168,44 @@ where
 pin_project! {
     #[derive(Debug)]
     #[must_use = "futures do nothing unless polled"]
-    pub struct MapOk<A, F>
+    pub struct MapOk<Act, A, F>
         where
-            A: ActorFuture,
+            Act: Actor,
+            A: ActorFuture<Act>,
     {
         #[pin]
         future: A,
         f: Option<F>,
+        _phantom: PhantomData<Act>,
     }
 }
 
-impl<A, F> MapOk<A, F>
+impl<Act, A, F> MapOk<Act, A, F>
 where
-    A: ActorFuture,
+    Act: Actor,
+    A: ActorFuture<Act>,
 {
-    pub fn new(future: A, f: F) -> MapOk<A, F> {
-        MapOk { future, f: Some(f) }
+    pub fn new(future: A, f: F) -> MapOk<Act, A, F> {
+        MapOk {
+            future,
+            f: Some(f),
+            _phantom: PhantomData,
+        }
     }
 }
 
-impl<U, A, F, E, T> ActorFuture for MapOk<A, F>
+impl<Act, U, A, F, E, T> ActorFuture<Act> for MapOk<Act, A, F>
 where
-    A: ActorFuture<Output = Result<T, E>>,
-    F: FnOnce(T, &mut A::Actor, &mut <A::Actor as Actor>::Context) -> U,
+    Act: Actor,
+    A: ActorFuture<Act, Output = Result<T, E>>,
+    F: FnOnce(T, &mut Act, &mut <Act as Actor>::Context) -> U,
 {
     type Output = Result<U, E>;
-    type Actor = A::Actor;
+
     fn poll(
         self: Pin<&mut Self>,
-        act: &mut Self::Actor,
-        ctx: &mut <A::Actor as Actor>::Context,
+        act: &mut Act,
+        ctx: &mut <Act as Actor>::Context,
         task: &mut task::Context,
     ) -> Poll<Self::Output> {
         let this = self.project();
@@ -202,36 +226,44 @@ where
 pin_project! {
     #[derive(Debug)]
     #[must_use = "futures do nothing unless polled"]
-    pub struct MapErr<A, F>
+    pub struct MapErr<Act, A, F>
         where
-            A: ActorFuture,
+            Act: Actor,
+            A: ActorFuture<Act>,
     {
         #[pin]
         future: A,
         f: Option<F>,
+        _phantom: PhantomData<Act>,
     }
 }
 
-impl<A, F> MapErr<A, F>
+impl<Act, A, F> MapErr<Act, A, F>
 where
-    A: ActorFuture,
+    Act: Actor,
+    A: ActorFuture<Act>,
 {
-    pub fn new(future: A, f: F) -> MapErr<A, F> {
-        MapErr { future, f: Some(f) }
+    pub fn new(future: A, f: F) -> MapErr<Act, A, F> {
+        MapErr {
+            future,
+            f: Some(f),
+            _phantom: PhantomData,
+        }
     }
 }
 
-impl<U, A, F, E, T> ActorFuture for MapErr<A, F>
+impl<Act, U, A, F, E, T> ActorFuture<Act> for MapErr<Act, A, F>
 where
-    A: ActorFuture<Output = Result<E, T>>,
-    F: FnOnce(T, &mut A::Actor, &mut <A::Actor as Actor>::Context) -> U,
+    Act: Actor,
+    A: ActorFuture<Act, Output = Result<E, T>>,
+    F: FnOnce(T, &mut Act, &mut <Act as Actor>::Context) -> U,
 {
     type Output = Result<E, U>;
-    type Actor = A::Actor;
+
     fn poll(
         self: Pin<&mut Self>,
-        act: &mut Self::Actor,
-        ctx: &mut <A::Actor as Actor>::Context,
+        act: &mut Act,
+        ctx: &mut <Act as Actor>::Context,
         task: &mut task::Context,
     ) -> Poll<Self::Output> {
         let this = self.project();

--- a/net/Cargo.toml
+++ b/net/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 workspace = ".."
 
 [dependencies]
-actix = { version = "0.11.0-beta.1", default-features = false }
+actix = { version = "0.11.1", default-features = false }
 async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"], branch = "fix-tcp-leak" }
 failure = "0.1.8"
 futures = "0.3.8"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,7 +7,7 @@ description = "node component"
 edition = "2018"
 
 [dependencies]
-actix = { version = "0.11.0-beta.1", default-features = false }
+actix = { version = "0.11.1", default-features = false }
 ansi_term = "0.12.1"
 async-stream = "0.3"
 bincode = "1.2.1"

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -23,7 +23,7 @@ use witnet_data_structures::{
     utxo_pool::OwnUnspentOutputsPool,
     vrf::VrfCtx,
 };
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 use witnet_util::timestamp::pretty_print;
 
 /// Implement Actor trait for `ChainManager`

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -1,4 +1,6 @@
-use actix::{ActorFuture, AsyncContext, Context, ContextFutureSpawner, SystemService, WrapFuture};
+use actix::{
+    ActorFutureExt, AsyncContext, Context, ContextFutureSpawner, SystemService, WrapFuture,
+};
 use ansi_term::Color::{White, Yellow};
 use futures::future::{try_join_all, FutureExt};
 use std::{
@@ -50,7 +52,7 @@ use witnet_data_structures::{
     utxo_pool::{UnspentOutputsPool, UtxoDiff},
     vrf::{BlockEligibilityClaim, DataRequestEligibilityClaim, VrfMessage},
 };
-use witnet_futures_utils::{ActorFutureExt, TryFutureExt2};
+use witnet_futures_utils::{ActorFutureExt2, TryFutureExt2};
 
 impl ChainManager {
     /// Try to mine a block

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -35,7 +35,7 @@ use std::{
 };
 
 use actix::{
-    prelude::*, ActorFuture, AsyncContext, Context, ContextFutureSpawner, Supervised,
+    prelude::*, ActorFutureExt, AsyncContext, Context, ContextFutureSpawner, Supervised,
     SystemService, WrapFuture,
 };
 use ansi_term::Color::{Purple, White, Yellow};
@@ -86,7 +86,7 @@ use crate::{
     },
     signature_mngr, storage_mngr,
 };
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 mod actor;
 mod handlers;

--- a/node/src/actors/connections_manager/handlers.rs
+++ b/node/src/actors/connections_manager/handlers.rs
@@ -1,4 +1,4 @@
-use actix::{ActorFuture, ContextFutureSpawner, Handler, SystemService, WrapFuture};
+use actix::{ActorFutureExt, ContextFutureSpawner, Handler, SystemService, WrapFuture};
 
 use witnet_p2p::sessions::SessionType;
 

--- a/node/src/actors/connections_manager/mod.rs
+++ b/node/src/actors/connections_manager/mod.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use actix::prelude::*;
+use futures::future::Ready;
 use tokio::net::{TcpListener, TcpStream};
 
 use witnet_p2p::sessions::SessionType;
@@ -13,7 +14,7 @@ use crate::{
     },
     config_mngr,
 };
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 mod actor;
 mod handlers;
@@ -86,7 +87,7 @@ impl ConnectionsManager {
         response: Result<ResolverResult, MailboxError>,
         session_type: SessionType,
         address: &SocketAddr,
-    ) -> actix::fut::FutureResult<(), (), Self> {
+    ) -> Ready<Result<(), ()>> {
         // Process the Result<ResolverResult, MailboxError>
         match response {
             Err(error) => {

--- a/node/src/actors/epoch_manager/mod.rs
+++ b/node/src/actors/epoch_manager/mod.rs
@@ -14,7 +14,7 @@ use witnet_util::timestamp::{
 
 use crate::actors::messages::{EpochNotification, EpochResult};
 use crate::config_mngr;
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 mod actor;
 mod handlers;

--- a/node/src/actors/epoch_manager/mod.rs
+++ b/node/src/actors/epoch_manager/mod.rs
@@ -12,8 +12,10 @@ use witnet_util::timestamp::{
     duration_between_timestamps, get_timestamp, get_timestamp_nanos, update_global_timestamp,
 };
 
-use crate::actors::messages::{EpochNotification, EpochResult};
-use crate::config_mngr;
+use crate::{
+    actors::messages::{EpochNotification, EpochResult},
+    config_mngr,
+};
 use witnet_futures_utils::ActorFutureExt2;
 
 mod actor;

--- a/node/src/actors/inventory_manager/handlers.rs
+++ b/node/src/actors/inventory_manager/handlers.rs
@@ -1,12 +1,13 @@
-use actix::prelude::*;
-use actix::{ActorFutureExt, Context, Handler, ResponseActFuture, WrapFuture};
+use actix::{prelude::*, ActorFutureExt, Context, Handler, ResponseActFuture, WrapFuture};
 
 use super::{InventoryManager, InventoryManagerError};
-use crate::actors::messages::{
-    AddItem, AddItems, GetItem, GetItemBlock, GetItemSuperblock, GetItemTransaction,
-    StoreInventoryItem, SuperBlockNotify,
+use crate::{
+    actors::messages::{
+        AddItem, AddItems, GetItem, GetItemBlock, GetItemSuperblock, GetItemTransaction,
+        StoreInventoryItem, SuperBlockNotify,
+    },
+    storage_mngr,
 };
-use crate::storage_mngr;
 use witnet_data_structures::{
     chain::{Block, Epoch, Hash, Hashable, InventoryEntry, InventoryItem, PointerToBlock},
     transaction::Transaction,

--- a/node/src/actors/inventory_manager/handlers.rs
+++ b/node/src/actors/inventory_manager/handlers.rs
@@ -1,5 +1,5 @@
 use actix::prelude::*;
-use actix::{ActorFuture, Context, Handler, ResponseActFuture, WrapFuture};
+use actix::{ActorFutureExt, Context, Handler, ResponseActFuture, WrapFuture};
 
 use super::{InventoryManager, InventoryManagerError};
 use crate::actors::messages::{
@@ -11,7 +11,7 @@ use witnet_data_structures::{
     chain::{Block, Epoch, Hash, Hashable, InventoryEntry, InventoryItem, PointerToBlock},
     transaction::Transaction,
 };
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 fn key_superblock(superblock_index: u32) -> Vec<u8> {
     // Add 0 padding to the left of the superblock index to make sorted keys represent consecutive

--- a/node/src/actors/json_rpc/connection.rs
+++ b/node/src/actors/json_rpc/connection.rs
@@ -1,5 +1,5 @@
 use actix::{
-    io::FramedWrite, io::WriteHandler, Actor, ActorFuture, Addr, AsyncContext, Context,
+    io::FramedWrite, io::WriteHandler, Actor, ActorFutureExt, Addr, AsyncContext, Context,
     ContextFutureSpawner, Running, StreamHandler, WrapFuture,
 };
 

--- a/node/src/actors/node.rs
+++ b/node/src/actors/node.rs
@@ -15,7 +15,7 @@ use witnet_config::config::Config;
 /// Function to run the main system
 pub fn run(config: Arc<Config>, callback: fn()) -> Result<(), failure::Error> {
     // Init system
-    let system = System::new("node");
+    let system = System::new();
 
     // Init actors
     system.block_on(async {

--- a/node/src/actors/peers_manager/actor.rs
+++ b/node/src/actors/peers_manager/actor.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     config_mngr, storage_mngr,
 };
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 use witnet_p2p::peers::Peers;
 
 /// Make actor from PeersManager

--- a/node/src/actors/peers_manager/mod.rs
+++ b/node/src/actors/peers_manager/mod.rs
@@ -1,7 +1,8 @@
 use std::{net::SocketAddr, time::Duration};
 
 use actix::{
-    ActorFuture, AsyncContext, Context, ContextFutureSpawner, Supervised, SystemService, WrapFuture,
+    ActorFutureExt, AsyncContext, Context, ContextFutureSpawner, Supervised, SystemService,
+    WrapFuture,
 };
 
 use witnet_p2p::{peers::Peers, sessions::SessionType};

--- a/node/src/actors/session/actor.rs
+++ b/node/src/actors/session/actor.rs
@@ -1,5 +1,5 @@
 use actix::{
-    Actor, ActorContext, ActorFuture, AsyncContext, Context, ContextFutureSpawner, Running,
+    Actor, ActorContext, ActorFutureExt, AsyncContext, Context, ContextFutureSpawner, Running,
     SystemService, WrapFuture,
 };
 
@@ -13,7 +13,7 @@ use crate::actors::{
     messages::{AddBlocks, GetEpoch, Register, Subscribe, Unregister},
     sessions_manager::SessionsManager,
 };
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 use witnet_util::timestamp::pretty_print;
 
 /// Implement actor trait for Session

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -1,11 +1,12 @@
 use std::{cmp::Ordering, convert::TryFrom, io::Error, net::SocketAddr};
 
 use actix::{
-    io::WriteHandler, ActorContext, ActorFuture, Context, ContextFutureSpawner, Handler,
+    io::WriteHandler, ActorContext, ActorFutureExt, Context, ContextFutureSpawner, Handler,
     StreamHandler, SystemService, WrapFuture,
 };
 use bytes::BytesMut;
 use failure::Fail;
+use futures::future::Either;
 
 use witnet_data_structures::{
     builders::from_address,
@@ -37,7 +38,7 @@ use crate::actors::{
     peers_manager::PeersManager,
     sessions_manager::SessionsManager,
 };
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 use witnet_util::timestamp::get_timestamp;
 
 #[derive(Debug, Eq, Fail, PartialEq)]
@@ -313,9 +314,9 @@ impl StreamHandler<Result<BytesMut, Error>> for Session {
                                     });
 
                                 if send_superblock_votes {
-                                    actix::fut::Either::left(fut)
+                                    Either::Left(fut)
                                 } else {
-                                    actix::fut::Either::right(actix::fut::ok(()))
+                                    Either::Right(actix::fut::ok(()))
                                 }
                             })
                             .map(|_res: Result<(), ()>, _act, _ctx| ())

--- a/node/src/actors/sessions_manager/actor.rs
+++ b/node/src/actors/sessions_manager/actor.rs
@@ -2,7 +2,7 @@ use super::SessionsManager;
 use crate::config_mngr;
 use actix::prelude::*;
 use witnet_data_structures::chain::EpochConstants;
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 use witnet_util::timestamp::get_timestamp;
 
 /// Make actor from `SessionsManager`

--- a/node/src/actors/sessions_manager/mod.rs
+++ b/node/src/actors/sessions_manager/mod.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration};
 
 use actix::{
-    ActorFuture, Addr, AsyncContext, Context, ContextFutureSpawner, MailboxError, SystemService,
+    ActorFutureExt, Addr, AsyncContext, Context, ContextFutureSpawner, MailboxError, SystemService,
     WrapFuture,
 };
 

--- a/node/src/signature_mngr.rs
+++ b/node/src/signature_mngr.rs
@@ -5,6 +5,7 @@
 //! that key.
 use actix::prelude::*;
 use failure::{bail, format_err};
+use futures::Future;
 use futures_util::FutureExt;
 
 use crate::{
@@ -27,7 +28,7 @@ use witnet_data_structures::{
     transaction::MemoizedHashable,
     vrf::{VrfCtx, VrfMessage, VrfProof},
 };
-use witnet_futures_utils::{ActorFutureExt, TryFutureExt2};
+use witnet_futures_utils::{ActorFutureExt2, TryFutureExt2};
 use witnet_protected::ProtectedString;
 use witnet_validations::validations;
 

--- a/node/src/storage_mngr.rs
+++ b/node/src/storage_mngr.rs
@@ -6,10 +6,11 @@ use std::sync::Arc;
 
 use actix::prelude::*;
 use bincode::{deserialize, serialize};
+use futures::Future;
 
 use crate::config_mngr;
 use witnet_config::{config, config::Config};
-use witnet_futures_utils::{ActorFutureExt, TryFutureExt2};
+use witnet_futures_utils::{ActorFutureExt2, TryFutureExt2};
 use witnet_storage::{backends, storage};
 
 macro_rules! as_failure {

--- a/node/src/utils.rs
+++ b/node/src/utils.rs
@@ -43,7 +43,7 @@ pub fn test_actix_system<F: FnOnce() -> Fut, Fut: Future>(test_function: F) {
     let done = Arc::new(AtomicBool::new(false));
 
     // Init system
-    let system = System::new("test_node");
+    let system = System::new();
 
     // Init actors
     system.block_on(async {

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -20,7 +20,7 @@ rocksdb = "0.13.0"
 rayon = "1.3.0"
 num_cpus = "1.12.0"
 jsonrpc-pubsub = "15.1.0"
-actix = { version = "0.11.0-beta.1", default-features = false }
+actix = { version = "0.11.1", default-features = false }
 tokio = { version = "1.0", features = ["signal"] }
 failure = "0.1.8"
 hex = "0.4.1"

--- a/wallet/src/actors/app/handlers/create_data_req.rs
+++ b/wallet/src/actors/app/handlers/create_data_req.rs
@@ -14,7 +14,7 @@ use witnet_data_structures::{
     transaction::Transaction,
     transaction_factory::FeeType,
 };
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 #[derive(Debug, Deserialize)]
 pub struct CreateDataReqRequest {

--- a/wallet/src/actors/app/handlers/create_mnemonics.rs
+++ b/wallet/src/actors/app/handlers/create_mnemonics.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::actors::app;
 use futures_util::FutureExt;
 use witnet_crypto::mnemonic;
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateMnemonicsRequest {

--- a/wallet/src/actors/app/handlers/create_vtt.rs
+++ b/wallet/src/actors/app/handlers/create_vtt.rs
@@ -15,7 +15,7 @@ use witnet_data_structures::{
     transaction::Transaction,
     transaction_factory::FeeType,
 };
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VttOutputParams {

--- a/wallet/src/actors/app/handlers/create_wallet.rs
+++ b/wallet/src/actors/app/handlers/create_wallet.rs
@@ -2,8 +2,7 @@ use actix::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::str;
 
-use crate::actors::app;
-use crate::types;
+use crate::{actors::app, types};
 use futures_util::FutureExt;
 use witnet_futures_utils::ActorFutureExt2;
 

--- a/wallet/src/actors/app/handlers/create_wallet.rs
+++ b/wallet/src/actors/app/handlers/create_wallet.rs
@@ -5,7 +5,7 @@ use std::str;
 use crate::actors::app;
 use crate::types;
 use futures_util::FutureExt;
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 /// Create Wallet request, where name, description and overwrite are optional and backup_password
 /// is only needed if seed_source is xprv

--- a/wallet/src/actors/app/handlers/export_master_key.rs
+++ b/wallet/src/actors/app/handlers/export_master_key.rs
@@ -1,6 +1,6 @@
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 use crate::{actors::app, types};
 

--- a/wallet/src/actors/app/handlers/generate_address.rs
+++ b/wallet/src/actors/app/handlers/generate_address.rs
@@ -1,6 +1,6 @@
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 use crate::actors::app;
 use crate::{model, types};

--- a/wallet/src/actors/app/handlers/generate_address.rs
+++ b/wallet/src/actors/app/handlers/generate_address.rs
@@ -2,8 +2,7 @@ use actix::prelude::*;
 use serde::{Deserialize, Serialize};
 use witnet_futures_utils::ActorFutureExt2;
 
-use crate::actors::app;
-use crate::{model, types};
+use crate::{actors::app, model, types};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GenerateAddressRequest {

--- a/wallet/src/actors/app/handlers/get.rs
+++ b/wallet/src/actors/app/handlers/get.rs
@@ -1,8 +1,7 @@
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::actors::app;
-use crate::types;
+use crate::{actors::app, types};
 use witnet_futures_utils::ActorFutureExt2;
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/wallet/src/actors/app/handlers/get.rs
+++ b/wallet/src/actors/app/handlers/get.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::actors::app;
 use crate::types;
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetRequest {

--- a/wallet/src/actors/app/handlers/resync.rs
+++ b/wallet/src/actors/app/handlers/resync.rs
@@ -1,6 +1,6 @@
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 use crate::actors::app;
 use crate::types;

--- a/wallet/src/actors/app/handlers/resync.rs
+++ b/wallet/src/actors/app/handlers/resync.rs
@@ -2,8 +2,7 @@ use actix::prelude::*;
 use serde::{Deserialize, Serialize};
 use witnet_futures_utils::ActorFutureExt2;
 
-use crate::actors::app;
-use crate::types;
+use crate::{actors::app, types};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ResyncWalletRequest {

--- a/wallet/src/actors/app/handlers/unlock_wallet.rs
+++ b/wallet/src/actors/app/handlers/unlock_wallet.rs
@@ -1,6 +1,6 @@
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 use crate::{actors::app, model, types};
 

--- a/wallet/src/actors/app/handlers/update_wallet.rs
+++ b/wallet/src/actors/app/handlers/update_wallet.rs
@@ -2,8 +2,7 @@ use actix::prelude::*;
 use serde::{Deserialize, Serialize};
 use witnet_futures_utils::ActorFutureExt2;
 
-use crate::actors::app;
-use crate::types;
+use crate::{actors::app, types};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UpdateWalletRequest {

--- a/wallet/src/actors/app/handlers/update_wallet.rs
+++ b/wallet/src/actors/app/handlers/update_wallet.rs
@@ -1,6 +1,6 @@
 use actix::prelude::*;
 use serde::{Deserialize, Serialize};
-use witnet_futures_utils::ActorFutureExt;
+use witnet_futures_utils::ActorFutureExt2;
 
 use crate::actors::app;
 use crate::types;

--- a/wallet/src/actors/app/methods.rs
+++ b/wallet/src/actors/app/methods.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 use super::*;
-use witnet_futures_utils::{ActorFutureExt, TryFutureExt2};
+use witnet_futures_utils::{ActorFutureExt2, TryFutureExt2};
 
 pub struct Validated {
     pub description: Option<String>,

--- a/wallet/src/actors/app/routes.rs
+++ b/wallet/src/actors/app/routes.rs
@@ -76,7 +76,7 @@ macro_rules! forwarded_routes {
 pub fn connect_routes<T, S>(
     handler: &mut PubSubHandler<T, S>,
     api: Addr<App>,
-    system_arbiter: Arbiter,
+    system_arbiter: ArbiterHandle,
 ) where
     T: PubSubMetadata,
     S: Middleware<T>,
@@ -135,7 +135,7 @@ pub fn connect_routes<T, S>(
                             })
                     }).map(|_: std::result::Result<(), ()>| ());
 
-                system_arbiter.send(Box::pin(f));
+                system_arbiter.spawn(Box::pin(f));
             }
         }),
         ("rpc.off", {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -82,7 +82,7 @@ pub fn run(conf: Config) -> Result<(), Error> {
     // Size of the address synchronization batch
     let sync_address_batch_length = conf.wallet.sync_address_batch_length;
 
-    let system = System::new("witnet-wallet");
+    let system = System::new();
 
     let node_jsonrpc_server_address = conf.jsonrpc.server_address;
 


### PR DESCRIPTION
I expected this to be easier because we are currently using `actix = "0.11.0-beta.1"`, but there have been lots of ""refactors"" in the actix crate.

* `actix::fut::Either` does not exist anymore, use `futures::future::Either` instead
* `ActorFuture::map` and `ActorFuture::then` have been moved into a new `ActorFutureExt` trait
* `witnet_futures_utils::ActorFutureExt` has been renamed to `witnet_futures_utils::ActorFutureExt2` to avoid name collisions with the new `actix::ActorFutureExt` trait

And other minor changes to the actix API.