### PR TITLE
feat(bridge): add value limit to avoid relaying expensive DRs

### DIFF
--- a/bridges/centralized-ethereum/src/actors/dr_sender.rs
+++ b/bridges/centralized-ethereum/src/actors/dr_sender.rs
@@ -129,13 +129,19 @@ impl DrSender {
                         // error and report error as result to ethereum.
                         log::error!("[{}] error: {}", dr_id, err);
                         let result = err.encode_cbor();
+                        // In this case there is no data request transaction, so the dr_tx_hash
+                        // field can be set to anything.
+                        // Except all zeros, because that hash is invalid.
+                        let dr_tx_hash =
+                            "0000000000000000000000000000000000000000000000000000000000000001"
+                                .parse()
+                                .unwrap();
 
-                        // TODO: review if dr_tx_hash = [0;32] makes sense
                         dr_reporter_addr
                             .send(DrReporterMsg {
                                 dr_id,
                                 dr_bytes,
-                                dr_tx_hash: Default::default(),
+                                dr_tx_hash,
                                 result,
                             })
                             .await

--- a/bridges/centralized-ethereum/src/actors/dr_sender.rs
+++ b/bridges/centralized-ethereum/src/actors/dr_sender.rs
@@ -20,6 +20,9 @@ use witnet_data_structures::{
 };
 use witnet_validations::validations::{validate_data_request_output, validate_rad_request};
 
+#[cfg(test)]
+mod tests;
+
 /// DrSender actor reads the new requests from DrDatabase and includes them in Witnet
 #[derive(Default)]
 pub struct DrSender {

--- a/bridges/centralized-ethereum/src/actors/dr_sender/tests.rs
+++ b/bridges/centralized-ethereum/src/actors/dr_sender/tests.rs
@@ -1,0 +1,85 @@
+use super::*;
+use witnet_data_structures::chain::{RADAggregate, RADRequest, RADRetrieve, RADTally};
+
+#[test]
+fn deserialize_empty_dr() {
+    // An empty data request is invalid with error 0xE0: BridgeMalformedRequest
+    let err = deserialize_and_validate_dr_bytes(&[], 1).unwrap_err();
+    assert_eq!(err.encode_cbor(), vec![216, 39, 129, 24, 224]);
+}
+
+#[test]
+fn deserialize_dr_not_protobuf() {
+    // A malformed data request is invalid with error 0xE0: BridgeMalformedRequest
+    let err = deserialize_and_validate_dr_bytes(&[1, 2, 3, 4], 1).unwrap_err();
+    assert_eq!(err.encode_cbor(), vec![216, 39, 129, 24, 224]);
+}
+
+#[test]
+fn deserialize_dr_high_value() {
+    // A minimal valid data request
+    let dro = DataRequestOutput {
+        witness_reward: 1_000_000,
+        witnesses: 20,
+        min_consensus_percentage: 51,
+        data_request: RADRequest {
+            retrieve: vec![RADRetrieve {
+                url: "http://127.0.0.1:8000".to_string(),
+                script: vec![128],
+                ..Default::default()
+            }],
+            aggregate: RADAggregate {
+                filters: vec![],
+                reducer: 3,
+            },
+            tally: RADTally {
+                filters: vec![],
+                reducer: 3,
+            },
+            time_lock: 0,
+        },
+        ..Default::default()
+    };
+    // The cost of creating this data request is the reward (1_000_000) times the number of
+    // witnesses (20)
+    let total_value = dro.checked_total_value().unwrap();
+    assert_eq!(total_value, 20_000_000);
+
+    let dro_bytes = dro.to_pb_bytes().unwrap();
+    // Setting the maximum allowed value to 1 nanowit below that will result in an error 0xE1:
+    // BridgePoorIncentives
+    let err = deserialize_and_validate_dr_bytes(&dro_bytes, total_value - 1).unwrap_err();
+    assert_eq!(err.encode_cbor(), vec![216, 39, 129, 24, 225]);
+}
+
+#[test]
+fn deserialize_dr_value_overflow() {
+    // This data request will return an error when calling checked_total_value()
+    // This will result in error 0xE0: BridgeMalformedRequest
+    let dro = DataRequestOutput {
+        witness_reward: u64::MAX,
+        witnesses: 20,
+        min_consensus_percentage: 51,
+        data_request: RADRequest {
+            retrieve: vec![RADRetrieve {
+                url: "http://127.0.0.1:8000".to_string(),
+                script: vec![128],
+                ..Default::default()
+            }],
+            aggregate: RADAggregate {
+                filters: vec![],
+                reducer: 3,
+            },
+            tally: RADTally {
+                filters: vec![],
+                reducer: 3,
+            },
+            time_lock: 0,
+        },
+        ..Default::default()
+    };
+
+    let dro_bytes = dro.to_pb_bytes().unwrap();
+    let err = deserialize_and_validate_dr_bytes(&dro_bytes, 1).unwrap_err();
+    assert_eq!(err.encode_cbor(), vec![216, 39, 129, 24, 224]);
+}

--- a/bridges/centralized-ethereum/src/config.rs
+++ b/bridges/centralized-ethereum/src/config.rs
@@ -28,7 +28,7 @@ pub struct Config {
     pub wit_tally_polling_rate_ms: u64,
     /// Period to post new requests to Witnet
     pub wit_dr_sender_polling_rate_ms: u64,
-    /// Max value that will be accepted in a data request
+    /// Max value that will be accepted by the bridge node in a data request
     pub max_dr_value_nanowits: u64,
     /// Running in the witnet testnet?
     pub witnet_testnet: bool,

--- a/bridges/centralized-ethereum/src/config.rs
+++ b/bridges/centralized-ethereum/src/config.rs
@@ -28,6 +28,8 @@ pub struct Config {
     pub wit_tally_polling_rate_ms: u64,
     /// Period to post new requests to Witnet
     pub wit_dr_sender_polling_rate_ms: u64,
+    /// Max value that will be accepted in a data request
+    pub max_dr_value_nanowits: u64,
     /// Running in the witnet testnet?
     pub witnet_testnet: bool,
     /// Gas limits for some methods. If missing, let the client estimate

--- a/witnet_centralized_ethereum_bridge.toml
+++ b/witnet_centralized_ethereum_bridge.toml
@@ -15,7 +15,7 @@ wit_tally_polling_rate_ms = 45_000
 # Period to post new requests to Witnet
 wit_dr_sender_polling_rate_ms = 45_000
 
-# Max value that will be accepted in a data request
+# Max value that will be accepted by the bridge node in a data request
 # This is the maximum amount that the relayer is willing to lose per one data request
 max_dr_value_nanowits = 100_000_000_000
 

--- a/witnet_centralized_ethereum_bridge.toml
+++ b/witnet_centralized_ethereum_bridge.toml
@@ -15,6 +15,10 @@ wit_tally_polling_rate_ms = 45_000
 # Period to post new requests to Witnet
 wit_dr_sender_polling_rate_ms = 45_000
 
+# Max value that will be accepted in a data request
+# This is the maximum amount that the relayer is willing to lose per one data request
+max_dr_value_nanowits = 100_000_000_000
+
 # Running in the witnet testnet?
 witnet_testnet = true
 


### PR DESCRIPTION
Close #1904

Add a limit to the total value of a data request: this is the total cost of creating the data request, including all the fees. The bridge node will treat any data requests with a higher value as errors, and report a generic error to solidity.