### PR TITLE
chore: make CI fail when there are unstaged files

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,3 +58,7 @@ jobs:
         with:
           command: test
           args: --all --verbose
+
+      # This is used to ensure that Cargo.lock is up to date
+      - name: Check for unstaged files
+        run: git diff --exit-code


### PR DESCRIPTION
To prevent #1946 from happening again