### PR TITLE
fix(data_structures): remove misleading "0 votes:" log

### DIFF
--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -129,6 +129,11 @@ impl SuperBlockVotesMempool {
                 .unwrap();
             let pos = v.iter().position(|x| *x == old_sbv).unwrap();
             v.swap_remove(pos);
+
+            if v.is_empty() {
+                self.votes_on_each_superblock
+                    .remove(&old_sbv.superblock_hash);
+            }
         }
         self.penalized_identities.insert(pkh);
     }


### PR DESCRIPTION
In some rare occasions, we can see logs like this:

```
[2021-05-31T13:00:00Z DEBUG witnet_data_structures::superblock] Superblock votes (99 in total):
      a2c00dedb1f9f6fc41529112d6995b664e937c64ffc17c6364f1beab21ce0bae: 0 votes: []
      e61aed6cd040c2ab2d09f0dc033394043a76824771f15e431456a4556f9767c7: 11 votes: ["wit1agc...
      a43e0a1bedea3390d49eb93720be90f587c0b39f562f1dbd7d92fdb9ef18bee1: 88 votes: ["wit1ay3...
[2021-05-31T13:00:00Z DEBUG witnet_data_structures::superblock] Signing committee of size 100: ["wit1kn7...
```

Notice how the first line says "0 votes", which does not make sense. This happens when one identity votes more than once: the first vote was for superblock a2c00dedb1f9f6fc41529112d6995b664e937c64ffc17c6364f1beab21ce0bae, and the second vote was for superblock a43e0a1bedea3390d49eb93720be90f587c0b39f562f1dbd7d92fdb9ef18bee1. The current behavior is to remove both votes in that case, which leaves this misleading log line.

So this PR fixes this edge case by removing the superblock hashes that have 0 votes.