### PR TITLE
chore: fix clippy warnings for rust 1.52

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2974,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.18.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d147edb77bcccbfc81fabffdc7bd50c13e103b15ca1e27515fe40de69a5776b"
+checksum = "45604fc7a88158e7d514d8e22e14ac746081e7a70d7690074dd0029ee37458d6"
 dependencies = [
  "serde",
  "serde_derive",
@@ -2984,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.18.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e81f70c25aab9506f87253c55f7cdcd8917635d5597382958d20025c211bbbd"
+checksum = "cb87f342b585958c1c086313dbc468dcac3edf5e90362111c26d7a58127ac095"
 dependencies = [
  "protobuf",
 ]
@@ -3004,19 +3004,19 @@ dependencies = [
 
 [[package]]
 name = "protoc"
-version = "2.18.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57408af2c106a7f08cc61e15be6a31e3ace8ea26f90dd1be1ad19abf1073d36a"
+checksum = "4677a99cc1f866078918c00773cbb46dd72eecad949a31981de5aad1ff9bcc8d"
 dependencies = [
- "log 0.3.9",
+ "log 0.4.11",
  "which 4.0.2",
 ]
 
 [[package]]
 name = "protoc-rust"
-version = "2.18.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21c1582ff3efeccef1385b1c2dfaf4a9b5bc7794865624fc2a3ca9dff1145fa1"
+checksum = "b35a8c288bd8b80ab9eb660b75de7b99be75ee1a0a3920f15b4924d38da43f6c"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/bridges/ethereum/src/eth.rs
+++ b/bridges/ethereum/src/eth.rs
@@ -418,10 +418,10 @@ impl EthState {
             web3,
             accounts,
             wrb_contract,
-            block_relay_contract,
             post_dr_event_sig,
             inclusion_dr_event_sig,
             post_tally_event_sig,
+            block_relay_contract,
             wrb_requests,
         })
     }

--- a/data_structures/Cargo.toml
+++ b/data_structures/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4.8"
 num_enum = "0.4.2"
 ordered-float = "1.0"
 partial_struct = { path = "../partial_struct" }
-protobuf = { version = "2.10.1", features = ["with-serde"] }
+protobuf = { version = "2.23.0", features = ["with-serde"] }
 protobuf-convert = "0.1.1"
 rand = "0.7.3"
 serde = { version = "1.0.104", features = ["derive"] }

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -2699,8 +2699,8 @@ impl FromStr for OutputPointer {
             .map_err(OutputPointerParseError::ParseIntError)?;
 
         Ok(OutputPointer {
-            output_index,
             transaction_id,
+            output_index,
         })
     }
 }
@@ -2838,10 +2838,10 @@ impl DataRequestState {
 
         Self {
             data_request,
+            pkh,
             info,
             stage,
             epoch,
-            pkh,
         }
     }
 

--- a/partial_struct/src/lib.rs
+++ b/partial_struct/src/lib.rs
@@ -109,9 +109,9 @@ fn get_partial(input: &syn::DeriveInput) -> syn::DeriveInput {
     let generics = input.generics.clone();
 
     syn::DeriveInput {
-        ident,
         attrs,
         vis,
+        ident,
         generics,
         data,
     }

--- a/storage/src/backends/crypto.rs
+++ b/storage/src/backends/crypto.rs
@@ -21,7 +21,7 @@ impl<T: Storage> Backend<T> {
     /// actual storage backend but will encrypt the data with
     /// `password`
     pub fn new(password: Protected, backend: T) -> Self {
-        Backend { password, backend }
+        Backend { backend, password }
     }
 
     /// Get a reference to the inner storage backend

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -408,11 +408,11 @@ where
 
         let address = model::Address {
             address,
+            index,
+            keychain,
+            account,
             path,
             info,
-            index,
-            account,
-            keychain,
             pkh,
         };
 
@@ -629,12 +629,12 @@ where
 
             Ok(Arc::new(model::Address {
                 address,
-                path,
-                pkh,
                 index,
-                account,
                 keychain,
+                account,
+                path,
                 info,
+                pkh,
             }))
         }
     }
@@ -1627,9 +1627,9 @@ where
             signature::sign(&self.engine, parent_key.secret_key, hashed_data.as_ref())?.to_string();
 
         Ok(model::ExtendedKeyedSignature {
-            chaincode,
-            public_key,
             signature,
+            public_key,
+            chaincode,
         })
     }
 

--- a/wallet/src/repository/wallet/tests/factories.rs
+++ b/wallet/src/repository/wallet/tests/factories.rs
@@ -121,6 +121,6 @@ impl BlockInfo {
         );
         let epoch = self.epoch.unwrap_or_else(rand::random);
 
-        model::Beacon { block_hash, epoch }
+        model::Beacon { epoch, block_hash }
     }
 }


### PR DESCRIPTION
I had to update the `protobuf` crate to get rid of a new error, and updating it may be dangerous if there is some weird serialization format change because we use protobuf to calculate the hashes of blocks and transactions, so any change would have changed the hash. So I have run a full resync on a mainnet node to ensure that nothing breaks.