### PR TITLE
Update dependencies to fix cargo audit warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,8 +18,8 @@ dependencies = [
  "log 0.4.11",
  "once_cell",
  "parking_lot 0.11.0",
- "pin-project-lite 0.2.0",
- "smallvec 1.6.0",
+ "pin-project-lite 0.2.6",
+ "smallvec 1.6.1",
  "tokio 1.5.0",
  "tokio-util 0.6.0",
 ]
@@ -125,9 +125,9 @@ checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
+checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
 
 [[package]]
 name = "arrayref"
@@ -1646,7 +1646,7 @@ checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
 dependencies = [
  "bytes 1.0.0",
  "http 0.2.1",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.6",
 ]
 
 [[package]]
@@ -1697,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.12.35"
+version = "0.12.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
+checksum = "5c843caf6296fc1f93444735205af9ed4e109a539005abb2564ae1d6fad34c52"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
@@ -1727,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.8"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -1741,7 +1741,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 0.4.27",
+ "pin-project 1.0.1",
  "socket2",
  "tokio 0.2.25",
  "tower-service",
@@ -1798,7 +1798,7 @@ checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 dependencies = [
  "bytes 0.4.12",
  "futures 0.1.30",
- "hyper 0.12.35",
+ "hyper 0.12.36",
  "native-tls",
  "tokio-io",
 ]
@@ -1810,7 +1810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
  "bytes 0.5.6",
- "hyper 0.13.8",
+ "hyper 0.13.10",
  "native-tls",
  "tokio 0.2.25",
  "tokio-tls 0.3.1",
@@ -2593,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3741934be594d77de1c8461ebcbbe866f585ea616a9753aa78f2bdc69f0e4579"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
 dependencies = [
  "num-traits",
 ]
@@ -2702,7 +2702,7 @@ dependencies = [
  "libc",
  "rand 0.6.5",
  "rustc_version",
- "smallvec 0.6.13",
+ "smallvec 0.6.14",
  "winapi 0.3.9",
 ]
 
@@ -2717,7 +2717,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "rustc_version",
- "smallvec 0.6.13",
+ "smallvec 0.6.14",
  "winapi 0.3.9",
 ]
 
@@ -2731,7 +2731,7 @@ dependencies = [
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.6.0",
+ "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
 
@@ -2746,7 +2746,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.6.0",
+ "smallvec 1.6.1",
  "winapi 0.3.9",
 ]
 
@@ -2829,15 +2829,15 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -3008,7 +3008,7 @@ version = "2.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57408af2c106a7f08cc61e15be6a31e3ace8ea26f90dd1be1ad19abf1073d36a"
 dependencies = [
- "log 0.4.11",
+ "log 0.3.9",
  "which 4.0.2",
 ]
 
@@ -3113,7 +3113,7 @@ checksum = "a76330fb486679b4ace3670f117bbc9e16204005c4bde9c4bd372f45bed34f12"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
- "rand_core 0.6.0",
+ "rand_core 0.6.2",
  "rand_hc 0.3.0",
 ]
 
@@ -3144,7 +3144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.0",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -3173,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b34ba8cfb21243bd8df91854c830ff0d785fff2e82ebd4434c2644cb9ada18"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.1",
 ]
@@ -3204,7 +3204,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.0",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -3360,7 +3360,7 @@ dependencies = [
  "futures-util",
  "http 0.2.1",
  "http-body 0.3.1",
- "hyper 0.13.8",
+ "hyper 0.13.10",
  "hyper-tls 0.4.3",
  "ipnet",
  "js-sys",
@@ -3370,7 +3370,7 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.1.12",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3804,18 +3804,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
 dependencies = [
  "maybe-uninit",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a55ca5f3b68e41c979bf8c46a6f1da892ca4db8f94023ce0bd32407573b1ac0"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
@@ -4139,7 +4139,7 @@ dependencies = [
  "memchr",
  "mio 0.6.23",
  "num_cpus",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.1.12",
  "slab 0.4.2",
 ]
 
@@ -4157,7 +4157,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot 0.11.0",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.6",
  "signal-hook-registry",
  "tokio-macros",
  "winapi 0.3.9",
@@ -4293,7 +4293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.6",
  "tokio 1.5.0",
 ]
 
