### PR TITLE
feat: implement signalingInfo JSON-RPC method

### DIFF
--- a/data_structures/src/mainnet_validations.rs
+++ b/data_structures/src/mainnet_validations.rs
@@ -238,6 +238,18 @@ impl BitTapiCounter {
     pub fn is_empty(&self) -> bool {
         self.current_length == 0
     }
+
+    pub fn info(&self) -> Vec<BitVotesCounter> {
+        self.info[..self.current_length]
+            .iter()
+            .flatten()
+            .cloned()
+            .collect()
+    }
+
+    pub fn last_epoch(&self) -> Epoch {
+        self.last_epoch
+    }
 }
 
 fn is_bit_n_activated(v: u32, n: usize) -> bool {

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -32,9 +32,9 @@ use crate::{
             AddTransaction, Broadcast, BuildDrt, BuildVtt, EpochNotification, GetBalance,
             GetBlocksEpochRange, GetDataRequestInfo, GetHighestCheckpointBeacon,
             GetMemoryTransaction, GetMempool, GetMempoolResult, GetNodeStats, GetReputation,
-            GetReputationResult, GetState, GetSuperBlockVotes, GetUtxoInfo, IsConfirmedBlock,
-            PeersBeacons, ReputationStats, Rewind, SendLastBeacon, SessionUnitResult,
-            SetLastBeacon, SetPeersLimits, TryMineBlock,
+            GetReputationResult, GetSignalingInfo, GetState, GetSuperBlockVotes, GetUtxoInfo,
+            IsConfirmedBlock, PeersBeacons, ReputationStats, Rewind, SendLastBeacon,
+            SessionUnitResult, SetLastBeacon, SetPeersLimits, SignalingInfo, TryMineBlock,
         },
         sessions_manager::SessionsManager,
         storage_keys,
@@ -1602,7 +1602,21 @@ impl Handler<Rewind> for ChainManager {
     }
 }
 
-#[allow(dead_code)]
+impl Handler<GetSignalingInfo> for ChainManager {
+    type Result = Result<SignalingInfo, failure::Error>;
+
+    fn handle(&mut self, _msg: GetSignalingInfo, _ctx: &mut Self::Context) -> Self::Result {
+        let active_upgrades = self.chain_state.tapi_engine.wip_activation.clone();
+        let pending_upgrades = self.chain_state.tapi_engine.bit_tapi_counter.info();
+        let epoch = self.chain_state.tapi_engine.bit_tapi_counter.last_epoch();
+        Ok(SignalingInfo {
+            active_upgrades,
+            pending_upgrades,
+            epoch,
+        })
+    }
+}
+
 #[derive(Debug, Eq, PartialEq)]
 pub enum BlockBatches<T> {
     TargetNotReached(Vec<T>),

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -30,8 +30,8 @@ use crate::{
             AddCandidates, AddPeers, AddTransaction, BuildDrt, BuildVtt, ClearPeers, DropAllPeers,
             GetBalance, GetBlocksEpochRange, GetConsolidatedPeers, GetDataRequestInfo, GetEpoch,
             GetHighestCheckpointBeacon, GetItemBlock, GetItemSuperblock, GetItemTransaction,
-            GetKnownPeers, GetMemoryTransaction, GetMempool, GetNodeStats, GetReputation, GetState,
-            GetUtxoInfo, InitializePeers, IsConfirmedBlock, Rewind,
+            GetKnownPeers, GetMemoryTransaction, GetMempool, GetNodeStats, GetReputation,
+            GetSignalingInfo, GetState, GetUtxoInfo, InitializePeers, IsConfirmedBlock, Rewind,
         },
         peers_manager::PeersManager,
         sessions_manager::SessionsManager,
@@ -103,6 +103,9 @@ pub fn jsonrpc_io_handler(
     });
     io.add_method("getSuperblock", |params: Params| {
         Compat::new(Box::pin(get_superblock(params.parse())))
+    });
+    io.add_method("signalingInfo", |params: Params| {
+        Compat::new(Box::pin(signaling_info(params.parse())))
     });
 
     // Enable methods that assume that JSON-RPC is only accessible by the owner of the node.
@@ -1540,6 +1543,32 @@ pub async fn get_superblock(
     }
 }
 
+/// Get the blocks that pertain to the superblock index
+pub async fn signaling_info(params: Result<(), jsonrpc_core::Error>) -> JsonRpcResult {
+    let _params = match params {
+        Ok(x) => x,
+        Err(e) => return Err(e),
+    };
+
+    let chain_manager_addr = ChainManager::from_registry();
+
+    let info = chain_manager_addr
+        .send(GetSignalingInfo {})
+        .await
+        .map_err(internal_error)?;
+
+    match info {
+        Ok(x) => match serde_json::to_value(&x) {
+            Ok(x) => Ok(x),
+            Err(e) => {
+                let err = internal_error_s(e);
+                Err(err)
+            }
+        },
+        Err(e) => Err(internal_error_s(e)),
+    }
+}
+
 #[cfg(test)]
 mod mock_actix {
     use actix::{MailboxError, Message};
@@ -1887,6 +1916,7 @@ mod tests {
                 "sendRequest",
                 "sendValue",
                 "sign",
+                "signalingInfo",
                 "syncStatus",
                 "witnet_subscribe",
                 "witnet_unsubscribe",

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -21,7 +21,7 @@ use witnet_data_structures::{
         InventoryEntry, InventoryItem, NodeStats, PointerToBlock, PublicKeyHash, RADRequest,
         RADTally, Reputation, StateMachine, SuperBlock, SuperBlockVote, ValueTransferOutput,
     },
-    mainnet_validations::ActiveWips,
+    mainnet_validations::{ActiveWips, BitVotesCounter},
     radon_report::RadonReport,
     transaction::{CommitTransaction, RevealTransaction, Transaction},
     transaction_factory::NodeBalance,
@@ -588,6 +588,24 @@ pub struct GetItemSuperblock {
 
 impl Message for GetItemSuperblock {
     type Result = Result<SuperBlockNotify, InventoryManagerError>;
+}
+
+/// Get TAPI Signaling Info
+pub struct GetSignalingInfo {}
+
+/// Result of GetSignalingInfo
+#[derive(Deserialize, Serialize)]
+pub struct SignalingInfo {
+    /// List of protocol upgrades that are already active, and their activation epoch
+    pub active_upgrades: HashMap<String, Epoch>,
+    /// List of protocol upgrades that are currently being polled for activation signaling
+    pub pending_upgrades: Vec<BitVotesCounter>,
+    /// Last epoch
+    pub epoch: Epoch,
+}
+
+impl Message for GetSignalingInfo {
+    type Result = Result<SignalingInfo, failure::Error>;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Example usage:

```
echo '{"jsonrpc":"2.0","id":"1","method":"signalingInfo","params":null}' | cargo run -- -c witnet_01.toml node raw
```


Example output:

```json
{
  "jsonrpc": "2.0",
  "result": {
    "active_upgrades": {
      "WIP0008": 192000,
      "WIP0009-0011-0012": 376320
    },
    "epoch": 501453,
    "pending_upgrades": [
      {
        "bit": 14,
        "end": 4294967295,
        "init": 1096423,
        "period": 100,
        "votes": 0,
        "wip": "WIPXXX1"
      }
    ]
  },
  "id": "1"
}
```
