### PR TITLE
feat: allow to select from address when creating VTT transactions

### DIFF
--- a/data_structures/tests/serialization_helpers.rs
+++ b/data_structures/tests/serialization_helpers.rs
@@ -1,0 +1,82 @@
+use serde::Serialize;
+use witnet_data_structures::utxo_pool::UtxoSelectionStrategy;
+
+fn test_json_serialization<T>(value: T, json_str: &'static str)
+where
+    T: Serialize,
+    T: serde::de::DeserializeOwned,
+    T: std::fmt::Debug,
+    T: PartialEq,
+{
+    let x = value;
+    let res = serde_json::to_string(&x).unwrap();
+
+    assert_eq!(&res, json_str);
+
+    let d: T = serde_json::from_str(&res).unwrap();
+    assert_eq!(d, x);
+}
+
+#[test]
+fn serialize_utxo_selection_strategy_no_from() {
+    test_json_serialization(UtxoSelectionStrategy::Random { from: None }, r#""random""#);
+    test_json_serialization(
+        UtxoSelectionStrategy::BigFirst { from: None },
+        r#""big_first""#,
+    );
+    test_json_serialization(
+        UtxoSelectionStrategy::SmallFirst { from: None },
+        r#""small_first""#,
+    );
+}
+#[test]
+fn serialize_utxo_selection_strategy_with_from() {
+    // Address with all zeros for testing
+    let my_pkh = "wit1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwrt3a4"
+        .parse()
+        .unwrap();
+
+    test_json_serialization(
+        UtxoSelectionStrategy::Random { from: Some(my_pkh) },
+        r#"{"strategy":"random","from":"wit1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwrt3a4"}"#,
+    );
+    test_json_serialization(
+        UtxoSelectionStrategy::BigFirst { from: Some(my_pkh) },
+        r#"{"strategy":"big_first","from":"wit1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwrt3a4"}"#,
+    );
+    test_json_serialization(
+        UtxoSelectionStrategy::SmallFirst { from: Some(my_pkh) },
+        r#"{"strategy":"small_first","from":"wit1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwrt3a4"}"#,
+    );
+}
+
+#[test]
+fn deserialize_utxo_selection_strategy_object_no_from() {
+    // Check that the "from" field is optional and defaults to None
+    let d: UtxoSelectionStrategy = serde_json::from_str(r#"{"strategy": "random"}"#).unwrap();
+    assert_eq!(d, UtxoSelectionStrategy::Random { from: None });
+}
+
+#[test]
+fn deserialize_utxo_selection_strategy_object_invalid_from() {
+    // Check that when the "from" field is invalid, the error message is easy to understand
+    let d: Result<UtxoSelectionStrategy, _> =
+        serde_json::from_str(r#"{"strategy": "Random", "from": "potato"}"#);
+    assert_eq!(
+        d.unwrap_err().to_string(),
+        "Failed to deserialize Bech32: invalid length at line 1 column 40"
+    );
+}
+
+#[test]
+fn deserialize_utxo_selection_strategy_name_alias() {
+    // Check that "random" and "Random" are both valid names
+    let d: UtxoSelectionStrategy = serde_json::from_str(r#"{"strategy": "random"}"#).unwrap();
+    assert_eq!(d, UtxoSelectionStrategy::Random { from: None });
+    let d: UtxoSelectionStrategy = serde_json::from_str(r#"{"strategy": "Random"}"#).unwrap();
+    assert_eq!(d, UtxoSelectionStrategy::Random { from: None });
+    let d: UtxoSelectionStrategy = serde_json::from_str(r#""random""#).unwrap();
+    assert_eq!(d, UtxoSelectionStrategy::Random { from: None });
+    let d: UtxoSelectionStrategy = serde_json::from_str(r#""Random""#).unwrap();
+    assert_eq!(d, UtxoSelectionStrategy::Random { from: None });
+}

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -1158,7 +1158,7 @@ impl Handler<BuildVtt> for ChainManager {
             &self.chain_state.unspent_outputs_pool,
             timestamp,
             self.tx_pending_timeout,
-            msg.utxo_strategy,
+            &msg.utxo_strategy,
             max_vt_weight,
         ) {
             Err(e) => {

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -474,9 +474,9 @@ pub fn send_vtt(
     });
 
     let utxo_strategy = match sorted_bigger {
-        Some(true) => UtxoSelectionStrategy::BigFirst,
-        Some(false) => UtxoSelectionStrategy::SmallFirst,
-        None => UtxoSelectionStrategy::Random,
+        Some(true) => UtxoSelectionStrategy::BigFirst { from: None },
+        Some(false) => UtxoSelectionStrategy::SmallFirst { from: None },
+        None => UtxoSelectionStrategy::Random { from: None },
     };
 
     let params = BuildVtt {

--- a/wallet/src/actors/app/handlers/create_vtt.rs
+++ b/wallet/src/actors/app/handlers/create_vtt.rs
@@ -14,6 +14,7 @@ use witnet_data_structures::{
     proto::ProtobufConvert,
     transaction::Transaction,
     transaction_factory::FeeType,
+    utxo_pool::UtxoSelectionStrategy,
 };
 use witnet_futures_utils::ActorFutureExt2;
 
@@ -40,6 +41,8 @@ pub struct CreateVttRequest {
     session_id: types::SessionId,
     wallet_id: String,
     fee_type: Option<FeeType>,
+    #[serde(default)]
+    utxo_strategy: UtxoSelectionStrategy,
 }
 
 /// Part of CreateVttResponse struct, containing additional data to be displayed in clients
@@ -89,6 +92,7 @@ impl Handler<CreateVttRequest> for app::App {
                 fee: msg.fee,
                 outputs,
                 fee_type,
+                utxo_strategy: msg.utxo_strategy.clone(),
             };
 
             act.create_vtt(&msg.session_id, &msg.wallet_id, params)

--- a/wallet/src/repository/wallet/tests/mod.rs
+++ b/wallet/src/repository/wallet/tests/mod.rs
@@ -327,13 +327,20 @@ fn test_create_transaction_components_when_wallet_have_no_utxos() {
     let fee = 0;
     let pkh = factories::pkh();
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
     let vto = ValueTransferOutput {
         pkh,
         value,
         time_lock,
     };
     let err = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Absolute)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Absolute,
+            &utxo_strategy,
+        )
         .unwrap_err();
 
     assert_eq!(
@@ -372,6 +379,7 @@ fn test_create_transaction_components_without_a_change_address() {
     let value = 1;
     let fee = 0;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
     let vto = ValueTransferOutput {
         pkh,
         value,
@@ -379,7 +387,13 @@ fn test_create_transaction_components_without_a_change_address() {
     };
 
     let (inputs, outputs) = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Absolute)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Absolute,
+            &utxo_strategy,
+        )
         .unwrap();
 
     assert_eq!(1, inputs.len());
@@ -417,6 +431,7 @@ fn test_create_transaction_components_with_a_change_address() {
     let value = 1;
     let fee = 0;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
 
     let vto = ValueTransferOutput {
         pkh,
@@ -425,7 +440,13 @@ fn test_create_transaction_components_with_a_change_address() {
     };
 
     let (inputs, outputs) = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Absolute)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Absolute,
+            &utxo_strategy,
+        )
         .unwrap();
 
     assert_eq!(1, inputs.len());
@@ -482,13 +503,20 @@ fn test_create_transaction_components_which_value_overflows() {
     let value = std::u64::MAX;
     let fee = 0;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
     let vto = ValueTransferOutput {
         pkh,
         value,
         time_lock,
     };
     let err = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Absolute)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Absolute,
+            &utxo_strategy,
+        )
         .unwrap_err();
 
     assert_eq!(
@@ -531,6 +559,7 @@ fn test_create_vtt_does_not_spend_utxos() {
     let value = 1;
     let fee = 0;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
 
     let state_utxo_set = wallet.utxo_set().unwrap();
     let utxo_set: HashMap<model::OutPtr, model::OutputInfo> =
@@ -550,6 +579,7 @@ fn test_create_vtt_does_not_spend_utxos() {
                 time_lock,
             }],
             fee_type: FeeType::Absolute,
+            utxo_strategy,
         })
         .unwrap();
 
@@ -952,6 +982,7 @@ fn test_index_transaction_vtt_created_by_wallet() {
                 time_lock: 0,
             }],
             fee_type: FeeType::Absolute,
+            utxo_strategy: UtxoSelectionStrategy::Random { from: None },
         })
         .unwrap();
 
@@ -1065,6 +1096,7 @@ fn test_get_transaction() {
                 time_lock: 0,
             }],
             fee_type: FeeType::Absolute,
+            utxo_strategy: UtxoSelectionStrategy::Random { from: None },
         })
         .unwrap();
 
@@ -1136,6 +1168,7 @@ fn test_get_transactions() {
                 time_lock: 0,
             }],
             fee_type: FeeType::Absolute,
+            utxo_strategy: UtxoSelectionStrategy::Random { from: None },
         })
         .unwrap();
 