@@ -4441,7 +4441,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log 0.4.11",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.1.12",
  "tokio 0.2.25",
 ]
 
@@ -4456,7 +4456,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "log 0.4.11",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.6",
  "slab 0.4.2",
  "tokio 1.5.0",
  "tokio-stream",
@@ -4485,7 +4485,7 @@ checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
  "log 0.4.11",
- "pin-project-lite 0.1.11",
+ "pin-project-lite 0.1.12",
  "tracing-core",
 ]
 
@@ -4532,7 +4532,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.11",
  "rand 0.8.0",
- "smallvec 1.6.0",
+ "smallvec 1.6.1",
  "thiserror",
  "tokio 1.5.0",
  "url 2.1.1",
@@ -4552,7 +4552,7 @@ dependencies = [
  "lru-cache",
  "parking_lot 0.11.0",
  "resolv-conf",
- "smallvec 1.6.0",
+ "smallvec 1.6.1",
  "thiserror",
  "tokio 1.5.0",
  "trust-dns-proto",
@@ -4894,7 +4894,7 @@ dependencies = [
  "ethabi 9.0.1",
  "ethereum-types 0.8.0",
  "futures 0.1.30",
- "hyper 0.12.35",
+ "hyper 0.12.36",
  "hyper-tls 0.3.2",
  "jsonrpc-core 14.2.0",
  "log 0.4.11",
@@ -5232,7 +5232,7 @@ version = "0.1.0"
 dependencies = [
  "actix",
  "futures 0.3.8",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.6",
 ]
 
 [[package]]
@@ -5270,7 +5270,7 @@ dependencies = [
  "jsonrpc-core 15.1.0",
  "jsonrpc-pubsub",
  "log 0.4.11",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.6",
  "rand 0.7.3",
  "rayon",
  "secp256k1 0.17.2",


### PR DESCRIPTION
For some reason the bot that creates new issues when there is a security problem with our dependencies doesn't always work. So this PR is me running `cargo audit`, and then `cargo update` on the relevant dependencies.

Before this PR: 8 vulnerabilities and 9 warnings. After this PR: 1 vulnerability and 3 warnings. The remaining warnings already have open issues: https://github.com/witnet/witnet-rust/issues?q=is%3Aissue+is%3Aopen+RUSTSEC

<details>
<summary>List of fixed issues</summary>

```sh
cargo audit > cargo-audit-before
# Update dependencies
cargo audit > cargo-audit-after
git diff --no-prefix --no-index -U100000 cargo-audit-before cargo-audit-after
```

The lines in red are vulnerabilities fixed by this PR:

```diff
diff --git cargo-audit-before cargo-audit-after
index e55e8b5..7c23c93 100644
--- cargo-audit-before
+++ cargo-audit-after
@@ -1,241 +1,116 @@
 $ cargo audit
     Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
       Loaded 289 security advisories (from /home/tomasz/.cargo/advisory-db)
     Updating crates.io index
     Scanning Cargo.lock for vulnerabilities (486 crate dependencies)
-Crate:         arc-swap
-Version:       0.4.7
-Title:         Dangling reference in `access::Map` with Constant
-Date:          2020-12-10
-ID:            RUSTSEC-2020-0091
-URL:           https://rustsec.org/advisories/RUSTSEC-2020-0091
-Solution:      Upgrade to >=1.1.0 OR >=0.4.8
-Dependency tree: 
-arc-swap 0.4.7
-└── signal-hook-registry 1.2.1
-    └── tokio 1.0.1
-
-Crate:         hyper
-Version:       0.12.35
-Title:         Multiple Transfer-Encoding headers misinterprets request payload
-Date:          2021-02-05
-ID:            RUSTSEC-2021-0020
-URL:           https://rustsec.org/advisories/RUSTSEC-2021-0020
-Solution:      Upgrade to >=0.14.3 OR >=0.13.10, <0.14.0 OR >=0.12.36, <0.13.0
-Dependency tree: 
-hyper 0.12.35
-
-Crate:         hyper
-Version:       0.13.8
-Title:         Multiple Transfer-Encoding headers misinterprets request payload
-Date:          2021-02-05
-ID:            RUSTSEC-2021-0020
-URL:           https://rustsec.org/advisories/RUSTSEC-2021-0020
-Solution:      Upgrade to >=0.14.3 OR >=0.13.10, <0.14.0 OR >=0.12.36, <0.13.0
-Dependency tree: 
-hyper 0.13.8
-
-Crate:         ordered-float
-Version:       1.1.0
-Title:         ordered_float:NotNan may contain NaN after panic in assignment operators
-Date:          2020-12-06
-ID:            RUSTSEC-2020-0082
-URL:           https://rustsec.org/advisories/RUSTSEC-2020-0082
-Solution:      Upgrade to >=1.1.1, <2.0.0 OR >=2.0.1
-Dependency tree: 
-ordered-float 1.1.0
-└── witnet_data_structures 0.3.2
-    ├── witnet_wallet 0.3.2
-    │   └── witnet 1.2.1
-    ├── witnet_validations 0.3.2
-    │   ├── witnet_wallet 0.3.2
-    │   ├── witnet_node 0.4.0
-    │   │   └── witnet 1.2.1
-    │   ├── witnet-ethereum-bridge 0.1.0
-    │   └── witnet 1.2.1
-    ├── witnet_rad 0.3.2
-    │   ├── witnet_wallet 0.3.2
-    │   ├── witnet_validations 0.3.2
-    │   ├── witnet_node 0.4.0
-    │   └── witnet 1.2.1
-    ├── witnet_node 0.4.0
-    ├── witnet_config 0.3.2
-    │   ├── witnet_wallet 0.3.2
-    │   ├── witnet_p2p 0.3.2
-    │   │   └── witnet_node 0.4.0
-    │   ├── witnet_node 0.4.0
-    │   └── witnet 1.2.1
-    ├── witnet-ethereum-bridge 0.1.0
-    └── witnet 1.2.1
-
-Crate:         rand_core
-Version:       0.6.0
-Title:         Incorrect check on buffer length when seeding RNGs
-Date:          2021-02-12
-ID:            RUSTSEC-2021-0023
-URL:           https://rustsec.org/advisories/RUSTSEC-2021-0023
-Solution:      Upgrade to >=0.6.2
-Dependency tree: 
-rand_core 0.6.0
-
 Crate:         sized-chunks
 Version:       0.5.3
 Title:         Multiple soundness issues in Chunk and InlineArray
 Date:          2020-09-06
 ID:            RUSTSEC-2020-0041
 URL:           https://rustsec.org/advisories/RUSTSEC-2020-0041
 Solution:      Upgrade to >=0.6.3
 Dependency tree: 
 sized-chunks 0.5.3
 └── im 14.3.0
     └── sentry 0.18.1
         ├── witnet_node 0.4.0
         │   └── witnet 1.2.1
         └── witnet 1.2.1
 
-Crate:         smallvec
-Version:       0.6.13
-Title:         Buffer overflow in SmallVec::insert_many
-Date:          2021-01-08
-ID:            RUSTSEC-2021-0003
-URL:           https://rustsec.org/advisories/RUSTSEC-2021-0003
-Solution:      Upgrade to >=0.6.14, <1.0.0 OR >=1.6.1
-Dependency tree: 
-smallvec 0.6.13
-
-Crate:         smallvec
-Version:       1.6.0
-Title:         Buffer overflow in SmallVec::insert_many
-Date:          2021-01-08
-ID:            RUSTSEC-2021-0003
-URL:           https://rustsec.org/advisories/RUSTSEC-2021-0003
-Solution:      Upgrade to >=0.6.14, <1.0.0 OR >=1.6.1
-Dependency tree: 
-smallvec 1.6.0
-
 Crate:         failure
 Version:       0.1.8
 Warning:       unmaintained
 Title:         failure is officially deprecated/unmaintained
 Date:          2020-05-02
 ID:            RUSTSEC-2020-0036
 URL:           https://rustsec.org/advisories/RUSTSEC-2020-0036
 Dependency tree: 
 failure 0.1.8
 ├── witnet_wallet 0.3.2
 │   └── witnet 1.2.1
 ├── witnet_validations 0.3.2
 │   ├── witnet_wallet 0.3.2
 │   ├── witnet_node 0.4.0
 │   │   └── witnet 1.2.1
 │   ├── witnet-ethereum-bridge 0.1.0
 │   └── witnet 1.2.1
 ├── witnet_storage 0.3.2
 │   └── witnet_node 0.4.0
 ├── witnet_reputation 0.3.2
 │   └── witnet_data_structures 0.3.2
 │       ├── witnet_wallet 0.3.2
 │       ├── witnet_validations 0.3.2
 │       ├── witnet_rad 0.3.2
 │       │   ├── witnet_wallet 0.3.2
 │       │   ├── witnet_validations 0.3.2
 │       │   ├── witnet_node 0.4.0
 │       │   └── witnet 1.2.1
 │       ├── witnet_node 0.4.0
 │       ├── witnet_config 0.3.2
 │       │   ├── witnet_wallet 0.3.2
 │       │   ├── witnet_p2p 0.3.2
 │       │   │   └── witnet_node 0.4.0
 │       │   ├── witnet_node 0.4.0
 │       │   └── witnet 1.2.1
 │       ├── witnet-ethereum-bridge 0.1.0
 │       └── witnet 1.2.1
 ├── witnet_rad 0.3.2
 ├── witnet_p2p 0.3.2
 ├── witnet_node 0.4.0
 ├── witnet_net 0.1.0
 │   └── witnet_wallet 0.3.2
 ├── witnet_data_structures 0.3.2
 ├── witnet_crypto 0.3.2
 │   ├── witnet_wallet 0.3.2
 │   ├── witnet_validations 0.3.2
 │   ├── witnet_storage 0.3.2
 │   ├── witnet_rad 0.3.2
 │   ├── witnet_p2p 0.3.2
 │   ├── witnet_node 0.4.0
 │   ├── witnet_data_structures 0.3.2
 │   ├── witnet_config 0.3.2
 │   ├── witnet-ethereum-bridge 0.1.0
 │   └── witnet 1.2.1
 ├── witnet_config 0.3.2
 ├── witnet 1.2.1
 ├── vrf 0.2.2
 │   └── witnet_data_structures 0.3.2
 ├── tiny-bip39 0.7.3
 │   └── witnet_crypto 0.3.2
 ├── sentry-types 0.14.1
 │   └── sentry 0.18.1
 │       ├── witnet_node 0.4.0
 │       └── witnet 1.2.1
 ├── sentry 0.18.1
 └── bls-signatures-rs 0.1.0
     └── witnet_data_structures 0.3.2
 
 Crate:         net2
-Version:       0.2.35
+Version:       0.2.37
 Warning:       unmaintained
 Title:         `net2` crate has been deprecated; use `socket2` instead
 Date:          2020-05-01
 ID:            RUSTSEC-2020-0016
 URL:           https://rustsec.org/advisories/RUSTSEC-2020-0016
 Dependency tree: 
-net2 0.2.35
-├── miow 0.2.1
+net2 0.2.37
+├── miow 0.2.2
 ├── mio 0.6.22
-└── hyper 0.12.35
+└── hyper 0.12.36
 
 Crate:         term
 Version:       0.5.2
 Warning:       unmaintained
 Title:         term is looking for a new maintainer
 Date:          2018-11-19
 ID:            RUSTSEC-2018-0015
 URL:           https://rustsec.org/advisories/RUSTSEC-2018-0015
 Dependency tree: 
 term 0.5.2
 └── prettytable-rs 0.8.0
     └── witnet 1.2.1
 
-Crate:         arc-swap
-Version:       0.4.7
-Warning:       yanked
-
-Crate:         miow
-Version:       0.2.1
-Warning:       yanked
-Dependency tree: 
-miow 0.2.1
-
-Crate:         net2
-Version:       0.2.35
-Warning:       yanked
-
-Crate:         pin-project-lite
-Version:       0.1.11
-Warning:       yanked
-Dependency tree: 
-pin-project-lite 0.1.11
-
-Crate:         pin-project-lite
-Version:       0.2.0
-Warning:       yanked
-Dependency tree: 
-pin-project-lite 0.2.0
-
-Crate:         rand_core
-Version:       0.6.0
-Warning:       yanked
-
-error: 8 vulnerabilities found!
-warning: 9 allowed warnings found
+error: 1 vulnerability found!
+warning: 3 allowed warnings found
```
</details>

Side note: issue #1643 is not fixed but also not detected by running `cargo audit`, no idea why.