### PR TITLE
feat: temporarily allow microforked peering

### DIFF
--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -807,8 +807,10 @@ fn check_beacon_compatibility(
         }),
         // current_checkpoint == received_checkpoint
         Ordering::Equal => {
-            if current_beacon.highest_block_checkpoint.hash_prev_block
-                == received_beacon.highest_block_checkpoint.hash_prev_block
+            if current_beacon.highest_superblock_checkpoint.hash_prev_block
+                == received_beacon
+                    .highest_superblock_checkpoint
+                    .hash_prev_block
             {
                 // Beacons are equal
                 Ok(())


### PR DESCRIPTION
This makes a node tolerate peers that have the same top superblock, even if they are on different blocks, assuming that they will eventually get on the same page at some point after failed superblock consensus.