@@ -1207,6 +1240,7 @@ fn test_create_vtt_with_locked_balance() {
                 time_lock: 0,
             }],
             fee_type: FeeType::Absolute,
+            utxo_strategy: UtxoSelectionStrategy::Random { from: None },
         })
         .unwrap_err();
 
@@ -1269,6 +1303,7 @@ fn test_create_vtt_with_multiple_outputs() {
                 },
             ],
             fee_type: FeeType::Absolute,
+            utxo_strategy: UtxoSelectionStrategy::Random { from: None },
         })
         .unwrap();
 
@@ -1346,13 +1381,20 @@ fn test_create_vt_components_weighted_fee() {
     let value = 1;
     let fee = 1;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
     let vto = ValueTransferOutput {
         pkh,
         value,
         time_lock,
     };
     let (inputs, outputs) = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Weighted)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Weighted,
+            &utxo_strategy,
+        )
         .unwrap();
 
     assert_eq!(1, inputs.len());
@@ -1408,13 +1450,20 @@ fn test_create_vt_components_weighted_fee_2() {
     let value = 1;
     let fee = 1;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
     let vto = ValueTransferOutput {
         pkh,
         value,
         time_lock,
     };
     let (inputs, outputs) = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Weighted)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Weighted,
+            &utxo_strategy,
+        )
         .unwrap();
 
     assert!(!inputs.is_empty());
