### PR TITLE
feat: create struct to store active WIPs

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1,13 +1,3 @@
-use bech32::{FromBase32, ToBase32};
-use bls_signatures_rs::{bn256, bn256::Bn256, MultiSignature};
-use failure::Fail;
-use ordered_float::OrderedFloat;
-use partial_struct::PartialStruct;
-use secp256k1::{
-    PublicKey as Secp256k1_PublicKey, SecretKey as Secp256k1_SecretKey,
-    Signature as Secp256k1_Signature,
-};
-use serde::{Deserialize, Serialize};
 use std::{
     cell::{Cell, RefCell},
     cmp::Ordering,
@@ -17,6 +7,18 @@ use std::{
     ops::{AddAssign, SubAssign},
     str::FromStr,
 };
+
+use bech32::{FromBase32, ToBase32};
+use bls_signatures_rs::{bn256, bn256::Bn256, MultiSignature};
+use failure::Fail;
+use ordered_float::OrderedFloat;
+use secp256k1::{
+    PublicKey as Secp256k1_PublicKey, SecretKey as Secp256k1_SecretKey,
+    Signature as Secp256k1_Signature,
+};
+use serde::{Deserialize, Serialize};
+
+use partial_struct::PartialStruct;
 use witnet_crypto::{
     hash::{calculate_sha256, Sha256},
     key::ExtendedSK,
@@ -3843,11 +3845,6 @@ pub fn block_example() -> Block {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{
-        superblock::{mining_build_superblock, ARSIdentities},
-        transaction::{CommitTransactionBody, RevealTransactionBody, VTTransactionBody},
-    };
     use witnet_crypto::{
         merkle::{merkle_tree_root, InclusionProof},
         secp256k1::{
@@ -3855,6 +3852,13 @@ mod tests {
         },
         signature::sign,
     };
+
+    use crate::{
+        superblock::{mining_build_superblock, ARSIdentities},
+        transaction::{CommitTransactionBody, RevealTransactionBody, VTTransactionBody},
+    };
+
+    use super::*;
 
     fn dr_root_superblock_loop_test(
         sb: SuperBlock,

--- a/data_structures/src/data_request.rs
+++ b/data_structures/src/data_request.rs
@@ -486,7 +486,7 @@ where
 
         // Collateral division rest goes for the miner
         let non_reveals_count = commits_count - reveals_count;
-        let is_after_second_hard_fork = active_wips.second_hard_fork();
+        let is_after_second_hard_fork = active_wips.wips_0009_0011_0012();
         let (reward, _rest) = if is_after_second_hard_fork {
             calculate_witness_reward(
                 commits_count,

--- a/data_structures/src/data_request.rs
+++ b/data_structures/src/data_request.rs
@@ -9,8 +9,7 @@ use crate::{
         Hashable, PublicKeyHash, ValueTransferOutput,
     },
     error::{DataRequestError, TransactionError},
-    get_environment,
-    mainnet_validations::after_second_hard_fork,
+    mainnet_validations::ActiveWips,
     radon_report::{RadonReport, Stage, TypeLike},
     transaction::{CommitTransaction, DRTransaction, RevealTransaction, TallyTransaction},
 };
@@ -460,7 +459,7 @@ pub fn create_tally<RT, S: ::std::hash::BuildHasher>(
     committers: HashSet<PublicKeyHash, S>,
     collateral_minimum: u64,
     tally_bytes_on_encode_error: Vec<u8>,
-    block_epoch: Epoch,
+    active_wips: &ActiveWips,
 ) -> TallyTransaction
 where
     RT: TypeLike,
@@ -487,7 +486,7 @@ where
 
         // Collateral division rest goes for the miner
         let non_reveals_count = commits_count - reveals_count;
-        let is_after_second_hard_fork = after_second_hard_fork(block_epoch, get_environment());
+        let is_after_second_hard_fork = active_wips.second_hard_fork();
         let (reward, _rest) = if is_after_second_hard_fork {
             calculate_witness_reward(
                 commits_count,

--- a/data_structures/src/mainnet_validations.rs
+++ b/data_structures/src/mainnet_validations.rs
@@ -245,6 +245,32 @@ pub fn after_second_hard_fork(epoch: Epoch, environment: Environment) -> bool {
     epoch >= SECOND_HARD_FORK && Environment::Mainnet == environment
 }
 
+/// Allows to check the active Witnet Improvement Proposals
+#[derive(Clone, Debug)]
+pub struct ActiveWips {
+    pub active_wips: HashMap<&'static str, Epoch>,
+    pub block_epoch: Epoch,
+    pub environment: Environment,
+}
+
+impl ActiveWips {
+    pub fn first_hard_fork(&self) -> bool {
+        after_first_hard_fork(self.block_epoch, self.environment)
+    }
+
+    pub fn second_hard_fork(&self) -> bool {
+        after_second_hard_fork(self.block_epoch, self.environment)
+    }
+
+    pub fn wip0014(&self) -> bool {
+        // TODO: ignore environment?
+        self.active_wips
+            .get("WIP0014")
+            .map(|activation_epoch| self.block_epoch >= *activation_epoch)
+            .unwrap_or(false)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/data_structures/src/mainnet_validations.rs
+++ b/data_structures/src/mainnet_validations.rs
@@ -248,7 +248,7 @@ pub fn after_second_hard_fork(epoch: Epoch, environment: Environment) -> bool {
 /// Allows to check the active Witnet Improvement Proposals
 #[derive(Clone, Debug)]
 pub struct ActiveWips {
-    pub active_wips: HashMap<&'static str, Epoch>,
+    pub active_wips: HashMap<String, Epoch>,
     pub block_epoch: Epoch,
     pub environment: Environment,
 }

--- a/data_structures/src/mainnet_validations.rs
+++ b/data_structures/src/mainnet_validations.rs
@@ -265,7 +265,6 @@ pub fn after_second_hard_fork(epoch: Epoch, environment: Environment) -> bool {
 pub struct ActiveWips {
     pub active_wips: HashMap<String, Epoch>,
     pub block_epoch: Epoch,
-    pub environment: Environment,
 }
 
 impl ActiveWips {

--- a/data_structures/src/mainnet_validations.rs
+++ b/data_structures/src/mainnet_validations.rs
@@ -70,25 +70,40 @@ impl TapiEngine {
         self.bit_tapi_counter.last_epoch = epoch_to_update;
     }
 
-    pub fn initialize_wip_information(&mut self) -> (Epoch, HashSet<String>) {
-        // Hardcoded information about WIPs
-        self.wip_activation
-            .insert("WIP0008".to_string(), FIRST_HARD_FORK);
-        self.wip_activation
-            .insert("WIP0009-0011-0012".to_string(), SECOND_HARD_FORK);
-
-        // Hardcoded information about WIPs in vote processing
+    pub fn initialize_wip_information(
+        &mut self,
+        environment: Environment,
+    ) -> (Epoch, HashSet<String>) {
         let mut voting_wips = vec![None; 32];
-        let bit = 0;
-        let wip_0014 = BitVotesCounter {
-            votes: 0,
-            period: 26880,
-            wip: "WIP0014".to_string(),
-            init: 500000,
-            end: u32::MAX,
-            bit,
+
+        match environment {
+            Environment::Mainnet => {
+                // Hardcoded information about WIPs
+                self.wip_activation
+                    .insert("WIP0008".to_string(), FIRST_HARD_FORK);
+                self.wip_activation
+                    .insert("WIP0009-0011-0012".to_string(), SECOND_HARD_FORK);
+
+                // Hardcoded information about WIPs in vote processing
+                let bit = 0;
+                let wip_0014 = BitVotesCounter {
+                    votes: 0,
+                    period: 26880,
+                    wip: "WIP0014".to_string(),
+                    init: 500000,
+                    end: u32::MAX,
+                    bit,
+                };
+                voting_wips[bit] = Some(wip_0014);
+            }
+            Environment::Testnet | Environment::Development => {
+                // In non-mainnet chains, all the WIPs that are active in mainnet are considered
+                // active since epoch 0. And there is no voting.
+                self.wip_activation.insert("WIP0008".to_string(), 0);
+                self.wip_activation
+                    .insert("WIP0009-0011-0012".to_string(), 0);
+            }
         };
-        voting_wips[bit] = Some(wip_0014);
 
         // Assessment of new WIPs
         let mut min_epoch = u32::MAX;
@@ -256,16 +271,21 @@ pub struct ActiveWips {
 impl ActiveWips {
     // WIP 0008 was activated through community coordination on January 22, 2021
     pub fn wip_0008(&self) -> bool {
-        after_first_hard_fork(self.block_epoch, self.environment)
+        self.active_wips
+            .get("WIP0008")
+            .map(|activation_epoch| self.block_epoch >= *activation_epoch)
+            .unwrap_or(false)
     }
 
     // WIPs 0009, 0011 and 0012 were activated through community coordination on April 28, 2021
     pub fn wips_0009_0011_0012(&self) -> bool {
-        after_second_hard_fork(self.block_epoch, self.environment)
+        self.active_wips
+            .get("WIP0009-0011-0012")
+            .map(|activation_epoch| self.block_epoch >= *activation_epoch)
+            .unwrap_or(false)
     }
 
     pub fn wip0014(&self) -> bool {
-        // TODO: ignore environment?
         self.active_wips
             .get("WIP0014")
             .map(|activation_epoch| self.block_epoch >= *activation_epoch)
@@ -534,7 +554,7 @@ mod tests {
     fn test_initialize_wip_information() {
         let mut t = TapiEngine::default();
 
-        let (epoch, old_wips) = t.initialize_wip_information();
+        let (epoch, old_wips) = t.initialize_wip_information(Environment::Mainnet);
         // The first block whose vote must be counted is the one from WIP0014
         let init_epoch_wip0014 = 500000;
         assert_eq!(epoch, init_epoch_wip0014);
@@ -547,7 +567,7 @@ mod tests {
         assert_eq!(t.wip_activation, hm);
 
         // Test initialize_wip_information with a non-empty TapiEngine
-        let (epoch, old_wips) = t.initialize_wip_information();
+        let (epoch, old_wips) = t.initialize_wip_information(Environment::Mainnet);
         // WIP0014 is already included and it won't be updated
         let name_wip0014 = "WIP0014".to_string();
         let mut hs = HashSet::new();
@@ -556,5 +576,20 @@ mod tests {
 
         // There is no new WIPs to update so we obtain the max value
         assert_eq!(epoch, u32::MAX);
+    }
+
+    #[test]
+    fn test_initialize_mainnet_and_testnet() {
+        let mut t_mainnet = TapiEngine::default();
+        let (_epoch, _old_wips) = t_mainnet.initialize_wip_information(Environment::Mainnet);
+
+        let mut t_testnet = TapiEngine::default();
+        let (_epoch, _old_wips) = t_testnet.initialize_wip_information(Environment::Testnet);
+
+        // The keys of the wip_activation map should be the same
+        assert_eq!(
+            t_testnet.wip_activation.keys().collect::<HashSet<_>>(),
+            t_mainnet.wip_activation.keys().collect::<HashSet<_>>(),
+        )
     }
 }

--- a/data_structures/src/mainnet_validations.rs
+++ b/data_structures/src/mainnet_validations.rs
@@ -252,12 +252,18 @@ pub fn in_emergency_period(
 
 /// Returns a boolean indicating whether the epoch provided is after the first hard fork date
 pub fn after_first_hard_fork(epoch: Epoch, environment: Environment) -> bool {
-    epoch >= FIRST_HARD_FORK && Environment::Mainnet == environment
+    match environment {
+        Environment::Mainnet => epoch >= FIRST_HARD_FORK,
+        Environment::Testnet | Environment::Development => true,
+    }
 }
 
 /// Returns a boolean indicating whether the epoch provided is after the second hard fork date
 pub fn after_second_hard_fork(epoch: Epoch, environment: Environment) -> bool {
-    epoch >= SECOND_HARD_FORK && Environment::Mainnet == environment
+    match environment {
+        Environment::Mainnet => epoch >= SECOND_HARD_FORK,
+        Environment::Testnet | Environment::Development => true,
+    }
 }
 
 /// Allows to check the active Witnet Improvement Proposals

--- a/data_structures/src/mainnet_validations.rs
+++ b/data_structures/src/mainnet_validations.rs
@@ -254,11 +254,13 @@ pub struct ActiveWips {
 }
 
 impl ActiveWips {
-    pub fn first_hard_fork(&self) -> bool {
+    // WIP 0008 was activated through community coordination on January 22, 2021
+    pub fn wip_0008(&self) -> bool {
         after_first_hard_fork(self.block_epoch, self.environment)
     }
 
-    pub fn second_hard_fork(&self) -> bool {
+    // WIPs 0009, 0011 and 0012 were activated through community coordination on April 28, 2021
+    pub fn wips_0009_0011_0012(&self) -> bool {
         after_second_hard_fork(self.block_epoch, self.environment)
     }
 

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -18,6 +18,7 @@ use witnet_data_structures::{
         ReputationEngine,
     },
     data_request::DataRequestPool,
+    get_environment,
     superblock::SuperBlockState,
     types::LastBeacon,
     utxo_pool::OwnUnspentOutputsPool,
@@ -255,7 +256,7 @@ impl ChainManager {
                 act.chain_state = chain_state;
 
                 // Update possible new WIP information
-                let (new_wip_epoch, old_wips) = act.chain_state.tapi_engine.initialize_wip_information();
+                let (new_wip_epoch, old_wips) = act.chain_state.tapi_engine.initialize_wip_information(get_environment());
                 let last_consolidated_epoch = act.get_chain_beacon().checkpoint;
                 if new_wip_epoch < last_consolidated_epoch {
                     // Some blocks have been consolidated before this node updated to the latest version,

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -1,8 +1,3 @@
-use actix::{
-    ActorFutureExt, AsyncContext, Context, ContextFutureSpawner, SystemService, WrapFuture,
-};
-use ansi_term::Color::{White, Yellow};
-use futures::future::{try_join_all, FutureExt};
 use std::{
     collections::HashSet,
     convert::TryFrom,
@@ -14,6 +9,35 @@ use std::{
     },
 };
 
+use actix::{
+    ActorFutureExt, AsyncContext, Context, ContextFutureSpawner, SystemService, WrapFuture,
+};
+use ansi_term::Color::{White, Yellow};
+use futures::future::{try_join_all, FutureExt};
+
+use witnet_data_structures::{
+    chain::{
+        Block, BlockHeader, BlockMerkleRoots, BlockTransactions, Bn256PublicKey, CheckpointBeacon,
+        CheckpointVRF, DataRequestOutput, EpochConstants, Hash, Hashable, Input, PublicKeyHash,
+        ReputationEngine, TransactionsPool, ValueTransferOutput,
+    },
+    data_request::{
+        calculate_witness_reward, calculate_witness_reward_before_second_hard_fork, create_tally,
+        DataRequestPool,
+    },
+    error::TransactionError,
+    get_environment,
+    mainnet_validations::{after_second_hard_fork, ActiveWips},
+    radon_report::{RadonReport, ReportContext},
+    transaction::{
+        CommitTransaction, CommitTransactionBody, DRTransactionBody, MintTransaction,
+        RevealTransaction, RevealTransactionBody, TallyTransaction, VTTransactionBody,
+    },
+    transaction_factory::build_commit_collateral,
+    utxo_pool::{UnspentOutputsPool, UtxoDiff},
+    vrf::{BlockEligibilityClaim, DataRequestEligibilityClaim, VrfMessage},
+};
+use witnet_futures_utils::{ActorFutureExt2, TryFutureExt2};
 use witnet_rad::{error::RadError, types::serial_iter_decode};
 use witnet_util::timestamp::get_timestamp;
 use witnet_validations::validations::{
@@ -30,29 +54,6 @@ use crate::{
     },
     signature_mngr,
 };
-use witnet_data_structures::{
-    chain::{
-        Block, BlockHeader, BlockMerkleRoots, BlockTransactions, Bn256PublicKey, CheckpointBeacon,
-        CheckpointVRF, DataRequestOutput, EpochConstants, Hash, Hashable, Input, PublicKeyHash,
-        ReputationEngine, TransactionsPool, ValueTransferOutput,
-    },
-    data_request::{
-        calculate_witness_reward, calculate_witness_reward_before_second_hard_fork, create_tally,
-        DataRequestPool,
-    },
-    error::TransactionError,
-    get_environment,
-    mainnet_validations::after_second_hard_fork,
-    radon_report::{RadonReport, ReportContext},
-    transaction::{
-        CommitTransaction, CommitTransactionBody, DRTransactionBody, MintTransaction,
-        RevealTransaction, RevealTransactionBody, TallyTransaction, VTTransactionBody,
-    },
-    transaction_factory::build_commit_collateral,
-    utxo_pool::{UnspentOutputsPool, UtxoDiff},
-    vrf::{BlockEligibilityClaim, DataRequestEligibilityClaim, VrfMessage},
-};
-use witnet_futures_utils::{ActorFutureExt2, TryFutureExt2};
 
 impl ChainManager {
     /// Try to mine a block
@@ -136,6 +137,11 @@ impl ChainManager {
 
         let own_pkh = self.own_pkh.unwrap_or_default();
         let is_ars_member = rep_engine.is_ars_member(&own_pkh);
+        let active_wips = ActiveWips {
+            active_wips: Default::default(),
+            block_epoch: current_epoch,
+            environment: get_environment(),
+        };
 
         // Create a VRF proof and if eligible build block
         signature_mngr::vrf_prove(VrfMessage::block_mining(vrf_input))
@@ -149,6 +155,7 @@ impl ChainManager {
                             current_epoch,
                             minimum_difficulty,
                             epochs_with_minimum_difficulty,
+                            &active_wips,
                         );
                         let proof_invalid = vrf_proof_hash > target_hash;
 
@@ -495,12 +502,17 @@ impl ChainManager {
                     let rad_request = dr_state.data_request.data_request.clone();
 
                     // Send ResolveRA message to RADManager
+                    let active_wips = ActiveWips {
+                        active_wips: Default::default(),
+                        block_epoch: current_epoch,
+                        environment: get_environment(),
+                    };
                     let rad_manager_addr = RadManager::from_registry();
                     rad_manager_addr
                         .send(ResolveRA {
                             rad_request,
                             timeout: data_request_timeout,
-                            current_epoch,
+                            active_wips,
                         })
                         .map(move |res|
                             res.map(move |result| match result {
@@ -655,13 +667,18 @@ impl ChainManager {
                         let rad_manager_addr = RadManager::from_registry();
 
                         // The result of `RunTally` will be published as tally
+                        let active_wips = ActiveWips {
+                            active_wips: Default::default(),
+                            block_epoch,
+                            environment: get_environment(),
+                        };
                         let tally_result = rad_manager_addr
                             .send(RunTally {
                                 min_consensus_ratio,
                                 reports: reports.clone(),
                                 script: dr_state.data_request.data_request.tally.clone(),
                                 commits_count,
-                                block_epoch,
+                                active_wips: active_wips.clone(),
                             })
                             .await
                             .unwrap_or_else(|e| {
@@ -686,7 +703,7 @@ impl ChainManager {
                             committers,
                             collateral_minimum,
                             tally_bytes_on_encode_error(),
-                            block_epoch,
+                            &active_wips,
                         );
 
                         log::info!(
@@ -1037,16 +1054,17 @@ mod tests {
         PublicKey as Secp256k1_PublicKey, Secp256k1, SecretKey as Secp256k1_SecretKey,
     };
 
-    const INITIAL_BLOCK_REWARD: u64 = 250 * 1_000_000_000;
-    const HALVING_PERIOD: u32 = 3_500_000;
-
     use witnet_crypto::signature::{sign, verify};
     use witnet_data_structures::{chain::*, transaction::*, vrf::VrfCtx};
     use witnet_protected::Protected;
     use witnet_validations::validations::validate_block_signature;
 
-    use super::*;
     use crate::actors::chain_manager::verify_signatures;
+
+    use super::*;
+
+    const INITIAL_BLOCK_REWARD: u64 = 250 * 1_000_000_000;
+    const HALVING_PERIOD: u32 = 3_500_000;
 
     #[test]
     fn build_empty_block() {

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -138,7 +138,7 @@ impl ChainManager {
         let own_pkh = self.own_pkh.unwrap_or_default();
         let is_ars_member = rep_engine.is_ars_member(&own_pkh);
         let active_wips = ActiveWips {
-            active_wips: Default::default(),
+            active_wips: self.chain_state.tapi_engine.wip_activation.clone(),
             block_epoch: current_epoch,
             environment: get_environment(),
         };
@@ -207,6 +207,8 @@ impl ChainManager {
                     act.bn256_public_key.clone()
                 };
 
+                let tapi_version = act.tapi_signals_mask();
+
                 // Build the block using the supplied beacon and eligibility proof
                 let (block_header, txns) = build_block(
                     (
@@ -228,6 +230,7 @@ impl ChainManager {
                     act.external_percentage,
                     initial_block_reward,
                     halving_period,
+                    tapi_version,
                 );
 
                 // Sign the block hash
@@ -503,7 +506,7 @@ impl ChainManager {
 
                     // Send ResolveRA message to RADManager
                     let active_wips = ActiveWips {
-                        active_wips: Default::default(),
+                        active_wips: act.chain_state.tapi_engine.wip_activation.clone(),
                         block_epoch: current_epoch,
                         environment: get_environment(),
                     };
@@ -626,11 +629,14 @@ impl ChainManager {
                 )
             })
             .collect::<Vec<_>>();
+        let active_wips = self.chain_state.tapi_engine.wip_activation.clone();
 
         let future_tally_transactions =
             dr_reveals
                 .into_iter()
                 .map(move |(dr_pointer, reveals, dr_state)| {
+                    let active_wips = active_wips.clone();
+
                     async move {
                         log::debug!("Building tally for data request {}", dr_pointer);
 
@@ -668,7 +674,7 @@ impl ChainManager {
 
                         // The result of `RunTally` will be published as tally
                         let active_wips = ActiveWips {
-                            active_wips: Default::default(),
+                            active_wips,
                             block_epoch,
                             environment: get_environment(),
                         };
@@ -759,6 +765,7 @@ pub fn build_block(
     external_percentage: u8,
     initial_block_reward: u64,
     halving_period: u32,
+    tapi_version: u32,
 ) -> (BlockHeader, BlockTransactions) {
     let (transactions_pool, unspent_outputs_pool, dr_pool) = pools_ref;
     let epoch = beacon.checkpoint;
@@ -941,7 +948,7 @@ pub fn build_block(
     };
 
     let block_header = BlockHeader {
-        version: 0,
+        version: tapi_version,
         beacon,
         merkle_roots,
         proof,
@@ -1106,6 +1113,7 @@ mod tests {
             0,
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
+            0,
         );
         let block = Block::new(block_header, KeyedSignature::default(), txns);
 
@@ -1175,6 +1183,7 @@ mod tests {
             0,
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
+            0,
         );
 
         // Create a KeyedSignature
@@ -1297,6 +1306,7 @@ mod tests {
             0,
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
+            0,
         );
         let block = Block::new(block_header, KeyedSignature::default(), txns);
 
@@ -1391,6 +1401,7 @@ mod tests {
             0,
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
+            0,
         );
         let block = Block::new(block_header, KeyedSignature::default(), txns);
 
@@ -1480,6 +1491,7 @@ mod tests {
             0,
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
+            0,
         );
         let block = Block::new(block_header, KeyedSignature::default(), txns);
 
@@ -1571,6 +1583,7 @@ mod tests {
             0,
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
+            0,
         );
         let block = Block::new(block_header, KeyedSignature::default(), txns);
 

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -140,7 +140,6 @@ impl ChainManager {
         let active_wips = ActiveWips {
             active_wips: self.chain_state.tapi_engine.wip_activation.clone(),
             block_epoch: current_epoch,
-            environment: get_environment(),
         };
 
         // Create a VRF proof and if eligible build block
@@ -508,7 +507,6 @@ impl ChainManager {
                     let active_wips = ActiveWips {
                         active_wips: act.chain_state.tapi_engine.wip_activation.clone(),
                         block_epoch: current_epoch,
-                        environment: get_environment(),
                     };
                     let rad_manager_addr = RadManager::from_registry();
                     rad_manager_addr
@@ -676,7 +674,6 @@ impl ChainManager {
                         let active_wips = ActiveWips {
                             active_wips,
                             block_epoch,
-                            environment: get_environment(),
                         };
                         let tally_result = rad_manager_addr
                             .send(RunTally {

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -468,7 +468,7 @@ impl ChainManager {
             let mut vrf_input = chain_info.highest_vrf_output;
             vrf_input.checkpoint = block.block_header.beacon.checkpoint;
             let active_wips = ActiveWips {
-                active_wips: Default::default(),
+                active_wips: self.chain_state.tapi_engine.wip_activation.clone(),
                 block_epoch: block.block_header.beacon.checkpoint,
                 environment: get_environment(),
             };
@@ -535,7 +535,7 @@ impl ChainManager {
                 let mut vrf_input = chain_info.highest_vrf_output;
                 vrf_input.checkpoint = current_epoch;
                 let active_wips = ActiveWips {
-                    active_wips: Default::default(),
+                    active_wips: self.chain_state.tapi_engine.wip_activation.clone(),
                     block_epoch: block.block_header.beacon.checkpoint,
                     environment: get_environment(),
                 };
@@ -1139,7 +1139,7 @@ impl ChainManager {
             let mut vrf_input = chain_info.highest_vrf_output;
             vrf_input.checkpoint = current_epoch;
             let active_wips = ActiveWips {
-                active_wips: Default::default(),
+                active_wips: self.chain_state.tapi_engine.wip_activation.clone(),
                 // If this transaction will be included in a block, the block epoch must be greater
                 // than or equal to the current epoch
                 block_epoch: current_epoch,
@@ -1617,7 +1617,7 @@ impl ChainManager {
         let mut signatures_to_verify = vec![];
         let consensus_constants = self.consensus_constants();
         let active_wips = ActiveWips {
-            active_wips: Default::default(),
+            active_wips: self.chain_state.tapi_engine.wip_activation.clone(),
             block_epoch: block.block_header.beacon.checkpoint,
             environment: get_environment(),
         };
@@ -2095,6 +2095,12 @@ impl ChainManager {
         });
 
         Box::pin(fut)
+    }
+
+    /// Return the value of the version field
+    fn tapi_signals_mask(&self) -> u32 {
+        // TODO: change this to 1 to signal support for WIP0014
+        0
     }
 }
 

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -470,7 +470,6 @@ impl ChainManager {
             let active_wips = ActiveWips {
                 active_wips: self.chain_state.tapi_engine.wip_activation.clone(),
                 block_epoch: block.block_header.beacon.checkpoint,
-                environment: get_environment(),
             };
 
             let utxo_diff = process_validations(
@@ -537,7 +536,6 @@ impl ChainManager {
                 let active_wips = ActiveWips {
                     active_wips: self.chain_state.tapi_engine.wip_activation.clone(),
                     block_epoch: block.block_header.beacon.checkpoint,
-                    environment: get_environment(),
                 };
                 let target_vrf_slots = VrfSlots::from_rf(
                     u32::try_from(rep_engine.ars().active_identities_number()).unwrap(),
@@ -1143,7 +1141,6 @@ impl ChainManager {
                 // If this transaction will be included in a block, the block epoch must be greater
                 // than or equal to the current epoch
                 block_epoch: current_epoch,
-                environment: get_environment(),
             };
             let fut = future::ready(validate_new_transaction(
                 &msg.transaction,
@@ -1619,7 +1616,6 @@ impl ChainManager {
         let active_wips = ActiveWips {
             active_wips: self.chain_state.tapi_engine.wip_activation.clone(),
             block_epoch: block.block_header.beacon.checkpoint,
-            environment: get_environment(),
         };
         let res = validate_block(
             &block,

--- a/node/src/actors/inventory_manager/handlers.rs
+++ b/node/src/actors/inventory_manager/handlers.rs
@@ -426,6 +426,7 @@ mod tests {
             0,
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
+            0,
         );
 
         Block::new(block_header, KeyedSignature::default(), txns)

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -21,6 +21,7 @@ use witnet_data_structures::{
         InventoryEntry, InventoryItem, NodeStats, PointerToBlock, PublicKeyHash, RADRequest,
         RADTally, Reputation, StateMachine, SuperBlock, SuperBlockVote, ValueTransferOutput,
     },
+    mainnet_validations::ActiveWips,
     radon_report::RadonReport,
     transaction::{CommitTransaction, RevealTransaction, Transaction},
     transaction_factory::NodeBalance,
@@ -702,8 +703,9 @@ pub struct ResolveRA {
     pub rad_request: RADRequest,
     /// Timeout: if the execution does not finish before the timeout, it is cancelled.
     pub timeout: Option<Duration>,
-    /// Current epoch, used to select the correct version of the validation logic
-    pub current_epoch: Epoch,
+    /// Active Witnet protocol improvements as of the current epoch.
+    /// Used to select the correct version of the validation logic.
+    pub active_wips: ActiveWips,
 }
 
 /// Message for running the tally step of a data request.
@@ -717,8 +719,9 @@ pub struct RunTally {
     pub min_consensus_ratio: f64,
     /// Number of commits
     pub commits_count: usize,
-    /// Epoch of the block that will include this tally, used to select the correct version of the validation logic
-    pub block_epoch: Epoch,
+    /// Active Witnet protocol improvements as of the block that will include this tally.
+    /// Used to select the correct version of the validation logic.
+    pub active_wips: ActiveWips,
 }
 
 impl Message for ResolveRA {

--- a/node/src/actors/rad_manager/handlers.rs
+++ b/node/src/actors/rad_manager/handlers.rs
@@ -113,7 +113,7 @@ impl Handler<RunTally> for RadManager {
                 reports_len,
                 &msg.active_wips,
             );
-            if msg.active_wips.second_hard_fork() {
+            if msg.active_wips.wips_0009_0011_0012() {
                 evaluate_tally_postcondition_clause(
                     report,
                     msg.min_consensus_ratio,

--- a/node/src/actors/rad_manager/handlers.rs
+++ b/node/src/actors/rad_manager/handlers.rs
@@ -1,11 +1,7 @@
 //! Message handlers for `RadManager`
 
 use actix::{Handler, ResponseFuture};
-use witnet_data_structures::{
-    get_environment,
-    mainnet_validations::after_second_hard_fork,
-    radon_report::{RadonReport, ReportContext},
-};
+use witnet_data_structures::radon_report::{RadonReport, ReportContext};
 use witnet_rad::{error::RadError, script::RadonScriptExecutionSettings, types::RadonTypes};
 use witnet_validations::validations::{
     construct_report_from_clause_result, evaluate_tally_postcondition_clause,
@@ -46,7 +42,7 @@ impl Handler<ResolveRA> for RadManager {
             // Evaluate tally precondition to ensure that at least 20% of the data sources are not errors.
             // This stage does not need to evaluate the postcondition.
             let clause_result =
-                evaluate_tally_precondition_clause(retrieve_responses, 0.2, 1, msg.current_epoch);
+                evaluate_tally_precondition_clause(retrieve_responses, 0.2, 1, &msg.active_wips);
             match clause_result {
                 Ok(TallyPreconditionClauseResult::MajorityOfValues {
                     values,
@@ -109,15 +105,15 @@ impl Handler<RunTally> for RadManager {
                 reports,
                 msg.min_consensus_ratio,
                 msg.commits_count,
-                msg.block_epoch,
+                &msg.active_wips,
             );
             let report = construct_report_from_clause_result(
                 clause_result,
                 &packed_script,
                 reports_len,
-                msg.block_epoch,
+                &msg.active_wips,
             );
-            if after_second_hard_fork(msg.block_epoch, get_environment()) {
+            if msg.active_wips.second_hard_fork() {
                 evaluate_tally_postcondition_clause(
                     report,
                     msg.min_consensus_ratio,

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -47,7 +47,7 @@ const E: Epoch = SECOND_HARD_FORK + 1;
 // This should only be used in tests
 fn all_wips_active() -> ActiveWips {
     let mut active_wips = HashMap::new();
-    active_wips.insert("WIP0014", 500_000);
+    active_wips.insert("WIP0014".to_string(), 500_000);
 
     ActiveWips {
         active_wips,

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -51,7 +51,6 @@ fn all_wips_active() -> ActiveWips {
     ActiveWips {
         active_wips: tapi_engine.wip_activation,
         block_epoch: u32::MAX,
-        environment: Environment::Testnet,
     }
 }
 
@@ -63,7 +62,6 @@ fn active_wips_from_mainnet(block_epoch: Epoch) -> ActiveWips {
     ActiveWips {
         active_wips: tapi_engine.wip_activation,
         block_epoch,
-        environment: Environment::Mainnet,
     }
 }
 

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -1,11 +1,11 @@
-use itertools::Itertools;
 use std::{
     collections::HashSet,
     convert::TryFrom,
     sync::atomic::{AtomicU32, Ordering},
 };
 
-use crate::validations::*;
+use itertools::Itertools;
+
 use witnet_crypto::{
     key::CryptoEngine,
     secp256k1::{PublicKey as Secp256k1_PublicKey, Secp256k1, SecretKey as Secp256k1_SecretKey},
@@ -17,7 +17,7 @@ use witnet_data_structures::{
         calculate_tally_change, calculate_witness_reward, create_tally, DataRequestPool,
     },
     error::{BlockError, DataRequestError, Secp256k1ConversionError, TransactionError},
-    mainnet_validations::{FIRST_HARD_FORK, SECOND_HARD_FORK},
+    mainnet_validations::{ActiveWips, FIRST_HARD_FORK, SECOND_HARD_FORK},
     radon_error::RadonError,
     radon_report::{RadonReport, ReportContext, TypeLike},
     transaction::*,
@@ -33,6 +33,9 @@ use witnet_rad::{
     types::{integer::RadonInteger, RadonTypes},
 };
 
+use crate::validations::*;
+use std::collections::HashMap;
+
 static ONE_WIT: u64 = 1_000_000_000;
 const MAX_VT_WEIGHT: u32 = 20_000;
 const MAX_DR_WEIGHT: u32 = 80_000;
@@ -40,6 +43,18 @@ const INITIAL_BLOCK_REWARD: u64 = 250 * 1_000_000_000;
 const HALVING_PERIOD: u32 = 3_500_000;
 // Block epoch used in tally tests
 const E: Epoch = SECOND_HARD_FORK + 1;
+
+// This should only be used in tests
+fn all_wips_active() -> ActiveWips {
+    let mut active_wips = HashMap::new();
+    active_wips.insert("WIP0014", 500_000);
+
+    ActiveWips {
+        active_wips,
+        block_epoch: u32::MAX,
+        environment: Environment::Mainnet,
+    }
+}
 
 fn verify_signatures_test(
     signatures_to_verify: Vec<SignaturesToVerify>,
@@ -2316,6 +2331,7 @@ fn test_empty_commit(c_tx: &CommitTransaction) -> Result<(), failure::Error> {
         collateral_minimum,
         collateral_age,
         block_number,
+        &all_wips_active(),
     )
     .map(|_| ())
 }
@@ -2367,6 +2383,7 @@ fn test_commit_with_dr_and_utxo_set(
         collateral_minimum,
         collateral_age,
         block_number,
+        &all_wips_active(),
     )?;
     verify_signatures_test(signatures_to_verify)?;
 
@@ -2449,6 +2466,7 @@ fn test_commit_difficult_proof() {
         collateral_minimum,
         collateral_age,
         block_number,
+        &all_wips_active(),
     )
     .and_then(|_| verify_signatures_test(signatures_to_verify));
 
@@ -2522,6 +2540,7 @@ fn test_commit_with_collateral(
         collateral_minimum,
         collateral_age,
         block_number,
+        &all_wips_active(),
     )
     .map(|_| ())
 }
@@ -2764,6 +2783,7 @@ fn commitment_invalid_proof() {
         collateral_minimum,
         collateral_age,
         block_number,
+        &all_wips_active(),
     )
     .and_then(|_| verify_signatures_test(signatures_to_verify));
 
@@ -2837,6 +2857,7 @@ fn commitment_dr_in_reveal_stage() {
         collateral_minimum,
         collateral_age,
         block_number,
+        &all_wips_active(),
     );
     assert_eq!(
         x.unwrap_err().downcast::<DataRequestError>().unwrap(),
@@ -3219,6 +3240,7 @@ fn commitment_collateral_zero_is_minimum() {
             collateral_minimum,
             collateral_age,
             block_number,
+            &all_wips_active(),
         )
         .map(|_| ())
     };
@@ -3291,6 +3313,12 @@ fn commitment_timelock() {
         // Sign commitment
         let cs = sign_tx(PRIV_KEY_1, &cb);
         let c_tx = CommitTransaction::new(cb, vec![cs]);
+        // This test checks that the first hard fork is handled correctly
+        let active_wips = ActiveWips {
+            active_wips: Default::default(),
+            block_epoch: epoch,
+            environment: Environment::Mainnet,
+        };
 
         let mut signatures_to_verify = vec![];
         validate_commit_transaction(
@@ -3305,6 +3333,7 @@ fn commitment_timelock() {
             collateral_minimum,
             collateral_age,
             block_number,
+            &active_wips,
         )
         .map(|_| ())?;
 
@@ -4073,6 +4102,7 @@ fn tally_dr_not_tally_stage() {
     // Create DRTransaction
     let fake_block_hash = Hash::SHA256([1; 32]);
     let epoch = 0;
+    let active_wips = all_wips_active();
     let dr_output = DataRequestOutput {
         witnesses: 1,
         commit_and_reveal_fee: 20,
@@ -4120,7 +4150,7 @@ fn tally_dr_not_tally_stage() {
         TallyTransaction::new(dr_pointer, tally_value, vec![vt0], vec![], vec![]);
 
     let mut dr_pool = DataRequestPool::default();
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E);
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips);
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::DataRequestNotFound { hash: dr_pointer },
@@ -4129,7 +4159,7 @@ fn tally_dr_not_tally_stage() {
         .process_data_request(&dr_transaction, epoch, &Hash::default())
         .unwrap();
     dr_pool.update_data_request_stages();
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E);
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips);
     assert_eq!(
         x.unwrap_err().downcast::<DataRequestError>().unwrap(),
         DataRequestError::NotTallyStage
@@ -4139,7 +4169,7 @@ fn tally_dr_not_tally_stage() {
         .process_commit(&commit_transaction, &fake_block_hash)
         .unwrap();
     dr_pool.update_data_request_stages();
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E);
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips);
     assert_eq!(
         x.unwrap_err().downcast::<DataRequestError>().unwrap(),
         DataRequestError::NotTallyStage
@@ -4149,7 +4179,8 @@ fn tally_dr_not_tally_stage() {
         .process_reveal(&reveal_transaction, &fake_block_hash)
         .unwrap();
     dr_pool.update_data_request_stages();
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x =
+        validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips).map(|_| ());
     x.unwrap();
 }
 
@@ -4201,7 +4232,7 @@ fn tally_invalid_consensus() {
         slashed,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E);
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active());
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::MismatchedConsensus {
@@ -4267,7 +4298,8 @@ fn tally_valid_1_reveal_5_commits() {
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3], pkhs[4]],
         vec![pkhs[0]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -4433,7 +4465,8 @@ fn tally_valid_1_reveal_5_commits_invalid_value() {
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3], pkhs[4]],
         vec![pkhs[0]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::InvalidReward {
@@ -4499,7 +4532,8 @@ fn tally_valid_1_reveal_5_commits_with_absurd_timelock() {
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3], pkhs[4]],
         vec![pkhs[0]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::InvalidTimeLock {
@@ -4553,7 +4587,8 @@ fn tally_valid() {
         error_witnesses,
     );
 
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -4590,7 +4625,8 @@ fn tally_too_many_outputs() {
         slashed,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::WrongNumberOutputs {
@@ -4619,7 +4655,8 @@ fn tally_too_less_outputs() {
 
     let tally_transaction =
         TallyTransaction::new(dr_pointer, tally_value, vec![vt0], slashed, error_witnesses);
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::WrongNumberOutputs {
@@ -4673,7 +4710,8 @@ fn tally_invalid_change() {
         slashed,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::InvalidTallyChange {
@@ -4711,7 +4749,8 @@ fn tally_double_reward() {
         slashed,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::MultipleRewards { pkh: rewarded[0] },
@@ -4746,7 +4785,8 @@ fn tally_reveal_not_found() {
         slashed,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::RevealNotFound,
@@ -4782,7 +4822,8 @@ fn tally_invalid_reward() {
         slashed,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::InvalidReward {
@@ -4821,7 +4862,8 @@ fn tally_valid_2_reveals() {
         slashed,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -4862,7 +4904,8 @@ fn tally_valid_3_reveals_dr_liar() {
         slashed,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -4903,7 +4946,8 @@ fn tally_valid_3_reveals_dr_liar_invalid() {
         slashed_witnesses.clone(),
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
 
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
@@ -4965,7 +5009,8 @@ fn tally_valid_5_reveals_1_liar_1_error() {
         out_of_consensus,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -5010,7 +5055,8 @@ fn tally_valid_3_reveals_1_error() {
         error_witnesses.clone(),
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -5055,7 +5101,8 @@ fn tally_valid_3_reveals_1_error_invalid_reward() {
         error_witnesses.clone(),
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::InvalidReward {
@@ -5106,7 +5153,8 @@ fn tally_valid_3_reveals_mark_all_as_error() {
         error_witnesses,
         vec![rewarded[0], rewarded[1], rewarded[2]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::MismatchingErrorCount {
@@ -5152,7 +5200,8 @@ fn tally_dishonest_reward() {
         slashed,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
 
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
@@ -5186,11 +5235,12 @@ fn create_tally_validation_dr_liar() {
 
     // Create the RadonReport using the reveals and the RADTally script
     let min_consensus = 0.51;
+    let active_wips = all_wips_active();
     let clause_result = evaluate_tally_precondition_clause(
         vec![reveal_value.clone(), reveal_value, liar_value],
         min_consensus,
         3,
-        E,
+        &active_wips,
     );
     let script = RADTally {
         filters: vec![RADFilter {
@@ -5199,7 +5249,7 @@ fn create_tally_validation_dr_liar() {
         }],
         reducer: RadonReducers::Mode as u32,
     };
-    let report = construct_report_from_clause_result(clause_result, &script, 3, E);
+    let report = construct_report_from_clause_result(clause_result, &script, 3, &active_wips);
     let report = evaluate_tally_postcondition_clause(report, min_consensus, 3);
 
     // Create a TallyTransaction using the create_tally function
@@ -5215,10 +5265,11 @@ fn create_tally_validation_dr_liar() {
             .collect::<HashSet<PublicKeyHash>>(),
         ONE_WIT,
         tally_bytes_on_encode_error(),
-        E,
+        &active_wips,
     );
 
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x =
+        validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips).map(|_| ());
     x.unwrap();
 }
 
@@ -5255,6 +5306,7 @@ fn create_tally_validation_5_reveals_1_liar_1_error() {
 
     // Create the RadonReport using the reveals and the RADTally script
     let min_consensus = 0.51;
+    let active_wips = all_wips_active();
     let clause_result = evaluate_tally_precondition_clause(
         vec![
             reveal_value.clone(),
@@ -5265,7 +5317,7 @@ fn create_tally_validation_5_reveals_1_liar_1_error() {
         ],
         min_consensus,
         5,
-        E,
+        &active_wips,
     );
     let script = RADTally {
         filters: vec![RADFilter {
@@ -5274,7 +5326,7 @@ fn create_tally_validation_5_reveals_1_liar_1_error() {
         }],
         reducer: RadonReducers::Mode as u32,
     };
-    let report = construct_report_from_clause_result(clause_result, &script, 5, E);
+    let report = construct_report_from_clause_result(clause_result, &script, 5, &active_wips);
     let report = evaluate_tally_postcondition_clause(report, min_consensus, 5);
 
     // Create a TallyTransaction using the create_tally function
@@ -5302,10 +5354,11 @@ fn create_tally_validation_5_reveals_1_liar_1_error() {
         .collect::<HashSet<PublicKeyHash>>(),
         ONE_WIT,
         tally_bytes_on_encode_error(),
-        E,
+        &active_wips,
     );
 
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x =
+        validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips).map(|_| ());
     x.unwrap();
 }
 
@@ -5331,11 +5384,12 @@ fn create_tally_validation_4_commits_2_reveals() {
 
     // Create the RadonReport using the reveals and the RADTally script
     let min_consensus = 0.51;
+    let active_wips = all_wips_active();
     let clause_result = evaluate_tally_precondition_clause(
         vec![reveal_value.clone(), reveal_value],
         min_consensus,
         4,
-        E,
+        &active_wips,
     );
     let script = RADTally {
         filters: vec![RADFilter {
@@ -5344,7 +5398,7 @@ fn create_tally_validation_4_commits_2_reveals() {
         }],
         reducer: RadonReducers::Mode as u32,
     };
-    let report = construct_report_from_clause_result(clause_result, &script, 2, E);
+    let report = construct_report_from_clause_result(clause_result, &script, 2, &active_wips);
     let report = evaluate_tally_postcondition_clause(report, min_consensus, 4);
 
     // Create a TallyTransaction using the create_tally function
@@ -5360,10 +5414,11 @@ fn create_tally_validation_4_commits_2_reveals() {
             .collect::<HashSet<PublicKeyHash>>(),
         ONE_WIT,
         tally_bytes_on_encode_error(),
-        E,
+        &active_wips,
     );
 
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x =
+        validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips).map(|_| ());
     x.unwrap();
 }
 
@@ -5376,9 +5431,10 @@ fn tally_valid_zero_commits() {
 
     // Tally value: Insufficient commits Error
     let min_consensus = 0.0;
-    let clause_result = evaluate_tally_precondition_clause(vec![], min_consensus, 0, E);
+    let active_wips = all_wips_active();
+    let clause_result = evaluate_tally_precondition_clause(vec![], min_consensus, 0, &active_wips);
     let script = RADTally::default();
-    let report = construct_report_from_clause_result(clause_result, &script, 0, E);
+    let report = construct_report_from_clause_result(clause_result, &script, 0, &active_wips);
     let report = evaluate_tally_postcondition_clause(report, min_consensus, 0);
     let tally_value = report.result.encode().unwrap();
     let vt0 = ValueTransferOutput {
@@ -5388,7 +5444,8 @@ fn tally_valid_zero_commits() {
     };
     let tally_transaction =
         TallyTransaction::new(dr_pointer, tally_value, vec![vt0], slashed, error_witnesses);
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x =
+        validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips).map(|_| ());
     x.unwrap();
 }
 
@@ -5401,9 +5458,10 @@ fn create_tally_validation_zero_commits() {
 
     // Tally value: Insufficient commits Error
     let min_consensus = 0.51;
-    let clause_result = evaluate_tally_precondition_clause(vec![], min_consensus, 0, E);
+    let active_wips = all_wips_active();
+    let clause_result = evaluate_tally_precondition_clause(vec![], min_consensus, 0, &active_wips);
     let script = RADTally::default();
-    let report = construct_report_from_clause_result(clause_result, &script, 0, E);
+    let report = construct_report_from_clause_result(clause_result, &script, 0, &active_wips);
     let report = evaluate_tally_postcondition_clause(report, min_consensus, 0);
     let tally_transaction = create_tally(
         dr_pointer,
@@ -5414,9 +5472,10 @@ fn create_tally_validation_zero_commits() {
         HashSet::<PublicKeyHash>::default(),
         ONE_WIT,
         tally_bytes_on_encode_error(),
-        E,
+        &active_wips,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x =
+        validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips).map(|_| ());
     x.unwrap();
 }
 
@@ -5429,9 +5488,10 @@ fn tally_invalid_zero_commits() {
 
     // Tally value: Insufficient commits Error
     let min_consensus = 0.0;
-    let clause_result = evaluate_tally_precondition_clause(vec![], min_consensus, 0, E);
+    let active_wips = all_wips_active();
+    let clause_result = evaluate_tally_precondition_clause(vec![], min_consensus, 0, &active_wips);
     let script = RADTally::default();
-    let report = construct_report_from_clause_result(clause_result, &script, 0, E);
+    let report = construct_report_from_clause_result(clause_result, &script, 0, &active_wips);
     let report = evaluate_tally_postcondition_clause(report, min_consensus, 0);
     let tally_value = report.result.encode().unwrap();
     let vt0 = ValueTransferOutput {
@@ -5451,7 +5511,8 @@ fn tally_invalid_zero_commits() {
         slashed,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x =
+        validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips).map(|_| ());
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::WrongNumberOutputs {
@@ -5470,9 +5531,10 @@ fn tally_valid_zero_reveals() {
 
     // Tally value: NoReveals commits Error
     let min_consensus = 0.51;
-    let clause_result = evaluate_tally_precondition_clause(vec![], min_consensus, 5, E);
+    let active_wips = all_wips_active();
+    let clause_result = evaluate_tally_precondition_clause(vec![], min_consensus, 5, &active_wips);
     let script = RADTally::default();
-    let report = construct_report_from_clause_result(clause_result, &script, 0, E);
+    let report = construct_report_from_clause_result(clause_result, &script, 0, &active_wips);
     let report = evaluate_tally_postcondition_clause(report, min_consensus, 5);
     let tally_value = report.result.encode().unwrap();
 
@@ -5514,7 +5576,8 @@ fn tally_valid_zero_reveals() {
         slashed,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x =
+        validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips).map(|_| ());
     x.unwrap();
 }
 
@@ -5527,9 +5590,10 @@ fn create_tally_validation_zero_reveals() {
 
     // Tally value: NoReveals commits Error
     let min_consensus = 0.51;
-    let clause_result = evaluate_tally_precondition_clause(vec![], min_consensus, 5, E);
+    let active_wips = all_wips_active();
+    let clause_result = evaluate_tally_precondition_clause(vec![], min_consensus, 5, &active_wips);
     let script = RADTally::default();
-    let report = construct_report_from_clause_result(clause_result, &script, 0, E);
+    let report = construct_report_from_clause_result(clause_result, &script, 0, &active_wips);
     let report = evaluate_tally_postcondition_clause(report, min_consensus, 5);
 
     let mut committers = rewarded;
@@ -5547,9 +5611,10 @@ fn create_tally_validation_zero_reveals() {
             .collect::<HashSet<PublicKeyHash>>(),
         ONE_WIT,
         tally_bytes_on_encode_error(),
-        E,
+        &active_wips,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x =
+        validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips).map(|_| ());
     x.unwrap();
 }
 
@@ -5563,9 +5628,10 @@ fn create_tally_validation_zero_reveals_zero_collateral() {
 
     // Tally value: NoReveals commits Error
     let min_consensus = 0.51;
-    let clause_result = evaluate_tally_precondition_clause(vec![], min_consensus, 5, E);
+    let active_wips = all_wips_active();
+    let clause_result = evaluate_tally_precondition_clause(vec![], min_consensus, 5, &active_wips);
     let script = RADTally::default();
-    let report = construct_report_from_clause_result(clause_result, &script, 0, E);
+    let report = construct_report_from_clause_result(clause_result, &script, 0, &active_wips);
     let report = evaluate_tally_postcondition_clause(report, min_consensus, 5);
 
     let mut committers = rewarded;
@@ -5583,9 +5649,10 @@ fn create_tally_validation_zero_reveals_zero_collateral() {
             .collect::<HashSet<PublicKeyHash>>(),
         ONE_WIT,
         tally_bytes_on_encode_error(),
-        E,
+        &active_wips,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x =
+        validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &active_wips).map(|_| ());
     x.unwrap();
 }
 
@@ -5736,7 +5803,8 @@ fn tally_valid_4_reveals_all_liars() {
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -5787,7 +5855,8 @@ fn tally_valid_4_reveals_all_liars_attacker_pkh() {
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     // The attacker_pkh has not participated in the commit/reveal process, so the error is "CommitNotFound"
     assert_eq!(
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
@@ -5842,7 +5911,8 @@ fn tally_valid_4_reveals_2_liars_2_true() {
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -5895,7 +5965,8 @@ fn tally_valid_4_reveals_2_errors_2_true() {
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -5946,7 +6017,8 @@ fn tally_valid_4_reveals_1_liar_2_true() {
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
         vec![pkhs[0], pkhs[1], pkhs[2]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -6001,7 +6073,8 @@ fn tally_valid_4_reveals_invalid_script_arg() {
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -6056,7 +6129,8 @@ fn tally_valid_3_reveals_1_no_reveal_invalid_script_arg() {
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
         vec![pkhs[0], pkhs[1], pkhs[2]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -6104,7 +6178,8 @@ fn tally_valid_4_reveals_majority_of_errors() {
         vec![],
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -6151,7 +6226,8 @@ fn tally_valid_3_reveals_1_no_reveal_majority_of_errors() {
         vec![pkhs[3]],
         vec![pkhs[0], pkhs[1], pkhs[2]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -6200,7 +6276,8 @@ fn tally_valid_2_reveals_2_no_reveals_majority_of_errors_insufficient_consensus(
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
         vec![pkhs[0], pkhs[1]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -6255,7 +6332,8 @@ fn tally_valid_4_reveals_majority_of_errors_insufficient_consensus() {
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -6309,7 +6387,8 @@ fn tally_valid_3_reveals_1_no_reveal_majority_of_errors_insufficient_consensus()
         vec![pkhs[0], pkhs[1], pkhs[2], pkhs[3]],
         vec![pkhs[0], pkhs[1], pkhs[2]],
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -6353,7 +6432,8 @@ fn tally_unserializable_value() {
         slashed,
         error_witnesses,
     );
-    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, E).map(|_| ());
+    let x = validate_tally_transaction(&tally_transaction, &dr_pool, ONE_WIT, &all_wips_active())
+        .map(|_| ());
     x.unwrap();
 }
 
@@ -6520,6 +6600,14 @@ fn test_block_with_drpool_and_utxo_set<F: FnMut(&mut Block) -> bool>(
         initial_block_reward: INITIAL_BLOCK_REWARD,
         halving_period: HALVING_PERIOD,
     };
+    // TODO: In this test the active wips depend on the current epoch
+    // Ideally this should use all_wips_active() so that when adding new WIPs the existing tests
+    // will fail if the logic is accidentally changed.
+    let active_wips = ActiveWips {
+        active_wips: Default::default(),
+        block_epoch: current_epoch,
+        environment: Environment::Mainnet,
+    };
 
     // Insert output to utxo
     let output1 = ValueTransferOutput {
@@ -6587,6 +6675,7 @@ fn test_block_with_drpool_and_utxo_set<F: FnMut(&mut Block) -> bool>(
         &mut signatures_to_verify,
         &rep_eng,
         &consensus_constants,
+        &active_wips,
     )?;
     verify_signatures_test(signatures_to_verify)?;
     let mut signatures_to_verify = vec![];
@@ -6601,6 +6690,7 @@ fn test_block_with_drpool_and_utxo_set<F: FnMut(&mut Block) -> bool>(
         EpochConstants::default(),
         block_number,
         &consensus_constants,
+        &active_wips,
     )?;
     verify_signatures_test(signatures_to_verify)?;
 
@@ -6870,6 +6960,7 @@ fn block_difficult_proof() {
                 &mut signatures_to_verify,
                 &rep_eng,
                 &consensus_constants,
+                &all_wips_active(),
             )?;
             verify_signatures_test(signatures_to_verify)?;
             let mut signatures_to_verify = vec![];
@@ -6884,6 +6975,7 @@ fn block_difficult_proof() {
                 EpochConstants::default(),
                 block_number,
                 &consensus_constants,
+                &all_wips_active(),
             )?;
             verify_signatures_test(signatures_to_verify)?;
 
@@ -7570,6 +7662,7 @@ fn test_blocks_with_limits(
             &mut signatures_to_verify,
             &rep_eng,
             &consensus_constants,
+            &all_wips_active(),
         )?;
         verify_signatures_test(signatures_to_verify)?;
         let mut signatures_to_verify = vec![];
@@ -7585,6 +7678,7 @@ fn test_blocks_with_limits(
             EpochConstants::default(),
             block_number,
             &consensus_constants,
+            &all_wips_active(),
         )?;
         verify_signatures_test(signatures_to_verify)?;
 
@@ -8077,6 +8171,7 @@ fn genesis_block_after_not_bootstrap_hash() {
         &mut signatures_to_verify,
         &rep_eng,
         &consensus_constants,
+        &all_wips_active(),
     );
     assert_eq!(signatures_to_verify, vec![]);
 
@@ -8156,6 +8251,7 @@ fn genesis_block_value_overflow() {
         &mut signatures_to_verify,
         &rep_eng,
         &consensus_constants,
+        &all_wips_active(),
     )
     .unwrap();
     assert_eq!(signatures_to_verify, vec![]);
@@ -8172,6 +8268,7 @@ fn genesis_block_value_overflow() {
         EpochConstants::default(),
         block_number,
         &consensus_constants,
+        &all_wips_active(),
     );
     assert_eq!(signatures_to_verify, vec![]);
     assert_eq!(
@@ -8238,6 +8335,7 @@ fn genesis_block_full_validate() {
         &mut signatures_to_verify,
         &rep_eng,
         &consensus_constants,
+        &all_wips_active(),
     )
     .unwrap();
     assert_eq!(signatures_to_verify, vec![]);
@@ -8254,6 +8352,7 @@ fn genesis_block_full_validate() {
         EpochConstants::default(),
         block_number,
         &consensus_constants,
+        &all_wips_active(),
     )
     .unwrap();
     assert_eq!(signatures_to_verify, vec![]);
@@ -8340,6 +8439,7 @@ fn validate_block_transactions_uses_block_number_in_utxo_diff() {
             EpochConstants::default(),
             block_number,
             &consensus_constants,
+            &all_wips_active(),
         )
         .unwrap()
     };
@@ -8502,6 +8602,7 @@ fn validate_commit_transactions_included_in_utxo_diff() {
             EpochConstants::default(),
             block_number,
             &consensus_constants,
+            &all_wips_active(),
         )
         .unwrap()
     };
@@ -8556,6 +8657,7 @@ fn validate_required_tally_not_found() {
         EpochConstants::default(),
         100,
         &ConsensusConstants::default(),
+        &all_wips_active(),
     )
     .unwrap_err();
 

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -17,7 +17,7 @@ use witnet_data_structures::{
         calculate_tally_change, calculate_witness_reward, create_tally, DataRequestPool,
     },
     error::{BlockError, DataRequestError, Secp256k1ConversionError, TransactionError},
-    mainnet_validations::{ActiveWips, FIRST_HARD_FORK, SECOND_HARD_FORK},
+    mainnet_validations::{ActiveWips, TapiEngine, FIRST_HARD_FORK, SECOND_HARD_FORK},
     radon_error::RadonError,
     radon_report::{RadonReport, ReportContext, TypeLike},
     transaction::*,
@@ -34,7 +34,6 @@ use witnet_rad::{
 };
 
 use crate::validations::*;
-use std::collections::HashMap;
 
 static ONE_WIT: u64 = 1_000_000_000;
 const MAX_VT_WEIGHT: u32 = 20_000;
@@ -46,12 +45,24 @@ const E: Epoch = SECOND_HARD_FORK + 1;
 
 // This should only be used in tests
 fn all_wips_active() -> ActiveWips {
-    let mut active_wips = HashMap::new();
-    active_wips.insert("WIP0014".to_string(), 500_000);
+    let mut tapi_engine = TapiEngine::default();
+    tapi_engine.initialize_wip_information(Environment::Testnet);
 
     ActiveWips {
-        active_wips,
+        active_wips: tapi_engine.wip_activation,
         block_epoch: u32::MAX,
+        environment: Environment::Testnet,
+    }
+}
+
+// This should only be used in tests
+fn active_wips_from_mainnet(block_epoch: Epoch) -> ActiveWips {
+    let mut tapi_engine = TapiEngine::default();
+    tapi_engine.initialize_wip_information(Environment::Mainnet);
+
+    ActiveWips {
+        active_wips: tapi_engine.wip_activation,
+        block_epoch,
         environment: Environment::Mainnet,
     }
 }
@@ -3314,11 +3325,7 @@ fn commitment_timelock() {
         let cs = sign_tx(PRIV_KEY_1, &cb);
         let c_tx = CommitTransaction::new(cb, vec![cs]);
         // This test checks that the first hard fork is handled correctly
-        let active_wips = ActiveWips {
-            active_wips: Default::default(),
-            block_epoch: epoch,
-            environment: Environment::Mainnet,
-        };
+        let active_wips = active_wips_from_mainnet(epoch);
 
         let mut signatures_to_verify = vec![];
         validate_commit_transaction(
@@ -6603,11 +6610,7 @@ fn test_block_with_drpool_and_utxo_set<F: FnMut(&mut Block) -> bool>(
     // TODO: In this test the active wips depend on the current epoch
     // Ideally this should use all_wips_active() so that when adding new WIPs the existing tests
     // will fail if the logic is accidentally changed.
-    let active_wips = ActiveWips {
-        active_wips: Default::default(),
-        block_epoch: current_epoch,
-        environment: Environment::Mainnet,
-    };
+    let active_wips = active_wips_from_mainnet(current_epoch);
 
     // Insert output to utxo
     let output1 = ValueTransferOutput {

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -2464,7 +2464,7 @@ mod tests {
     // This should only be used in tests
     fn all_wips_active() -> ActiveWips {
         let mut active_wips = HashMap::new();
-        active_wips.insert("WIP0014", 500_000);
+        active_wips.insert("WIP0014".to_string(), 500_000);
 
         ActiveWips {
             active_wips,

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -2451,9 +2451,11 @@ pub fn verify_signatures(
 
 #[cfg(test)]
 mod tests {
-    use witnet_data_structures::chain::Environment;
     use witnet_data_structures::{
-        chain::Alpha, mainnet_validations::SECOND_HARD_FORK, radon_error::RadonError,
+        chain::Alpha,
+        chain::Environment,
+        mainnet_validations::{TapiEngine, SECOND_HARD_FORK},
+        radon_error::RadonError,
     };
     use witnet_rad::types::{float::RadonFloat, integer::RadonInteger};
 
@@ -2464,13 +2466,13 @@ mod tests {
 
     // This should only be used in tests
     fn all_wips_active() -> ActiveWips {
-        let mut active_wips = HashMap::new();
-        active_wips.insert("WIP0014".to_string(), 500_000);
+        let mut tapi_engine = TapiEngine::default();
+        tapi_engine.initialize_wip_information(Environment::Testnet);
 
         ActiveWips {
-            active_wips,
+            active_wips: tapi_engine.wip_activation,
             block_epoch: u32::MAX,
-            environment: Environment::Mainnet,
+            environment: Environment::Testnet,
         }
     }
 

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -25,8 +25,7 @@ use witnet_data_structures::{
         calculate_witness_reward_before_second_hard_fork, create_tally, DataRequestPool,
     },
     error::{BlockError, DataRequestError, TransactionError},
-    get_environment,
-    mainnet_validations::{after_first_hard_fork, after_second_hard_fork},
+    mainnet_validations::ActiveWips,
     radon_error::RadonError,
     radon_report::{RadonReport, ReportContext, Stage, TallyMetaData},
     transaction::{
@@ -351,7 +350,7 @@ pub fn evaluate_tally_precondition_clause(
     reveals: Vec<RadonReport<RadonTypes>>,
     minimum_consensus: f64,
     num_commits: usize,
-    block_epoch: Epoch,
+    active_wips: &ActiveWips,
 ) -> Result<TallyPreconditionClauseResult, RadError> {
     // Short-circuit if there were no commits
     if num_commits == 0 {
@@ -384,7 +383,7 @@ pub fn evaluate_tally_precondition_clause(
     // as the frequent type).
     let achieved_consensus = f64::from(counter.max_val) / num_commits_f;
 
-    if !after_second_hard_fork(block_epoch, get_environment()) {
+    if !active_wips.second_hard_fork() {
         // Before the second hard fork, the achieved_consensus below was incorrectly calculated as
         // max_count / num_reveals
         num_commits_f = f64::from(reveals_len);
@@ -541,7 +540,7 @@ pub fn construct_report_from_clause_result(
     clause_result: Result<TallyPreconditionClauseResult, RadError>,
     script: &RADTally,
     reports_len: usize,
-    block_epoch: Epoch,
+    active_wips: &ActiveWips,
 ) -> RadonReport<RadonTypes> {
     // This TallyMetadata would be included in case of Error Result, in that case,
     // no one has to be classified as a lier, but everyone as an error
@@ -568,7 +567,7 @@ pub fn construct_report_from_clause_result(
             ) {
                 Ok(x) => x,
                 Err(e) => {
-                    if after_second_hard_fork(block_epoch, get_environment()) {
+                    if active_wips.second_hard_fork() {
                         radon_report_from_error(
                             RadError::TallyExecution {
                                 inner: Some(Box::new(e)),
@@ -600,7 +599,7 @@ pub fn construct_report_from_clause_result(
         // Failed to evaluate the precondition clause. `RadonReport::from_result()?` is the last
         // chance for errors to be intercepted and used for consensus.
         Err(e) => {
-            if after_second_hard_fork(block_epoch, get_environment()) {
+            if active_wips.second_hard_fork() {
                 // If there is an error during the precondition, all revealers are set to error and liar.
                 // This is an error that is not penalized and not rewarded.
                 radon_report_from_error(e, reports_len)
@@ -837,6 +836,7 @@ pub fn validate_commit_transaction(
     collateral_minimum: u64,
     collateral_age: u32,
     block_number: u32,
+    active_wips: &ActiveWips,
 ) -> Result<(Hash, u16, u64), failure::Error> {
     // Get DataRequest information
     let dr_pointer = co_tx.body.dr_pointer;
@@ -888,7 +888,7 @@ pub fn validate_commit_transaction(
     )?;
 
     // commit time_lock was disabled in the first hard fork
-    if !after_first_hard_fork(epoch, get_environment()) {
+    if !active_wips.first_hard_fork() {
         // Verify that commits are only accepted after the time lock expired
         let epoch_timestamp = epoch_constants.epoch_timestamp(epoch)?;
         let dr_time_lock = i64::try_from(dr_output.data_request.time_lock)?;
@@ -984,7 +984,7 @@ fn create_expected_report(
     tally: &RADTally,
     non_error_min: f64,
     commits_count: usize,
-    block_epoch: Epoch,
+    active_wips: &ActiveWips,
 ) -> RadonReport<RadonTypes> {
     match panic::catch_unwind(|| {
         let results = serial_iter_decode(
@@ -1007,10 +1007,10 @@ fn create_expected_report(
 
         let results_len = results.len();
         let clause_result =
-            evaluate_tally_precondition_clause(results, non_error_min, commits_count, block_epoch);
+            evaluate_tally_precondition_clause(results, non_error_min, commits_count, active_wips);
         let report =
-            construct_report_from_clause_result(clause_result, &tally, results_len, block_epoch);
-        if after_second_hard_fork(block_epoch, get_environment()) {
+            construct_report_from_clause_result(clause_result, &tally, results_len, active_wips);
+        if active_wips.second_hard_fork() {
             evaluate_tally_postcondition_clause(report, non_error_min, commits_count)
         } else {
             report
@@ -1019,7 +1019,7 @@ fn create_expected_report(
         Ok(x) => x,
         Err(_e) => {
             // If there is a panic during tally creation: set tally result to RadError::Unknown
-            if after_second_hard_fork(block_epoch, get_environment()) {
+            if active_wips.second_hard_fork() {
                 radon_report_from_error(RadError::Unknown, reveals.len())
             } else {
                 RadonReport::from_result(Err(RadError::Unknown), &ReportContext::default())
@@ -1044,7 +1044,7 @@ fn create_expected_tally_transaction(
     ta_tx: &TallyTransaction,
     dr_pool: &DataRequestPool,
     collateral_minimum: u64,
-    block_epoch: Epoch,
+    active_wips: &ActiveWips,
 ) -> Result<(TallyTransaction, DataRequestState), failure::Error> {
     // Get DataRequestState
     let dr_pointer = ta_tx.dr_pointer;
@@ -1074,7 +1074,7 @@ fn create_expected_tally_transaction(
         &dr_output.data_request.tally,
         non_error_min,
         commit_length,
-        block_epoch,
+        active_wips,
     );
     let ta_tx = create_tally(
         dr_pointer,
@@ -1085,7 +1085,7 @@ fn create_expected_tally_transaction(
         committers,
         collateral_minimum,
         tally_bytes_on_encode_error(),
-        block_epoch,
+        active_wips,
     );
 
     Ok((ta_tx, dr_state.clone()))
@@ -1117,10 +1117,10 @@ pub fn validate_tally_transaction<'a>(
     ta_tx: &'a TallyTransaction,
     dr_pool: &DataRequestPool,
     collateral_minimum: u64,
-    block_epoch: Epoch,
+    active_wips: &ActiveWips,
 ) -> Result<(Vec<&'a ValueTransferOutput>, u64), failure::Error> {
     let (expected_ta_tx, dr_state) =
-        create_expected_tally_transaction(ta_tx, dr_pool, collateral_minimum, block_epoch)?;
+        create_expected_tally_transaction(ta_tx, dr_pool, collateral_minimum, active_wips)?;
 
     let sorted_out_of_consensus = ta_tx.out_of_consensus.iter().cloned().sorted().collect();
     let sorted_expected_out_of_consensus = expected_ta_tx
@@ -1193,7 +1193,7 @@ pub fn validate_tally_transaction<'a>(
 
     let mut pkh_rewarded: HashSet<PublicKeyHash> = HashSet::default();
     let mut total_tally_value = 0;
-    let is_after_second_hard_fork = after_second_hard_fork(block_epoch, get_environment());
+    let is_after_second_hard_fork = active_wips.second_hard_fork();
     let (reward, tally_extra_fee) = if is_after_second_hard_fork {
         calculate_witness_reward(
             commits_count,
@@ -1622,6 +1622,7 @@ pub fn validate_block_transactions(
     epoch_constants: EpochConstants,
     block_number: u32,
     consensus_constants: &ConsensusConstants,
+    active_wips: &ActiveWips,
 ) -> Result<Diff, failure::Error> {
     let epoch = block.block_header.beacon.checkpoint;
     let is_genesis = block.hash() == consensus_constants.genesis_hash;
@@ -1706,6 +1707,7 @@ pub fn validate_block_transactions(
             consensus_constants.collateral_minimum,
             consensus_constants.collateral_age,
             block_number,
+            active_wips,
         )?;
 
         // Validation for only one commit for pkh/data request in a block
@@ -1773,12 +1775,10 @@ pub fn validate_block_transactions(
             transaction,
             dr_pool,
             consensus_constants.collateral_minimum,
-            epoch,
+            active_wips,
         )?;
 
-        if !after_second_hard_fork(block_number, get_environment())
-            && transaction.tally == tally_bytes_on_encode_error()
-        {
+        if !active_wips.second_hard_fork() && transaction.tally == tally_bytes_on_encode_error() {
             // Before the second hard fork, do not allow RadError::Unknown as tally result
             return Err(TransactionError::MismatchedConsensus {
                 expected_tally: tally_bytes_on_encode_error(),
@@ -1818,7 +1818,7 @@ pub fn validate_block_transactions(
     }
 
     let mut dr_weight: u32 = 0;
-    if after_first_hard_fork(epoch, get_environment()) {
+    if active_wips.first_hard_fork() {
         // Calculate data request not solved weight
         let mut dr_pointers: HashSet<Hash> = dr_pool
             .get_dr_output_pointers_by_epoch(epoch)
@@ -1917,6 +1917,7 @@ pub fn validate_block(
     signatures_to_verify: &mut Vec<SignaturesToVerify>,
     rep_eng: &ReputationEngine,
     consensus_constants: &ConsensusConstants,
+    active_wips: &ActiveWips,
 ) -> Result<(), failure::Error> {
     let block_epoch = block.block_header.beacon.checkpoint;
     let hash_prev_block = block.block_header.beacon.hash_prev_block;
@@ -1951,6 +1952,7 @@ pub fn validate_block(
             block_epoch,
             consensus_constants.minimum_difficulty,
             consensus_constants.epochs_with_minimum_difficulty,
+            active_wips,
         );
 
         add_block_vrf_signature_to_verify(
@@ -2014,6 +2016,7 @@ pub fn validate_new_transaction(
     collateral_age: u32,
     max_vt_weight: u32,
     max_dr_weight: u32,
+    active_wips: &ActiveWips,
 ) -> Result<u64, failure::Error> {
     let utxo_diff = UtxoDiff::new(&unspent_outputs_pool, block_number);
 
@@ -2050,6 +2053,7 @@ pub fn validate_new_transaction(
             collateral_minimum,
             collateral_age,
             block_number,
+            active_wips,
         )
         .map(|(_, _, fee)| fee),
         Transaction::Reveal(tx) => {
@@ -2067,12 +2071,13 @@ pub fn calculate_randpoe_threshold(
     block_epoch: u32,
     minimum_difficulty: u32,
     epochs_with_minimum_difficulty: u32,
+    active_wips: &ActiveWips,
 ) -> (Hash, f64) {
     let max = u64::max_value();
     let minimum_difficulty = std::cmp::max(1, minimum_difficulty);
     let target = if block_epoch <= epochs_with_minimum_difficulty {
         max / u64::from(minimum_difficulty)
-    } else if after_second_hard_fork(block_epoch, get_environment()) {
+    } else if active_wips.second_hard_fork() {
         let difficulty = std::cmp::max(total_identities, minimum_difficulty);
         (max / u64::from(difficulty)).saturating_mul(u64::from(replication_factor))
     } else {
@@ -2144,6 +2149,7 @@ impl VrfSlots {
         block_epoch: u32,
         minimum_difficulty: u32,
         epochs_with_minimum_difficulty: u32,
+        active_wips: &ActiveWips,
     ) -> Self {
         Self::new(
             (replication_factor..=backup_factor)
@@ -2154,6 +2160,7 @@ impl VrfSlots {
                         block_epoch,
                         minimum_difficulty,
                         epochs_with_minimum_difficulty,
+                        active_wips,
                     )
                     .0
                 })
@@ -2443,6 +2450,7 @@ pub fn verify_signatures(
 
 #[cfg(test)]
 mod tests {
+    use witnet_data_structures::chain::Environment;
     use witnet_data_structures::{
         chain::Alpha, mainnet_validations::SECOND_HARD_FORK, radon_error::RadonError,
     };
@@ -2452,7 +2460,18 @@ mod tests {
 
     const INITIAL_BLOCK_REWARD: u64 = 250 * 1_000_000_000;
     const HALVING_PERIOD: u32 = 3_500_000;
-    const E: Epoch = SECOND_HARD_FORK + 1;
+
+    // This should only be used in tests
+    fn all_wips_active() -> ActiveWips {
+        let mut active_wips = HashMap::new();
+        active_wips.insert("WIP0014", 500_000);
+
+        ActiveWips {
+            active_wips,
+            block_epoch: u32::MAX,
+            environment: Environment::Mainnet,
+        }
+    }
 
     #[test]
     fn test_compare_candidate_same_section() {
@@ -2633,7 +2652,7 @@ mod tests {
         let rep_1 = Reputation(0);
         let rep_2 = Reputation(2);
         // Candidate 1 should always be better than candidate 2
-        let vrf_sections = VrfSlots::from_rf(16, 1, 2, 1001, 0, 0);
+        let vrf_sections = VrfSlots::from_rf(16, 1, 2, 1001, 0, 0, &all_wips_active());
         // Candidate 1 is in section 0
         let vrf_1 = vrf_sections.target_hashes[0];
         // Candidate 2 is in section 1
@@ -2782,11 +2801,17 @@ mod tests {
     #[allow(clippy::cast_possible_truncation)]
     #[test]
     fn target_randpoe() {
+        // This test is only valid before the first hard fork
+        let a = ActiveWips {
+            active_wips: Default::default(),
+            block_epoch: 1001,
+            environment: Environment::Mainnet,
+        };
         let rf = 1;
         let minimum_difficulty = 2000;
         let max_hash = Hash::with_first_u32(0xFFFF_FFFF);
-        let (t00, p00) = calculate_randpoe_threshold(0, rf, 1001, minimum_difficulty, 0);
-        let (t01, p01) = calculate_randpoe_threshold(1, rf, 1001, minimum_difficulty, 0);
+        let (t00, p00) = calculate_randpoe_threshold(0, rf, 1001, minimum_difficulty, 0, &a);
+        let (t01, p01) = calculate_randpoe_threshold(1, rf, 1001, minimum_difficulty, 0, &a);
         assert_eq!(t00, max_hash);
         assert_eq!(t00, t01);
         assert_eq!((p00 * 100_f64).round() as i128, 100);
@@ -2794,19 +2819,20 @@ mod tests {
             (p00 * 100_f64).round() as i128,
             (p01 * 100_f64).round() as i128
         );
-        let (t02, p02) = calculate_randpoe_threshold(2, rf, 1001, minimum_difficulty, 0);
+        let (t02, p02) = calculate_randpoe_threshold(2, rf, 1001, minimum_difficulty, 0, &a);
         assert_eq!(t02, Hash::with_first_u32(0x7FFF_FFFF));
         assert_eq!((p02 * 100_f64).round() as i128, 50);
-        let (t03, p03) = calculate_randpoe_threshold(3, rf, 1001, minimum_difficulty, 0);
+        let (t03, p03) = calculate_randpoe_threshold(3, rf, 1001, minimum_difficulty, 0, &a);
         assert_eq!(t03, Hash::with_first_u32(0x5555_5555));
         assert_eq!((p03 * 100_f64).round() as i128, 33);
-        let (t04, p04) = calculate_randpoe_threshold(4, rf, 1001, minimum_difficulty, 0);
+        let (t04, p04) = calculate_randpoe_threshold(4, rf, 1001, minimum_difficulty, 0, &a);
         assert_eq!(t04, Hash::with_first_u32(0x3FFF_FFFF));
         assert_eq!((p04 * 100_f64).round() as i128, 25);
-        let (t05, p05) = calculate_randpoe_threshold(1024, rf, 1001, minimum_difficulty, 0);
+        let (t05, p05) = calculate_randpoe_threshold(1024, rf, 1001, minimum_difficulty, 0, &a);
         assert_eq!(t05, Hash::with_first_u32(0x003F_FFFF));
         assert_eq!((p05 * 100_f64).round() as i128, 0);
-        let (t06, p06) = calculate_randpoe_threshold(1024 * 1024, rf, 1001, minimum_difficulty, 0);
+        let (t06, p06) =
+            calculate_randpoe_threshold(1024 * 1024, rf, 1001, minimum_difficulty, 0, &a);
         assert_eq!(t06, Hash::with_first_u32(0x0000_0FFF));
         assert_eq!((p06 * 100_f64).round() as i128, 0);
     }
@@ -2814,11 +2840,17 @@ mod tests {
     #[allow(clippy::cast_possible_truncation)]
     #[test]
     fn target_randpoe_initial_difficulty() {
-        let (t, p) = calculate_randpoe_threshold(2, 1, 1, 4, 10);
+        // This test is only valid before the first hard fork
+        let a = ActiveWips {
+            active_wips: Default::default(),
+            block_epoch: 1,
+            environment: Environment::Mainnet,
+        };
+        let (t, p) = calculate_randpoe_threshold(2, 1, 1, 4, 10, &a);
         assert_eq!(t, Hash::with_first_u32(0x3FFF_FFFF));
         assert_eq!((p * 100_f64).round() as i128, 25);
 
-        let (t, p) = calculate_randpoe_threshold(2, 1, 11, 4, 10);
+        let (t, p) = calculate_randpoe_threshold(2, 1, 11, 4, 10, &a);
         assert_eq!(t, Hash::with_first_u32(0x7FFF_FFFF));
         assert_eq!((p * 100_f64).round() as i128, 50);
     }
@@ -2828,6 +2860,12 @@ mod tests {
     fn target_randpoe_minimum_difficulty() {
         let replication_factor = 2;
         let minimum_difficulty = 2000;
+        // Before first hard fork
+        let active_wips = ActiveWips {
+            active_wips: Default::default(),
+            block_epoch: 1,
+            environment: Environment::Mainnet,
+        };
 
         let total_identities = 1000;
         let expected_prob = (1_f64 / f64::from(total_identities)) * f64::from(replication_factor);
@@ -2838,10 +2876,12 @@ mod tests {
             1,
             minimum_difficulty,
             0,
+            &active_wips,
         );
         assert_eq!((p * 10000_f64).round() / 10000_f64, expected_prob);
 
         // After second hard fork, minimum probability is used
+        let active_wips = all_wips_active();
         let block_epoch = SECOND_HARD_FORK + 1;
         let minimum_expected_prob =
             (1_f64 / f64::from(minimum_difficulty)) * f64::from(replication_factor);
@@ -2852,6 +2892,7 @@ mod tests {
             block_epoch,
             minimum_difficulty,
             0,
+            &active_wips,
         );
         assert_eq!((p * 10000_f64).round() / 10000_f64, minimum_expected_prob);
 
@@ -2862,6 +2903,7 @@ mod tests {
             block_epoch,
             minimum_difficulty,
             0,
+            &active_wips,
         );
         assert_eq!((p * 10000_f64).round() / 10000_f64, minimum_expected_prob);
 
@@ -2872,6 +2914,7 @@ mod tests {
             block_epoch,
             minimum_difficulty,
             0,
+            &active_wips,
         );
         assert_eq!((p * 10000_f64).round() / 10000_f64, minimum_expected_prob);
 
@@ -2886,6 +2929,7 @@ mod tests {
             block_epoch,
             minimum_difficulty,
             0,
+            &active_wips,
         );
         assert_eq!((p * 10000_f64).round() / 10000_f64, expected_prob);
 
@@ -2900,6 +2944,7 @@ mod tests {
             block_epoch,
             minimum_difficulty,
             0,
+            &active_wips,
         );
         assert_eq!(
             (p * 1_000_000_000_f64).round() / 1_000_000_000_f64,
@@ -2914,25 +2959,32 @@ mod tests {
         let rf = 4;
         let minimum_difficulty = 2000;
         let max_hash = Hash::with_first_u32(0xFFFF_FFFF);
-        let (t00, p00) = calculate_randpoe_threshold(0, rf, 1001, minimum_difficulty, 0);
-        let (t01, p01) = calculate_randpoe_threshold(1, rf, 1001, minimum_difficulty, 0);
+        // This test is only valid before the first hard fork
+        let a = ActiveWips {
+            active_wips: Default::default(),
+            block_epoch: 1001,
+            environment: Environment::Mainnet,
+        };
+        let (t00, p00) = calculate_randpoe_threshold(0, rf, 1001, minimum_difficulty, 0, &a);
+        let (t01, p01) = calculate_randpoe_threshold(1, rf, 1001, minimum_difficulty, 0, &a);
         assert_eq!(t00, max_hash);
         assert_eq!(t01, max_hash);
         assert_eq!((p00 * 100_f64).round() as i128, 100);
         assert_eq!((p01 * 100_f64).round() as i128, 100);
-        let (t02, p02) = calculate_randpoe_threshold(2, rf, 1001, minimum_difficulty, 0);
+        let (t02, p02) = calculate_randpoe_threshold(2, rf, 1001, minimum_difficulty, 0, &a);
         assert_eq!(t02, max_hash);
         assert_eq!((p02 * 100_f64).round() as i128, 100);
-        let (t03, p03) = calculate_randpoe_threshold(3, rf, 1001, minimum_difficulty, 0);
+        let (t03, p03) = calculate_randpoe_threshold(3, rf, 1001, minimum_difficulty, 0, &a);
         assert_eq!(t03, max_hash);
         assert_eq!((p03 * 100_f64).round() as i128, 100);
-        let (t04, p04) = calculate_randpoe_threshold(4, rf, 1001, minimum_difficulty, 0);
+        let (t04, p04) = calculate_randpoe_threshold(4, rf, 1001, minimum_difficulty, 0, &a);
         assert_eq!(t04, max_hash);
         assert_eq!((p04 * 100_f64).round() as i128, 100);
-        let (t05, p05) = calculate_randpoe_threshold(1024, rf, 1001, minimum_difficulty, 0);
+        let (t05, p05) = calculate_randpoe_threshold(1024, rf, 1001, minimum_difficulty, 0, &a);
         assert_eq!(t05, Hash::with_first_u32(0x00FF_FFFF));
         assert_eq!((p05 * 100_f64).round() as i128, 0);
-        let (t06, p06) = calculate_randpoe_threshold(1024 * 1024, rf, 1001, minimum_difficulty, 0);
+        let (t06, p06) =
+            calculate_randpoe_threshold(1024 * 1024, rf, 1001, minimum_difficulty, 0, &a);
         assert_eq!(t06, Hash::with_first_u32(0x0000_3FFF));
         assert_eq!((p06 * 100_f64).round() as i128, 0);
     }
@@ -3139,7 +3191,7 @@ mod tests {
             rad_rep_float,
         ];
         let tally_precondition_clause_result =
-            evaluate_tally_precondition_clause(v, 0.70, 4, E).unwrap();
+            evaluate_tally_precondition_clause(v, 0.70, 4, &all_wips_active()).unwrap();
 
         if let TallyPreconditionClauseResult::MajorityOfValues {
             values,
@@ -3163,7 +3215,7 @@ mod tests {
 
         let v = vec![rad_rep_int.clone(), rad_rep_int];
         let tally_precondition_clause_result =
-            evaluate_tally_precondition_clause(v, 0.99, 2, E).unwrap();
+            evaluate_tally_precondition_clause(v, 0.99, 2, &all_wips_active()).unwrap();
 
         if let TallyPreconditionClauseResult::MajorityOfValues {
             values,
@@ -3187,7 +3239,7 @@ mod tests {
 
         let v = vec![rad_rep_int.clone(), rad_rep_int];
         let tally_precondition_clause_result =
-            evaluate_tally_precondition_clause(v, 1., 2, E).unwrap();
+            evaluate_tally_precondition_clause(v, 1., 2, &all_wips_active()).unwrap();
 
         if let TallyPreconditionClauseResult::MajorityOfValues {
             values,
@@ -3218,7 +3270,7 @@ mod tests {
             rad_rep_int,
         ];
         let tally_precondition_clause_result =
-            evaluate_tally_precondition_clause(v, 0.70, 4, E).unwrap();
+            evaluate_tally_precondition_clause(v, 0.70, 4, &all_wips_active()).unwrap();
 
         if let TallyPreconditionClauseResult::MajorityOfValues {
             values,
@@ -3252,7 +3304,7 @@ mod tests {
             rad_rep_int,
         ];
         let tally_precondition_clause_result =
-            evaluate_tally_precondition_clause(v, 0.70, 4, E).unwrap();
+            evaluate_tally_precondition_clause(v, 0.70, 4, &all_wips_active()).unwrap();
 
         if let TallyPreconditionClauseResult::MajorityOfErrors { errors_mode } =
             tally_precondition_clause_result
@@ -3277,7 +3329,8 @@ mod tests {
             rad_rep_float,
             rad_rep_int,
         ];
-        let out = evaluate_tally_precondition_clause(v.clone(), 0.49, 4, E).unwrap_err();
+        let out =
+            evaluate_tally_precondition_clause(v.clone(), 0.49, 4, &all_wips_active()).unwrap_err();
 
         assert_eq!(
             out,
@@ -3315,7 +3368,7 @@ mod tests {
             rad_rep_int,
         ];
         let tally_precondition_clause_result =
-            evaluate_tally_precondition_clause(v, 0.40, 7, E).unwrap();
+            evaluate_tally_precondition_clause(v, 0.40, 7, &all_wips_active()).unwrap();
 
         if let TallyPreconditionClauseResult::MajorityOfErrors { errors_mode } =
             tally_precondition_clause_result
@@ -3329,7 +3382,7 @@ mod tests {
     #[test]
     fn test_tally_precondition_clause_no_commits() {
         let v = vec![];
-        let out = evaluate_tally_precondition_clause(v, 0.51, 0, E).unwrap_err();
+        let out = evaluate_tally_precondition_clause(v, 0.51, 0, &all_wips_active()).unwrap_err();
 
         assert_eq!(out, RadError::InsufficientCommits);
     }
@@ -3337,7 +3390,7 @@ mod tests {
     #[test]
     fn test_tally_precondition_clause_no_reveals() {
         let v = vec![];
-        let out = evaluate_tally_precondition_clause(v, 0.51, 1, E).unwrap_err();
+        let out = evaluate_tally_precondition_clause(v, 0.51, 1, &all_wips_active()).unwrap_err();
 
         assert_eq!(out, RadError::NoReveals);
     }
@@ -3357,7 +3410,7 @@ mod tests {
             rad_rep_err,
         ];
         let tally_precondition_clause_result =
-            evaluate_tally_precondition_clause(v, 0.51, 4, E).unwrap();
+            evaluate_tally_precondition_clause(v, 0.51, 4, &all_wips_active()).unwrap();
 
         if let TallyPreconditionClauseResult::MajorityOfErrors { errors_mode } =
             tally_precondition_clause_result
@@ -3382,7 +3435,7 @@ mod tests {
             rad_rep_float,
             rad_rep_int,
         ];
-        let out = evaluate_tally_precondition_clause(v, 0.51, 4, E).unwrap_err();
+        let out = evaluate_tally_precondition_clause(v, 0.51, 4, &all_wips_active()).unwrap_err();
 
         assert_eq!(
             out,
@@ -3409,7 +3462,7 @@ mod tests {
         );
 
         let v = vec![rad_rep_err1, rad_rep_err2];
-        let out = evaluate_tally_precondition_clause(v, 0.51, 2, E).unwrap_err();
+        let out = evaluate_tally_precondition_clause(v, 0.51, 2, &all_wips_active()).unwrap_err();
 
         assert_eq!(
             out,
@@ -3436,7 +3489,8 @@ mod tests {
         );
 
         let v = vec![rad_rep_err1, rad_rep_err2];
-        let out = evaluate_tally_precondition_clause(v.clone(), 0.49, 2, E).unwrap_err();
+        let out =
+            evaluate_tally_precondition_clause(v.clone(), 0.49, 2, &all_wips_active()).unwrap_err();
 
         assert_eq!(
             out,

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -2472,7 +2472,6 @@ mod tests {
         ActiveWips {
             active_wips: tapi_engine.wip_activation,
             block_epoch: u32::MAX,
-            environment: Environment::Testnet,
         }
     }
 
@@ -2808,7 +2807,6 @@ mod tests {
         let a = ActiveWips {
             active_wips: Default::default(),
             block_epoch: 1001,
-            environment: Environment::Mainnet,
         };
         let rf = 1;
         let minimum_difficulty = 2000;
@@ -2847,7 +2845,6 @@ mod tests {
         let a = ActiveWips {
             active_wips: Default::default(),
             block_epoch: 1,
-            environment: Environment::Mainnet,
         };
         let (t, p) = calculate_randpoe_threshold(2, 1, 1, 4, 10, &a);
         assert_eq!(t, Hash::with_first_u32(0x3FFF_FFFF));
@@ -2867,7 +2864,6 @@ mod tests {
         let active_wips = ActiveWips {
             active_wips: Default::default(),
             block_epoch: 1,
-            environment: Environment::Mainnet,
         };
 
         let total_identities = 1000;
@@ -2966,7 +2962,6 @@ mod tests {
         let a = ActiveWips {
             active_wips: Default::default(),
             block_epoch: 1001,
-            environment: Environment::Mainnet,
         };
         let (t00, p00) = calculate_randpoe_threshold(0, rf, 1001, minimum_difficulty, 0, &a);
         let (t01, p01) = calculate_randpoe_threshold(1, rf, 1001, minimum_difficulty, 0, &a);

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -383,7 +383,7 @@ pub fn evaluate_tally_precondition_clause(
     // as the frequent type).
     let achieved_consensus = f64::from(counter.max_val) / num_commits_f;
 
-    if !active_wips.second_hard_fork() {
+    if !active_wips.wips_0009_0011_0012() {
         // Before the second hard fork, the achieved_consensus below was incorrectly calculated as
         // max_count / num_reveals
         num_commits_f = f64::from(reveals_len);
@@ -567,7 +567,7 @@ pub fn construct_report_from_clause_result(
             ) {
                 Ok(x) => x,
                 Err(e) => {
-                    if active_wips.second_hard_fork() {
+                    if active_wips.wips_0009_0011_0012() {
                         radon_report_from_error(
                             RadError::TallyExecution {
                                 inner: Some(Box::new(e)),
@@ -599,7 +599,7 @@ pub fn construct_report_from_clause_result(
         // Failed to evaluate the precondition clause. `RadonReport::from_result()?` is the last
         // chance for errors to be intercepted and used for consensus.
         Err(e) => {
-            if active_wips.second_hard_fork() {
+            if active_wips.wips_0009_0011_0012() {
                 // If there is an error during the precondition, all revealers are set to error and liar.
                 // This is an error that is not penalized and not rewarded.
                 radon_report_from_error(e, reports_len)
@@ -888,7 +888,7 @@ pub fn validate_commit_transaction(
     )?;
 
     // commit time_lock was disabled in the first hard fork
-    if !active_wips.first_hard_fork() {
+    if !active_wips.wip_0008() {
         // Verify that commits are only accepted after the time lock expired
         let epoch_timestamp = epoch_constants.epoch_timestamp(epoch)?;
         let dr_time_lock = i64::try_from(dr_output.data_request.time_lock)?;
@@ -1010,7 +1010,7 @@ fn create_expected_report(
             evaluate_tally_precondition_clause(results, non_error_min, commits_count, active_wips);
         let report =
             construct_report_from_clause_result(clause_result, &tally, results_len, active_wips);
-        if active_wips.second_hard_fork() {
+        if active_wips.wips_0009_0011_0012() {
             evaluate_tally_postcondition_clause(report, non_error_min, commits_count)
         } else {
             report
@@ -1019,7 +1019,7 @@ fn create_expected_report(
         Ok(x) => x,
         Err(_e) => {
             // If there is a panic during tally creation: set tally result to RadError::Unknown
-            if active_wips.second_hard_fork() {
+            if active_wips.wips_0009_0011_0012() {
                 radon_report_from_error(RadError::Unknown, reveals.len())
             } else {
                 RadonReport::from_result(Err(RadError::Unknown), &ReportContext::default())
@@ -1193,7 +1193,7 @@ pub fn validate_tally_transaction<'a>(
 
     let mut pkh_rewarded: HashSet<PublicKeyHash> = HashSet::default();
     let mut total_tally_value = 0;
-    let is_after_second_hard_fork = active_wips.second_hard_fork();
+    let is_after_second_hard_fork = active_wips.wips_0009_0011_0012();
     let (reward, tally_extra_fee) = if is_after_second_hard_fork {
         calculate_witness_reward(
             commits_count,
@@ -1778,7 +1778,8 @@ pub fn validate_block_transactions(
             active_wips,
         )?;
 
-        if !active_wips.second_hard_fork() && transaction.tally == tally_bytes_on_encode_error() {
+        if !active_wips.wips_0009_0011_0012() && transaction.tally == tally_bytes_on_encode_error()
+        {
             // Before the second hard fork, do not allow RadError::Unknown as tally result
             return Err(TransactionError::MismatchedConsensus {
                 expected_tally: tally_bytes_on_encode_error(),
@@ -1818,7 +1819,7 @@ pub fn validate_block_transactions(
     }
 
     let mut dr_weight: u32 = 0;
-    if active_wips.first_hard_fork() {
+    if active_wips.wip_0008() {
         // Calculate data request not solved weight
         let mut dr_pointers: HashSet<Hash> = dr_pool
             .get_dr_output_pointers_by_epoch(epoch)
@@ -2077,7 +2078,7 @@ pub fn calculate_randpoe_threshold(
     let minimum_difficulty = std::cmp::max(1, minimum_difficulty);
     let target = if block_epoch <= epochs_with_minimum_difficulty {
         max / u64::from(minimum_difficulty)
-    } else if active_wips.second_hard_fork() {
+    } else if active_wips.wips_0009_0011_0012() {
         let difficulty = std::cmp::max(total_identities, minimum_difficulty);
         (max / u64::from(difficulty)).saturating_mul(u64::from(replication_factor))
     } else {


### PR DESCRIPTION
This pull request is a refactor of the validations code to use a new `ActiveWips` struct when checking if some validation logic is enabled or not. Currently this only replaces the `after_first_hard_fork` and `after_second_hard_fork` functions, but the idea is to extend it when the Threshold Activation of Protocol Improvements (TAPI) is implemented.