@@ -1467,13 +1516,20 @@ fn test_create_vt_components_weighted_fee_3() {
     let value = 1;
     let fee = 1;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
     let vto = ValueTransferOutput {
         pkh,
         value,
         time_lock,
     };
     let err = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Weighted)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Weighted,
+            &utxo_strategy,
+        )
         .unwrap_err();
 
     assert_eq!(
@@ -1551,13 +1607,20 @@ fn test_create_vt_components_weighted_fee_4() {
     let value = 1;
     let fee = 1;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
     let vto = ValueTransferOutput {
         pkh,
         value,
         time_lock,
     };
     let (inputs, outputs) = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Weighted)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Weighted,
+            &utxo_strategy,
+        )
         .unwrap();
 
     assert!(!inputs.is_empty());
@@ -1630,13 +1693,20 @@ fn test_create_vt_components_weighted_fee_5() {
     let value = 1;
     let fee = 1;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
     let vto = ValueTransferOutput {
         pkh,
         value,
         time_lock,
     };
     let (inputs, outputs) = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Weighted)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Weighted,
+            &utxo_strategy,
+        )
         .unwrap();
 
     assert!(!inputs.is_empty());
@@ -1715,13 +1785,20 @@ fn test_create_vt_components_weighted_fee_6() {
     let value = 1;
     let fee = 1;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
     let vto = ValueTransferOutput {
         pkh,
         value,
         time_lock,
     };
     let (inputs, outputs) = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Weighted)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Weighted,
+            &utxo_strategy,
+        )
         .unwrap();
 
     assert!(inputs.len() >= 2);
@@ -1751,13 +1828,20 @@ fn test_create_vt_components_weighted_fee_without_outputs() {
     let value = 1;
     let fee = 1;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
     let vto = ValueTransferOutput {
         pkh,
         value,
         time_lock,
     };
     let err = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Weighted)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Weighted,
+            &utxo_strategy,
+        )
         .unwrap_err();
 
     assert_eq!(
@@ -1802,13 +1886,20 @@ fn test_create_vt_components_weighted_fee_with_too_large_fee() {
     let value = 1;
     let fee = u64::MAX;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
     let vto = ValueTransferOutput {
         pkh,
         value,
         time_lock,
     };
     let err = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Weighted)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Weighted,
+            &utxo_strategy,
+        )
         .unwrap_err();
 
     assert_eq!(
@@ -1857,13 +1948,20 @@ fn test_create_vt_weight_too_large() {
     let value = 150;
     let fee = 0;
     let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: None };
     let vto = ValueTransferOutput {
         pkh,
         value,
         time_lock,
     };
     let err = wallet
-        .create_vt_transaction_components(&mut state, vec![vto], fee, FeeType::Weighted)
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Weighted,
+            &utxo_strategy,
+        )
         .unwrap_err();
 
     assert_eq!(
@@ -2214,6 +2312,222 @@ fn test_create_dr_components_weighted_fee_fee_too_large() {
 
     assert_eq!(
         mem::discriminant(&repository::Error::FeeTooLarge),
+        mem::discriminant(&err),
+        "{:?}",
+        err,
+    );
+}
+
+#[test]
+fn test_create_transaction_components_filter_from_address() {
+    // Create UTXO set with 2 UTXOs from different addresses
+    let pkh1 = factories::pkh();
+    let pkh2 = factories::pkh();
+    assert_ne!(pkh1, pkh2);
+    let mut utxo_set: HashMap<model::OutPtr, model::OutputInfo> = HashMap::new();
+
+    for i in 0..100 {
+        // 50 UTXOs with pkh1 and 50 UTXOs with pkh2
+        let pkh = if i < 50 { pkh1 } else { pkh2 };
+        utxo_set.insert(
+            model::OutPtr {
+                txn_hash: vec![0; 32],
+                output_index: i,
+            },
+            model::OutputInfo {
+                pkh,
+                amount: 1,
+                time_lock: 0,
+            },
+        );
+    }
+
+    let path1 = model::Path {
+        account: 0,
+        keychain: constants::EXTERNAL_KEYCHAIN,
+        index: 0,
+    };
+    let path2 = model::Path {
+        account: 0,
+        keychain: constants::EXTERNAL_KEYCHAIN,
+        index: 1,
+    };
+    let new_balance = model::BalanceInfo {
+        available: 10_000 + 10_000,
+        locked: 0u64,
+    };
+
+    let db = HashMapDb::default();
+    db.put(&keys::account_utxo_set(0), utxo_set).unwrap();
+    db.put(&keys::account_balance(0), new_balance).unwrap();
+    db.put(&keys::pkh(&pkh1), path1).unwrap();
+    db.put(&keys::pkh(&pkh2), path2).unwrap();
+    let (wallet, _db) = factories::wallet(Some(db));
+    let mut state = wallet.state.write().unwrap();
+    let pkh3 = factories::pkh();
+    let value = 50;
+    let fee = 0;
+    let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: Some(pkh1) };
+    let vto = ValueTransferOutput {
+        pkh: pkh3,
+        value,
+        time_lock,
+    };
+    let (inputs, _outputs) = wallet
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Absolute,
+            &utxo_strategy,
+        )
+        .unwrap();
+
+    assert!(inputs
+        .iter()
+        .all(|input| { input.output_pointer().output_index < 50 }))
+}
+
+#[test]
+fn test_create_transaction_components_filter_from_address_2() {
+    // Create UTXO set with 2 UTXOs from different addresses
+    let pkh1 = factories::pkh();
+    let pkh2 = factories::pkh();
+    assert_ne!(pkh1, pkh2);
+    let mut utxo_set: HashMap<model::OutPtr, model::OutputInfo> = HashMap::new();
+
+    for i in 0..100 {
+        // 50 UTXOs with pkh1 and 50 UTXOs with pkh2
+        let pkh = if i < 50 { pkh1 } else { pkh2 };
+        utxo_set.insert(
+            model::OutPtr {
+                txn_hash: vec![0; 32],
+                output_index: i,
+            },
+            model::OutputInfo {
+                pkh,
+                amount: 1,
+                time_lock: 0,
+            },
+        );
+    }
+
+    let path1 = model::Path {
+        account: 0,
+        keychain: constants::EXTERNAL_KEYCHAIN,
+        index: 0,
+    };
+    let path2 = model::Path {
+        account: 0,
+        keychain: constants::EXTERNAL_KEYCHAIN,
+        index: 1,
+    };
+    let new_balance = model::BalanceInfo {
+        available: 10_000 + 10_000,
+        locked: 0u64,
+    };
+
+    let db = HashMapDb::default();
+    db.put(&keys::account_utxo_set(0), utxo_set).unwrap();
+    db.put(&keys::account_balance(0), new_balance).unwrap();
+    db.put(&keys::pkh(&pkh1), path1).unwrap();
+    db.put(&keys::pkh(&pkh2), path2).unwrap();
+    let (wallet, _db) = factories::wallet(Some(db));
+    let mut state = wallet.state.write().unwrap();
+    let pkh3 = factories::pkh();
+    let value = 50;
+    let fee = 0;
+    let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: Some(pkh2) };
+    let vto = ValueTransferOutput {
+        pkh: pkh3,
+        value,
+        time_lock,
+    };
+    let (inputs, _outputs) = wallet
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Absolute,
+            &utxo_strategy,
+        )
+        .unwrap();
+
+    assert!(inputs
+        .iter()
+        .all(|input| { input.output_pointer().output_index >= 50 }))
+}
+
+#[test]
+fn test_create_transaction_components_filter_from_address_3() {
+    // Create UTXO set with 2 UTXOs from different addresses
+    let pkh1 = factories::pkh();
+    let pkh2 = factories::pkh();
+    assert_ne!(pkh1, pkh2);
+    let mut utxo_set: HashMap<model::OutPtr, model::OutputInfo> = HashMap::new();
+
+    for i in 0..100 {
+        // 50 UTXOs with pkh1 and 50 UTXOs with pkh2
+        let pkh = if i < 50 { pkh1 } else { pkh2 };
+        utxo_set.insert(
+            model::OutPtr {
+                txn_hash: vec![0; 32],
+                output_index: i,
+            },
+            model::OutputInfo {
+                pkh,
+                amount: 1,
+                time_lock: 0,
+            },
+        );
+    }
+
+    let path1 = model::Path {
+        account: 0,
+        keychain: constants::EXTERNAL_KEYCHAIN,
+        index: 0,
+    };
+    let path2 = model::Path {
+        account: 0,
+        keychain: constants::EXTERNAL_KEYCHAIN,
+        index: 1,
+    };
+    let new_balance = model::BalanceInfo {
+        available: 10_000 + 10_000,
+        locked: 0u64,
+    };
+
+    let db = HashMapDb::default();
+    db.put(&keys::account_utxo_set(0), utxo_set).unwrap();
+    db.put(&keys::account_balance(0), new_balance).unwrap();
+    db.put(&keys::pkh(&pkh1), path1).unwrap();
+    db.put(&keys::pkh(&pkh2), path2).unwrap();
+    let (wallet, _db) = factories::wallet(Some(db));
+    let mut state = wallet.state.write().unwrap();
+    let pkh3 = factories::pkh();
+    let value = 50;
+    let fee = 0;
+    let time_lock = 0;
+    let utxo_strategy = UtxoSelectionStrategy::Random { from: Some(pkh3) };
+    let vto = ValueTransferOutput {
+        pkh: pkh3,
+        value,
+        time_lock,
+    };
+    let err = wallet
+        .create_vt_transaction_components(
+            &mut state,
+            vec![vto],
+            fee,
+            FeeType::Absolute,
+            &utxo_strategy,
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        mem::discriminant(&repository::Error::InsufficientBalance),
         mem::discriminant(&err),
         "{:?}",
         err,

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -26,6 +26,7 @@ use witnet_data_structures::{
         TallyTransaction, Transaction, VTTransaction, VTTransactionBody,
     },
     transaction_factory::FeeType,
+    utxo_pool::UtxoSelectionStrategy,
 };
 
 use witnet_protected::{Protected, ProtectedString};
@@ -150,6 +151,7 @@ pub struct VttParams {
     pub fee: u64,
     pub outputs: Vec<ValueTransferOutput>,
     pub fee_type: FeeType,
+    pub utxo_strategy: UtxoSelectionStrategy,
 }
 
 pub struct DataReqParams {


### PR DESCRIPTION
Allow to use an UTXO selection strategy that only takes UTXOs from the specified address.

Close #1940

In the wallet JSON-RPC API: add optional utxo_strategy field to `create_vtt` method. This allows to choose the address of the inputs of the transaction, but it also allows to use different UTXO selection strategies such as "bigger first" or "smaller first", aside from the default "random".

In the node JSON-RPC API: since the node only has one address this field can only be used as a fail-safe: if the node address is the one in the "from" field then the transaction will be created, and if the node address is not the one in the "from" field then the transaction will return an error "InsufficientBalance".

Example call (node):

```json
{
  "jsonrpc": "2.0",
  "method": "sendValue",
  "params": {
    "vto": [
      {
        "pkh": "wit1vfuklxq4p5d7t744evcrj04r68q7j2f8yj0vqx",
        "value": 6000,
        "time_lock": 0
      }
    ],
    "fee": 0,
    "utxo_strategy": {
      "strategy": "Random",
      "from": "wit1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwrt3a4"
    }
  },
  "id": "1"
}
```