### PR TITLE
Remove threshold factor from reppoe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5321,6 +5321,7 @@ dependencies = [
  "failure",
  "itertools",
  "log 0.4.11",
+ "witnet_config",
  "witnet_crypto",
  "witnet_data_structures",
  "witnet_protected",

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -289,6 +289,8 @@ impl ChainManager {
         let current_epoch = self.current_epoch.unwrap();
         let data_request_timeout = self.data_request_timeout;
         let timestamp = u64::try_from(get_timestamp()).unwrap();
+        let consensus_constants = self.consensus_constants();
+        let minimum_reppoe_difficulty = consensus_constants.minimum_difficulty;
 
         // Data Request mining
         let dr_pointers = self
@@ -333,8 +335,6 @@ impl ChainManager {
                 ..vrf_input
             };
 
-            // TODO: pass difficulty as an argument to this function (from consensus constants)
-            let minimum_reppoe_difficulty = 2000;
             let active_wips = ActiveWips {
                 active_wips: self.chain_state.tapi_engine.wip_activation.clone(),
                 block_epoch: current_epoch,

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -1163,6 +1163,7 @@ impl ChainManager {
                 chain_info.consensus_constants.collateral_age,
                 chain_info.consensus_constants.max_vt_weight,
                 chain_info.consensus_constants.max_dr_weight,
+                chain_info.consensus_constants.minimum_difficulty,
                 &active_wips,
             ))
             .into_actor(self)

--- a/validations/Cargo.toml
+++ b/validations/Cargo.toml
@@ -17,6 +17,7 @@ witnet_rad = { path = "../rad" }
 
 [dev-dependencies]
 bencher = "0.1.5"
+witnet_config = { path = "../config" }
 witnet_protected = { path = "../protected" }
 
 [[bench]]

--- a/validations/src/tests.rs
+++ b/validations/src/tests.rs
@@ -2326,6 +2326,7 @@ fn test_empty_commit(c_tx: &CommitTransaction) -> Result<(), failure::Error> {
     let collateral_minimum = 1;
     let collateral_age = 1;
     let block_number = 0;
+    let minimum_reppoe_difficulty = 1;
     let utxo_diff = UtxoDiff::new(&utxo_set, block_number);
 
     validate_commit_transaction(
@@ -2340,6 +2341,7 @@ fn test_empty_commit(c_tx: &CommitTransaction) -> Result<(), failure::Error> {
         collateral_minimum,
         collateral_age,
         block_number,
+        minimum_reppoe_difficulty,
         &all_wips_active(),
     )
     .map(|_| ())
@@ -2356,6 +2358,7 @@ fn test_commit_with_dr_and_utxo_set(
     let utxo_diff = UtxoDiff::new(utxo_set, 0);
     let collateral_minimum = 1;
     let collateral_age = 1;
+    let minimum_reppoe_difficulty = 1;
 
     let mut dr_pool = DataRequestPool::default();
     let vrf_input = CheckpointVRF::default();
@@ -2392,6 +2395,7 @@ fn test_commit_with_dr_and_utxo_set(
         collateral_minimum,
         collateral_age,
         block_number,
+        minimum_reppoe_difficulty,
         &all_wips_active(),
     )?;
     verify_signatures_test(signatures_to_verify)?;
@@ -2452,6 +2456,7 @@ fn test_commit_difficult_proof() {
     let block_number = 100_000;
     let collateral_minimum = 1;
     let collateral_age = 1;
+    let minimum_reppoe_difficulty = 1;
     let utxo_diff = UtxoDiff::new(&utxo_set, 0);
     let vti = Input::new(utxo_set.iter().next().unwrap().0.clone());
 
@@ -2481,6 +2486,7 @@ fn test_commit_difficult_proof() {
         collateral_minimum,
         collateral_age,
         block_number,
+        minimum_reppoe_difficulty,
         &active_wips,
     )
     .and_then(|_| verify_signatures_test(signatures_to_verify));
@@ -2534,6 +2540,7 @@ fn test_commit_with_collateral(
     let collateral_minimum = 1;
     let collateral_age = 10;
     let utxo_diff = UtxoDiff::new(&utxo_set, 0);
+    let minimum_reppoe_difficulty = 1;
 
     let (inputs, outputs) = collateral;
     cb.collateral = inputs;
@@ -2555,6 +2562,7 @@ fn test_commit_with_collateral(
         collateral_minimum,
         collateral_age,
         block_number,
+        minimum_reppoe_difficulty,
         &all_wips_active(),
     )
     .map(|_| ())
@@ -2759,6 +2767,7 @@ fn commitment_invalid_proof() {
     let block_number = 100_000;
     let collateral_minimum = 1;
     let collateral_age = 1;
+    let minimum_reppoe_difficulty = 1;
     let utxo_diff = UtxoDiff::new(&utxo_set, 0);
     let vti = Input::new(utxo_set.iter().next().unwrap().0.clone());
 
@@ -2798,6 +2807,7 @@ fn commitment_invalid_proof() {
         collateral_minimum,
         collateral_age,
         block_number,
+        minimum_reppoe_difficulty,
         &all_wips_active(),
     )
     .and_then(|_| verify_signatures_test(signatures_to_verify));
@@ -2819,6 +2829,7 @@ fn commitment_dr_in_reveal_stage() {
     let block_number = 0;
     let collateral_minimum = 1;
     let collateral_age = 1;
+    let minimum_reppoe_difficulty = 1;
     let utxo_diff = UtxoDiff::new(&utxo_set, block_number);
 
     let mut dr_pool = DataRequestPool::default();
@@ -2872,6 +2883,7 @@ fn commitment_dr_in_reveal_stage() {
         collateral_minimum,
         collateral_age,
         block_number,
+        minimum_reppoe_difficulty,
         &all_wips_active(),
     );
     assert_eq!(
@@ -3233,6 +3245,7 @@ fn commitment_collateral_zero_is_minimum() {
         let block_number = 100_000;
         let collateral_minimum = 1;
         let collateral_age = 1;
+        let minimum_reppoe_difficulty = 1;
         let utxo_diff = UtxoDiff::new(&utxo_set, 0);
 
         let (inputs, outputs) = collateral;
@@ -3255,6 +3268,7 @@ fn commitment_collateral_zero_is_minimum() {
             collateral_minimum,
             collateral_age,
             block_number,
+            minimum_reppoe_difficulty,
             &all_wips_active(),
         )
         .map(|_| ())
@@ -3319,6 +3333,7 @@ fn commitment_timelock() {
         let block_number = 100_000;
         let collateral_minimum = 1;
         let collateral_age = 1;
+        let minimum_reppoe_difficulty = 1;
         let utxo_diff = UtxoDiff::new(&utxo_set, 0);
         let vti = Input::new(utxo_set.iter().next().unwrap().0.clone());
 
@@ -3344,6 +3359,7 @@ fn commitment_timelock() {
             collateral_minimum,
             collateral_age,
             block_number,
+            minimum_reppoe_difficulty,
             &active_wips,
         )
         .map(|_| ())?;
@@ -8570,7 +8586,7 @@ fn validate_commit_transactions_included_in_utxo_diff() {
             bootstrap_hash: Default::default(),
             mining_replication_factor: 0,
             extra_rounds: 0,
-            minimum_difficulty: 0,
+            minimum_difficulty: 1,
             epochs_with_minimum_difficulty: 0,
             superblock_signing_committee_size: 100,
             superblock_committee_decreasing_period: 100,

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -836,6 +836,7 @@ pub fn validate_commit_transaction(
     collateral_minimum: u64,
     collateral_age: u32,
     block_number: u32,
+    minimum_reppoe_difficulty: u32,
     active_wips: &ActiveWips,
 ) -> Result<(Hash, u16, u64), failure::Error> {
     // Get DataRequest information
@@ -916,8 +917,6 @@ pub fn validate_commit_transaction(
     let pkh = proof_pkh;
     let backup_witnesses = dr_state.backup_witnesses();
     let num_witnesses = dr_output.witnesses + backup_witnesses;
-    // TODO: pass difficulty as an argument to this function (from consensus constants)
-    let minimum_reppoe_difficulty = 2000;
     let (target_hash, _) = calculate_reppoe_threshold(
         rep_eng,
         &pkh,
@@ -1716,6 +1715,7 @@ pub fn validate_block_transactions(
             consensus_constants.collateral_minimum,
             consensus_constants.collateral_age,
             block_number,
+            consensus_constants.minimum_difficulty,
             active_wips,
         )?;
 
@@ -2026,6 +2026,7 @@ pub fn validate_new_transaction(
     collateral_age: u32,
     max_vt_weight: u32,
     max_dr_weight: u32,
+    minimum_reppoe_difficulty: u32,
     active_wips: &ActiveWips,
 ) -> Result<u64, failure::Error> {
     let utxo_diff = UtxoDiff::new(&unspent_outputs_pool, block_number);
@@ -2063,6 +2064,7 @@ pub fn validate_new_transaction(
             collateral_minimum,
             collateral_age,
             block_number,
+            minimum_reppoe_difficulty,
             active_wips,
         )
         .map(|(_, _, fee)| fee),

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -2480,7 +2480,6 @@ pub fn verify_signatures(
 #[cfg(test)]
 mod tests {
     use witnet_data_structures::{
-        chain::Alpha,
         chain::Environment,
         mainnet_validations::{TapiEngine, SECOND_HARD_FORK},
         radon_error::RadonError,
@@ -3015,194 +3014,6 @@ mod tests {
         assert_eq!((p06 * 100_f64).round() as i128, 0);
     }
 
-    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
-    #[allow(clippy::cast_possible_truncation)]
-    #[test]
-    fn target_reppoe() {
-        // This test is only valid before the third hard fork
-        let active_wips = ActiveWips {
-            active_wips: Default::default(),
-            block_epoch: 0,
-        };
-
-        let mut rep_engine = ReputationEngine::new(1000);
-        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
-        rep_engine
-            .trs_mut()
-            .gain(Alpha(10), vec![(id1, Reputation(50))])
-            .unwrap();
-        rep_engine.ars_mut().push_activity(vec![id1]);
-
-        // 100% when we have all the reputation
-        let (t00, p00) = calculate_reppoe_threshold(&rep_engine, &id1, 1, 2000, &active_wips);
-        assert_eq!(t00, Hash::with_first_u32(0xFFFF_FFFF));
-        assert_eq!((p00 * 100_f64).round() as i128, 100);
-
-        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
-        rep_engine
-            .trs_mut()
-            .gain(Alpha(10), vec![(id2, Reputation(50))])
-            .unwrap();
-        rep_engine.ars_mut().push_activity(vec![id2]);
-
-        // 50% when there are 2 nodes with 50% of the reputation each
-        let (t01, p01) = calculate_reppoe_threshold(&rep_engine, &id1, 1, 2000, &active_wips);
-        // Since the calculate_reppoe function first divides and later
-        // multiplies, we get a rounding error here
-        assert_eq!(t01, Hash::with_first_u32(0x7FFF_FFFF));
-        assert_eq!((p01 * 100_f64).round() as i128, 50);
-    }
-
-    // Auxiliar function to add reputation
-    fn add_rep(rep_engine: &mut ReputationEngine, alpha: u32, pkh: PublicKeyHash, rep: u32) {
-        rep_engine
-            .trs_mut()
-            .gain(Alpha(alpha), vec![(pkh, Reputation(rep))])
-            .unwrap();
-    }
-
-    #[test]
-    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
-    #[allow(
-        clippy::cast_possible_truncation,
-        clippy::cognitive_complexity,
-        clippy::cast_sign_loss
-    )]
-    fn target_reppoe_specific_example() {
-        // This test is only valid before the third hard fork
-        let active_wips = ActiveWips {
-            active_wips: Default::default(),
-            block_epoch: 0,
-        };
-
-        let mut rep_engine = ReputationEngine::new(1000);
-        let mut ids = vec![];
-        for i in 0..8 {
-            ids.push(PublicKeyHash::from_bytes(&[i; 20]).unwrap());
-        }
-        rep_engine.ars_mut().push_activity(ids.clone());
-
-        add_rep(&mut rep_engine, 10, ids[0], 79);
-        add_rep(&mut rep_engine, 10, ids[1], 9);
-        add_rep(&mut rep_engine, 10, ids[2], 1);
-        add_rep(&mut rep_engine, 10, ids[3], 1);
-        add_rep(&mut rep_engine, 10, ids[4], 1);
-        add_rep(&mut rep_engine, 10, ids[5], 1);
-
-        let rep_thresholds = |thres| {
-            let mut v = vec![];
-            for id in ids.iter() {
-                v.push(
-                    (calculate_reppoe_threshold(&rep_engine, id, thres, 2000, &active_wips).1
-                        * 100_f64)
-                        .round() as u32,
-                );
-            }
-            v
-        };
-
-        let expected_rep_1 = vec![28, 23, 19, 5, 14, 9, 1, 1];
-        assert_eq!(rep_thresholds(1), expected_rep_1);
-
-        let expected_rep_1 = vec![56, 46, 38, 10, 28, 18, 2, 2];
-        assert_eq!(rep_thresholds(2), expected_rep_1);
-
-        let expected_rep_1 = vec![84, 69, 57, 15, 42, 27, 3, 3];
-        assert_eq!(rep_thresholds(3), expected_rep_1);
-
-        let expected_rep_1 = vec![100, 100, 95, 25, 70, 45, 5, 5];
-        assert_eq!(rep_thresholds(4), expected_rep_1);
-
-        let expected_rep_1 = vec![100, 100, 100, 35, 98, 63, 7, 7];
-        assert_eq!(rep_thresholds(5), expected_rep_1);
-    }
-
-    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
-    #[allow(clippy::cast_possible_truncation)]
-    #[test]
-    fn target_reppoe_zero_reputation() {
-        // This test is only valid before the third hard fork
-        let active_wips = ActiveWips {
-            active_wips: Default::default(),
-            block_epoch: 0,
-        };
-
-        // Test the behavior of the algorithm when our node has 0 reputation
-        let mut rep_engine = ReputationEngine::new(1000);
-        let id0 = PublicKeyHash::from_bytes(&[0; 20]).unwrap();
-
-        // 100% when the total reputation is 0
-        let (t00, p00) = calculate_reppoe_threshold(&rep_engine, &id0, 1, 2000, &active_wips);
-        assert_eq!((p00 * 100_f64).round() as i128, 100);
-        assert_eq!(t00, Hash::with_first_u32(0xFFFF_FFFF));
-        let (t01, p01) = calculate_reppoe_threshold(&rep_engine, &id0, 100, 2000, &active_wips);
-        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF));
-        assert_eq!((p01 * 100_f64).round() as i128, 100);
-
-        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
-        rep_engine.ars_mut().push_activity(vec![id1]);
-        let (t02, p02) = calculate_reppoe_threshold(&rep_engine, &id0, 1, 2000, &active_wips);
-        assert_eq!(t02, Hash::with_first_u32(0xFFFF_FFFF));
-        assert_eq!((p02 * 100_f64).round() as i128, 100);
-
-        // 50% when the total reputation is 1
-        rep_engine
-            .trs_mut()
-            .gain(Alpha(10), vec![(id1, Reputation(1))])
-            .unwrap();
-        let (t03, p03) = calculate_reppoe_threshold(&rep_engine, &id0, 1, 2000, &active_wips);
-        assert_eq!(t03, Hash::with_first_u32(0x7FFF_FFFF));
-        assert_eq!((p03 * 100_f64).round() as i128, 50);
-
-        // 33% when the total reputation is 1 but there are 2 active identities
-        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
-        rep_engine.ars_mut().push_activity(vec![id2]);
-        let (t04, p04) = calculate_reppoe_threshold(&rep_engine, &id0, 1, 2000, &active_wips);
-        assert_eq!(t04, Hash::with_first_u32(0x5555_5555));
-        assert_eq!((p04 * 100_f64).round() as i128, 33);
-
-        // 10 identities with 100 total reputation: 1 / (100 + 10) ~= 0.9%
-        for i in 3..=10 {
-            rep_engine
-                .ars_mut()
-                .push_activity(vec![PublicKeyHash::from_bytes(&[i; 20]).unwrap()]);
-        }
-        rep_engine
-            .trs_mut()
-            .gain(Alpha(10), vec![(id1, Reputation(99))])
-            .unwrap();
-        let (t05, p05) = calculate_reppoe_threshold(&rep_engine, &id0, 1, 2000, &active_wips);
-        assert_eq!(t05, Hash::with_first_u32(0x0253_C825));
-        assert_eq!((p05 * 100_f64).round() as i128, 1);
-    }
-
-    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
-    #[allow(clippy::cast_possible_truncation)]
-    #[test]
-    fn reppoe_overflow() {
-        // Test the behavior of the algorithm when our node has 0 reputation
-        let mut rep_engine = ReputationEngine::new(1000);
-        let id0 = PublicKeyHash::from_bytes(&[0; 20]).unwrap();
-        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
-        rep_engine.ars_mut().push_activity(vec![id0]);
-        rep_engine.ars_mut().push_activity(vec![id1]);
-        rep_engine
-            .trs_mut()
-            .gain(Alpha(10), vec![(id0, Reputation(u32::max_value() - 2))])
-            .unwrap();
-
-        // This test is only valid before the third hard fork
-        let active_wips = ActiveWips {
-            active_wips: Default::default(),
-            block_epoch: 0,
-        };
-
-        // Test big values that result in < 100%
-        let (t01, p01) = calculate_reppoe_threshold(&rep_engine, &id0, 1, 2000, &active_wips);
-        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFE));
-        assert_eq!((p01 * 100_f64).round() as i128, 100);
-    }
-
     #[test]
     fn test_counter() {
         let mut counter = Counter::new(7);
@@ -3575,5 +3386,1089 @@ mod tests {
         assert_eq!(a.slot(&h1), 1);
         assert_eq!(a.slot(&h2), 1);
         assert_eq!(a.slot(&h3), 2);
+    }
+}
+
+#[cfg(test)]
+mod reppoe_tests {
+    use super::*;
+    use witnet_data_structures::{
+        chain::{Alpha, Environment},
+        mainnet_validations::TapiEngine,
+    };
+
+    // This should only be used in tests
+    fn all_wips_active() -> ActiveWips {
+        let mut tapi_engine = TapiEngine::default();
+        tapi_engine.initialize_wip_information(Environment::Testnet);
+
+        ActiveWips {
+            active_wips: tapi_engine.wip_activation,
+            block_epoch: u32::MAX,
+        }
+    }
+
+    fn calculate_reppoe_threshold_v1(
+        rep_eng: &ReputationEngine,
+        pkh: &PublicKeyHash,
+        num_witnesses: u16,
+        minimum_difficulty: u32,
+    ) -> (Hash, f64) {
+        let active_wips = ActiveWips {
+            active_wips: HashMap::default(),
+            block_epoch: 0,
+        };
+        assert!(!active_wips.wip0016());
+        assert!(!active_wips.third_hard_fork());
+        calculate_reppoe_threshold(
+            rep_eng,
+            pkh,
+            num_witnesses,
+            minimum_difficulty,
+            &active_wips,
+        )
+    }
+
+    fn calculate_reppoe_threshold_v2(
+        rep_eng: &ReputationEngine,
+        pkh: &PublicKeyHash,
+        num_witnesses: u16,
+        minimum_difficulty: u32,
+    ) -> (Hash, f64) {
+        let mut active_wips = ActiveWips {
+            active_wips: HashMap::default(),
+            block_epoch: 0,
+        };
+        active_wips
+            .active_wips
+            .insert("THIRD_HARD_FORK".to_string(), 0);
+        assert!(!active_wips.wip0016());
+        assert!(active_wips.third_hard_fork());
+        calculate_reppoe_threshold(
+            rep_eng,
+            pkh,
+            num_witnesses,
+            minimum_difficulty,
+            &active_wips,
+        )
+    }
+
+    fn calculate_reppoe_threshold_v3(
+        rep_eng: &ReputationEngine,
+        pkh: &PublicKeyHash,
+        num_witnesses: u16,
+        minimum_difficulty: u32,
+    ) -> (Hash, f64) {
+        let mut active_wips = all_wips_active();
+        active_wips
+            .active_wips
+            .insert("WIP0014-0016".to_string(), 0);
+        assert!(active_wips.wip0016());
+        assert!(active_wips.third_hard_fork());
+        calculate_reppoe_threshold(
+            rep_eng,
+            pkh,
+            num_witnesses,
+            minimum_difficulty,
+            &active_wips,
+        )
+    }
+
+    // Auxiliar function to add reputation
+    fn add_rep(rep_engine: &mut ReputationEngine, alpha: u32, pkh: PublicKeyHash, rep: u32) {
+        rep_engine
+            .trs_mut()
+            .gain(Alpha(alpha), vec![(pkh, Reputation(rep))])
+            .unwrap();
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn target_reppoe_v1() {
+        let mut rep_engine = ReputationEngine::new(1000);
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+        add_rep(&mut rep_engine, 10, id1, 50);
+        rep_engine.ars_mut().push_activity(vec![id1]);
+
+        // 100% when we have all the reputation
+        let (t00, p00) = calculate_reppoe_threshold_v1(&rep_engine, &id1, 1, 2000);
+        assert_eq!(t00, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p00 * 100_f64).round() as i128, 100);
+
+        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
+        add_rep(&mut rep_engine, 10, id2, 50);
+        rep_engine.ars_mut().push_activity(vec![id2]);
+
+        // 50% when there are 2 nodes with 50% of the reputation each
+        let (t01, p01) = calculate_reppoe_threshold_v1(&rep_engine, &id1, 1, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0x7FFF_FFFF));
+        assert_eq!((p01 * 100_f64).round() as i128, 50);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn target_reppoe_v2() {
+        let mut rep_engine = ReputationEngine::new(1000);
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+        add_rep(&mut rep_engine, 10, id1, 50);
+        rep_engine.ars_mut().push_activity(vec![id1]);
+
+        // 0.05% when the total reputation is less than 2000
+        let (t00, p00) = calculate_reppoe_threshold_v2(&rep_engine, &id1, 1, 2000);
+        assert_eq!(t00, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        // 1 / 2000 = 500 / 1_000_000
+        assert_eq!((p00 * 1_000_000_f64).round() as i128, 500);
+
+        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
+        add_rep(&mut rep_engine, 10, id2, 50);
+        rep_engine.ars_mut().push_activity(vec![id2]);
+
+        // 0.05% when the total reputation is less than 2000
+        let (t01, p01) = calculate_reppoe_threshold_v2(&rep_engine, &id1, 1, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        // 1 / 2000 = 500 / 1_000_000
+        assert_eq!((p01 * 1_000_000_f64).round() as i128, 500);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn target_reppoe_v3() {
+        let mut rep_engine = ReputationEngine::new(1000);
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+        add_rep(&mut rep_engine, 10, id1, 50);
+        rep_engine.ars_mut().push_activity(vec![id1]);
+
+        // 0.05% * 51 when the total reputation is less than 2000
+        // 51 is the reputation of this node (50 + 1 because active)
+        let (t00, p00) = calculate_reppoe_threshold_v3(&rep_engine, &id1, 1, 2000);
+        // 0xFFFF_FFFF / 2000 * 51
+        assert_eq!(t00, Hash::with_first_u32(0x06872b02));
+        assert_eq!((p00 * 100_f64).round() as i128, 3);
+
+        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
+        add_rep(&mut rep_engine, 10, id2, 50);
+        rep_engine.ars_mut().push_activity(vec![id2]);
+
+        // 0.05% * 51 when the total reputation is less than 2000
+        // 51 is the reputation of this node (50 + 1 because active)
+        let (t01, p01) = calculate_reppoe_threshold_v3(&rep_engine, &id1, 1, 2000);
+        // 0xFFFF_FFFF / 2000 * 51
+        assert_eq!(t01, Hash::with_first_u32(0x06872b02));
+        assert_eq!((p01 * 100_f64).round() as i128, 3);
+    }
+
+    #[test]
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cognitive_complexity,
+        clippy::cast_sign_loss
+    )]
+    fn target_reppoe_specific_example_v1() {
+        let mut rep_engine = ReputationEngine::new(1000);
+        let mut ids = vec![];
+        for i in 0..8 {
+            ids.push(PublicKeyHash::from_bytes(&[i; 20]).unwrap());
+        }
+        rep_engine.ars_mut().push_activity(ids.clone());
+
+        add_rep(&mut rep_engine, 10, ids[0], 79);
+        add_rep(&mut rep_engine, 10, ids[1], 9);
+        add_rep(&mut rep_engine, 10, ids[2], 1);
+        add_rep(&mut rep_engine, 10, ids[3], 1);
+        add_rep(&mut rep_engine, 10, ids[4], 1);
+        add_rep(&mut rep_engine, 10, ids[5], 1);
+
+        let rep_thresholds = |thres| {
+            let mut v = vec![];
+            for id in ids.iter() {
+                v.push(
+                    (calculate_reppoe_threshold_v1(&rep_engine, id, thres, 2000).1 * 1_000_000_f64)
+                        .round() as u32,
+                );
+            }
+            v
+        };
+
+        assert_eq!(
+            rep_thresholds(1),
+            vec![280_000, 230_000, 190_000, 50_000, 140_000, 90_000, 10_000, 10_000]
+        );
+        assert_eq!(
+            rep_thresholds(2),
+            vec![560_000, 460_000, 380_000, 100_000, 280_000, 180_000, 20_000, 20_000]
+        );
+        assert_eq!(
+            rep_thresholds(3),
+            vec![840_000, 690_000, 570_000, 150_000, 420_000, 270_000, 30_000, 30_000]
+        );
+        assert_eq!(
+            rep_thresholds(4),
+            vec![1_000_000, 1_000_000, 950_000, 250_000, 700_000, 450_000, 50_000, 50_000]
+        );
+        assert_eq!(
+            rep_thresholds(5),
+            vec![1_000_000, 1_000_000, 1_000_000, 350_000, 980_000, 630_000, 70_000, 70_000]
+        );
+        assert_eq!(
+            rep_thresholds(6),
+            vec![1_000_000, 1_000_000, 1_000_000, 750_000, 1_000_000, 1_000_000, 150_000, 150_000]
+        );
+        assert_eq!(
+            rep_thresholds(7),
+            vec![
+                1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 1_000_000, 500_000, 500_000
+            ]
+        );
+        assert_eq!(rep_thresholds(8), vec![1_000_000; 8]);
+        assert_eq!(rep_thresholds(9), vec![1_000_000; 8]);
+        assert_eq!(rep_thresholds(10), vec![1_000_000; 8]);
+    }
+
+    #[test]
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cognitive_complexity,
+        clippy::cast_sign_loss
+    )]
+    fn target_reppoe_specific_example_v2() {
+        let mut rep_engine = ReputationEngine::new(1000);
+        let mut ids = vec![];
+        for i in 0..8 {
+            ids.push(PublicKeyHash::from_bytes(&[i; 20]).unwrap());
+        }
+        rep_engine.ars_mut().push_activity(ids.clone());
+
+        add_rep(&mut rep_engine, 10, ids[0], 79);
+        add_rep(&mut rep_engine, 10, ids[1], 9);
+        add_rep(&mut rep_engine, 10, ids[2], 1);
+        add_rep(&mut rep_engine, 10, ids[3], 1);
+        add_rep(&mut rep_engine, 10, ids[4], 1);
+        add_rep(&mut rep_engine, 10, ids[5], 1);
+
+        let rep_thresholds = |thres| {
+            let mut v = vec![];
+            for id in ids.iter() {
+                v.push(
+                    (calculate_reppoe_threshold_v2(&rep_engine, id, thres, 2000).1 * 1_000_000_f64)
+                        .round() as u32,
+                );
+            }
+            v
+        };
+
+        assert_eq!(rep_thresholds(1), vec![500; 8]);
+        assert_eq!(rep_thresholds(2), vec![1000; 8]);
+        assert_eq!(rep_thresholds(3), vec![1500; 8]);
+        assert_eq!(rep_thresholds(4), vec![2500; 8]);
+        assert_eq!(rep_thresholds(5), vec![3500; 8]);
+        assert_eq!(rep_thresholds(6), vec![7500; 8]);
+        assert_eq!(rep_thresholds(7), vec![25_000; 8]);
+        assert_eq!(rep_thresholds(8), vec![50_000; 8]);
+        assert_eq!(rep_thresholds(9), vec![1_000_000; 8]);
+        assert_eq!(rep_thresholds(10), vec![1_000_000; 8]);
+    }
+
+    #[test]
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cognitive_complexity,
+        clippy::cast_sign_loss
+    )]
+    fn target_reppoe_specific_example_v3() {
+        let mut rep_engine = ReputationEngine::new(1000);
+        let mut ids = vec![];
+        for i in 0..8 {
+            ids.push(PublicKeyHash::from_bytes(&[i; 20]).unwrap());
+        }
+        rep_engine.ars_mut().push_activity(ids.clone());
+
+        add_rep(&mut rep_engine, 10, ids[0], 79);
+        add_rep(&mut rep_engine, 10, ids[1], 9);
+        add_rep(&mut rep_engine, 10, ids[2], 1);
+        add_rep(&mut rep_engine, 10, ids[3], 1);
+        add_rep(&mut rep_engine, 10, ids[4], 1);
+        add_rep(&mut rep_engine, 10, ids[5], 1);
+
+        let rep_thresholds = |thres| {
+            let mut v = vec![];
+            for id in ids.iter() {
+                v.push(
+                    (calculate_reppoe_threshold_v3(&rep_engine, id, thres, 2000).1 * 1_000_000_f64)
+                        .round() as u32,
+                );
+            }
+            v
+        };
+
+        assert_eq!(
+            rep_thresholds(1),
+            vec![14_000, 11_500, 9500, 2500, 7000, 4500, 500, 500]
+        );
+        assert_eq!(
+            rep_thresholds(2),
+            vec![28_000, 23_000, 19_000, 5000, 14_000, 9000, 1000, 1000]
+        );
+        assert_eq!(
+            rep_thresholds(3),
+            vec![42_000, 34_500, 28_500, 7500, 21_000, 13_500, 1500, 1500]
+        );
+        assert_eq!(
+            rep_thresholds(4),
+            vec![56_000, 46_000, 38_000, 10_000, 28_000, 18_000, 2000, 2000]
+        );
+        assert_eq!(
+            rep_thresholds(5),
+            vec![70_000, 57_500, 47_500, 12_500, 35_000, 22_500, 2500, 2500]
+        );
+        assert_eq!(
+            rep_thresholds(6),
+            vec![84_000, 69_000, 57_000, 15_000, 42_000, 27_000, 3000, 3000]
+        );
+        assert_eq!(
+            rep_thresholds(7),
+            vec![98_000, 80_500, 66_500, 17_500, 49_000, 31_500, 3500, 3500]
+        );
+        assert_eq!(
+            rep_thresholds(8),
+            vec![112_000, 92000, 76_000, 20_000, 56_000, 36_000, 4000, 4000]
+        );
+        assert_eq!(
+            rep_thresholds(9),
+            vec![126_000, 103_500, 85_500, 22_500, 63_000, 40_500, 4500, 4500]
+        );
+        assert_eq!(
+            rep_thresholds(10),
+            vec![140_000, 115_000, 95_000, 25_000, 70_000, 45_000, 5000, 5000]
+        );
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn target_reppoe_zero_reputation_v1() {
+        // Test the behavior of the algorithm when our node has 0 reputation
+        let mut rep_engine = ReputationEngine::new(1000);
+        let id0 = PublicKeyHash::from_bytes(&[0; 20]).unwrap();
+
+        // 100% when the total reputation is 0
+        let (t00, p00) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 1, 2000);
+        assert_eq!((p00 * 100_f64).round() as i128, 100);
+        assert_eq!(t00, Hash::with_first_u32(0xFFFF_FFFF));
+        let (t01, p01) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 100, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+        rep_engine.ars_mut().push_activity(vec![id1]);
+        let (t02, p02) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p02 * 100_f64).round() as i128, 100);
+        let (t02b, p02b) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 2, 2000);
+        assert_eq!(t02b, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p02b * 100_f64).round() as i128, 100);
+
+        // 50% when the total reputation is 1
+        add_rep(&mut rep_engine, 10, id1, 1);
+        let (t03, p03) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0x7FFF_FFFF));
+        assert_eq!((p03 * 100_f64).round() as i128, 50);
+        // 100% when the total reputation is 1
+        // but the number of witnesses is greater than the number of active identities
+        let (t03b, p03b) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 2, 2000);
+        assert_eq!(t03b, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p03b * 100_f64).round() as i128, 100);
+
+        // 33% when the total reputation is 1 but there are 2 active identities
+        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
+        rep_engine.ars_mut().push_activity(vec![id2]);
+        let (t04, p04) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t04, Hash::with_first_u32(0x5555_5555));
+        assert_eq!((p04 * 100_f64).round() as i128, 33);
+        // 100% when the total reputation is 1 but there are 2 active identities
+        // but the number of witnesses is greater than the number of active identities
+        let (t04b, p04b) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 2, 2000);
+        assert_eq!(t04b, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p04b * 100_f64).round() as i128, 100);
+        // 100% when the total reputation is 1 but there are 2 active identities
+        // but the number of witnesses is greater than the number of active identities
+        let (t04c, p04c) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 3, 2000);
+        assert_eq!(t04c, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p04c * 100_f64).round() as i128, 100);
+
+        // 10 identities with 100 total reputation: 1 / (100 + 10) ~= 0.9%
+        for i in 3..=10 {
+            rep_engine
+                .ars_mut()
+                .push_activity(vec![PublicKeyHash::from_bytes(&[i; 20]).unwrap()]);
+        }
+        add_rep(&mut rep_engine, 10, id1, 99);
+        let (t05, p05) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t05, Hash::with_first_u32(0x0253_C825));
+        assert_eq!((p05 * 100_f64).round() as i128, 1);
+
+        // 10 identities with 10000 total reputation: 1 / (10000 + 10) ~= 0.01%
+        add_rep(&mut rep_engine, 10, id1, 9900);
+        let (t05b, p05b) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t05b, Hash::with_first_u32(0xFFFF_FFFF / (10_000 + 10)));
+        assert_eq!((p05b * 1_000_000_f64).round() as i128, 100);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn target_reppoe_zero_reputation_v2() {
+        // Test the behavior of the algorithm when our node has 0 reputation
+        let mut rep_engine = ReputationEngine::new(1000);
+        let id0 = PublicKeyHash::from_bytes(&[0; 20]).unwrap();
+
+        // 100% when the total reputation is 0
+        let (t00, p00) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t00, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p00 * 100_f64).round() as i128, 100);
+        let (t01, p01) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 100, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+
+        // 0.05% when the total reputation is 0 but there is 1 active identity
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+        rep_engine.ars_mut().push_activity(vec![id1]);
+        let (t02, p02) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 500);
+        // 100% when the total reputation is 0 and there is 1 active identity,
+        // but the number of witnesses is greater than the number of active identities
+        let (t02b, p02b) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 2, 2000);
+        assert_eq!(t02b, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p02b * 100_f64).round() as i128, 100);
+
+        // 0.05% when the total reputation is 1
+        add_rep(&mut rep_engine, 10, id1, 1);
+        let (t03, p03) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        assert_eq!((p03 * 1_000_000_f64).round() as i128, 500);
+        // 100% when the total reputation is 1
+        // but the number of witnesses is greater than the number of active identities
+        let (t03b, p03b) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 2, 2000);
+        assert_eq!(t03b, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p03b * 100_f64).round() as i128, 100);
+
+        // 0.05% when the total reputation is 1 but there are 2 active identities
+        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
+        rep_engine.ars_mut().push_activity(vec![id2]);
+        let (t04, p04) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t04, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        assert_eq!((p04 * 1_000_000_f64).round() as i128, 500);
+        // 0.15% when the total reputation is 1 but there are 2 active identities
+        // but the number of witnesses is greater than 1
+        let (t04b, p04b) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 2, 2000);
+        // 0xFFFF_FFFF / 2000 * 3
+        assert_eq!(t04b, Hash::with_first_u32(0x00624dd2));
+        assert_eq!((p04b * 1_000_000_f64).round() as i128, 1500);
+        // 100% when the total reputation is 1 but there are 2 active identities
+        // but the number of witnesses is greater than the number of active identities
+        let (t04c, p04c) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 3, 2000);
+        assert_eq!(t04c, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p04c * 100_f64).round() as i128, 100);
+
+        // 10 identities with 100 total reputation: 0.15% (100 is less than the minimum of 2000)
+        for i in 3..=10 {
+            rep_engine
+                .ars_mut()
+                .push_activity(vec![PublicKeyHash::from_bytes(&[i; 20]).unwrap()]);
+        }
+        add_rep(&mut rep_engine, 10, id1, 99);
+        let (t05, p05) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t05, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        assert_eq!((p05 * 1_000_000_f64).round() as i128, 500);
+
+        // 10 identities with 10000 total reputation: 1 / (10000 + 10) ~= 0.01%
+        add_rep(&mut rep_engine, 10, id1, 9900);
+        let (t05b, p05b) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t05b, Hash::with_first_u32(0xFFFF_FFFF / (10_000 + 10)));
+        assert_eq!((p05b * 1_000_000_f64).round() as i128, 100);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn target_reppoe_zero_reputation_v3() {
+        // Test the behavior of the algorithm when our node has 0 reputation
+        let mut rep_engine = ReputationEngine::new(1000);
+        let id0 = PublicKeyHash::from_bytes(&[0; 20]).unwrap();
+
+        // 0.05% when the total reputation is 0
+        let (t00, p00) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t00, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        assert_eq!((p00 * 1_000_000_f64).round() as i128, 500);
+        // 5% when the total reputation is 0 but the number of witnesses is 100
+        let (t01, p01) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 100, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF / (2000 / 100)));
+        assert_eq!((p01 * 100_f64).round() as i128, 5);
+
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+        rep_engine.ars_mut().push_activity(vec![id1]);
+        let (t02, p02) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 500);
+        // 0.10% when the total reputation is 0 and there is 1 active identity,
+        // but the number of witnesses is 2
+        let (t02b, p02b) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 2, 2000);
+        // 0xFFFF_FFFF / 2000 * 2
+        assert_eq!(t02b, Hash::with_first_u32(0x00418937));
+        assert_eq!((p02b * 1_000_000_f64).round() as i128, 1000);
+
+        // 0.05% when the total reputation is 1
+        add_rep(&mut rep_engine, 10, id1, 1);
+        let (t03, p03) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        assert_eq!((p03 * 1_000_000_f64).round() as i128, 500);
+        // 0.10% when the total reputation is 1
+        // but the number of witnesses is greater than the number of active identities
+        let (t03b, p03b) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 2, 2000);
+        // 0xFFFF_FFFF / 2000 * 2 + 1
+        assert_eq!(t03b, Hash::with_first_u32(0x00418937));
+        assert_eq!((p03b * 1_000_000_f64).round() as i128, 1000);
+
+        // When the total reputation is 1 but there are 2 active identities:
+        // 0.05% when the number of witnesses is 1
+        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
+        rep_engine.ars_mut().push_activity(vec![id2]);
+        let (t04, p04) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t04, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        assert_eq!((p04 * 1_000_000_f64).round() as i128, 500);
+        // 0.10% when the number of witnesses is 2
+        let (t04b, p04b) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 2, 2000);
+        // 0xFFFF_FFFF / 2000 * 2
+        assert_eq!(t04b, Hash::with_first_u32(0x00418937));
+        assert_eq!((p04b * 1_000_000_f64).round() as i128, 1000);
+        // 0.15% when the number of witnesses is 3
+        let (t04c, p04c) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 3, 2000);
+        // 0xFFFF_FFFF / 2000 * 3
+        assert_eq!(t04c, Hash::with_first_u32(0x00624dd2));
+        assert_eq!((p04c * 1_000_000_f64).round() as i128, 1500);
+
+        // 10 identities with 100 total reputation: 0.15% (100 is less than the minimum of 2000)
+        for i in 3..=10 {
+            rep_engine
+                .ars_mut()
+                .push_activity(vec![PublicKeyHash::from_bytes(&[i; 20]).unwrap()]);
+        }
+        add_rep(&mut rep_engine, 10, id1, 99);
+        let (t05, p05) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t05, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        assert_eq!((p05 * 1_000_000_f64).round() as i128, 500);
+
+        // 10 identities with 10000 total reputation: 1 / (10000 + 10) ~= 0.01%
+        add_rep(&mut rep_engine, 10, id1, 9900);
+        let (t05b, p05b) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t05b, Hash::with_first_u32(0xFFFF_FFFF / (10_000 + 10)));
+        assert_eq!((p05b * 1_000_000_f64).round() as i128, 100);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn reppoe_overflow_v1() {
+        // Test the behavior of the algorithm when one node has 99% of the reputation
+        let mut rep_engine = ReputationEngine::new(1000);
+        let id0 = PublicKeyHash::from_bytes(&[0; 20]).unwrap();
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
+        rep_engine.ars_mut().push_activity(vec![id0]);
+        rep_engine.ars_mut().push_activity(vec![id1]);
+        add_rep(&mut rep_engine, 10, id0, u32::max_value() - 2);
+
+        // Test big values that result in < 100%
+        // Active identity with 100% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFE));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+        // Active identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v1(&rep_engine, &id1, 1, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x00000001));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 0);
+        // Inactive identity with 0 reputation
+        let (t03, p03) = calculate_reppoe_threshold_v1(&rep_engine, &id2, 1, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0x00000001));
+        assert_eq!((p03 * 1_000_000_f64).round() as i128, 0);
+
+        // Repeat test with 2 witnesses
+        // Active identity with 100% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 2, 2000);
+        // 100% eligibility because the number of witnesses is greater than the number of active identities
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+        // Active identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v1(&rep_engine, &id1, 2, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p02 * 100_f64).round() as i128, 100);
+        // Inactive identity with 0 reputation
+        let (t03, p03) = calculate_reppoe_threshold_v1(&rep_engine, &id2, 2, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p03 * 100_f64).round() as i128, 100);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn reppoe_overflow_v2() {
+        // Test the behavior of the algorithm when one node has 99% of the reputation
+        let mut rep_engine = ReputationEngine::new(1000);
+        let id0 = PublicKeyHash::from_bytes(&[0; 20]).unwrap();
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
+        rep_engine.ars_mut().push_activity(vec![id0]);
+        rep_engine.ars_mut().push_activity(vec![id1]);
+        add_rep(&mut rep_engine, 10, id0, u32::max_value() - 2);
+
+        // Test big values that result in < 100%
+        // Active identity with 100% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        // 1 / 2000 = 500 / 1_000_000
+        assert_eq!((p01 * 1_000_000_f64).round() as i128, 500);
+        // Active identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v2(&rep_engine, &id1, 1, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x00000001));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 0);
+        // Inactive identity with 0 reputation
+        let (t03, p03) = calculate_reppoe_threshold_v2(&rep_engine, &id2, 1, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0x00000001));
+        assert_eq!((p03 * 1_000_000_f64).round() as i128, 0);
+
+        // Repeat test with 2 witnesses
+        // Active identity with 100% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 2, 2000);
+        // 100% eligibility because the number of witnesses is greater than the number of active identities
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+        // Active identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v2(&rep_engine, &id1, 2, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p02 * 100_f64).round() as i128, 100);
+        // Inactive identity with 0 reputation
+        let (t03, p03) = calculate_reppoe_threshold_v2(&rep_engine, &id2, 2, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p03 * 100_f64).round() as i128, 100);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn reppoe_overflow_v3() {
+        // Test the behavior of the algorithm when one node has 99% of the reputation
+        let mut rep_engine = ReputationEngine::new(1000);
+        let id0 = PublicKeyHash::from_bytes(&[0; 20]).unwrap();
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
+        rep_engine.ars_mut().push_activity(vec![id0]);
+        rep_engine.ars_mut().push_activity(vec![id1]);
+        add_rep(&mut rep_engine, 10, id0, u32::max_value() - 2);
+
+        // Test big values that result in < 100%
+        // Active identity with 100% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFE));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+        // Active identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v3(&rep_engine, &id1, 1, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x00000001));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 0);
+        // Inactive identity with 0 reputation
+        let (t03, p03) = calculate_reppoe_threshold_v3(&rep_engine, &id2, 1, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0x00000001));
+        assert_eq!((p03 * 1_000_000_f64).round() as i128, 0);
+
+        // Repeat test with 2 witnesses
+        // Active identity with 100% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 2, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+        // Active identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v3(&rep_engine, &id1, 2, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x00000002));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 0);
+        // Inactive identity with 0 reputation
+        let (t03, p03) = calculate_reppoe_threshold_v3(&rep_engine, &id2, 2, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0x00000002));
+        assert_eq!((p03 * 1_000_000_f64).round() as i128, 0);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn reppoe_much_rep_trapezoid_v1() {
+        // Test the behavior of the algorithm when one node has 99% reputation and another node has 1%
+        let mut rep_engine = ReputationEngine::new(1000);
+        let id0 = PublicKeyHash::from_bytes(&[0; 20]).unwrap();
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
+        rep_engine.ars_mut().push_activity(vec![id0]);
+        rep_engine.ars_mut().push_activity(vec![id1]);
+        add_rep(&mut rep_engine, 10, id0, u32::max_value() - 4);
+        add_rep(&mut rep_engine, 10, id1, 1);
+
+        // Test big values that result in < 100%
+        // Active identity with 99% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xDFFF_FFFE));
+        assert_eq!((p01 * 100_f64).round() as i128, 87);
+        // Active identity with 1 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v1(&rep_engine, &id1, 1, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x20000001));
+        assert_eq!((p02 * 100_f64).round() as i128, 13);
+        // Inactive identity with 0 reputation
+        let (t03, p03) = calculate_reppoe_threshold_v1(&rep_engine, &id2, 1, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0x00000001));
+        assert_eq!((p03 * 1_000_000_f64).round() as i128, 0);
+
+        // Repeat test with 2 witnesses
+        // Active identity with 99% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v1(&rep_engine, &id0, 2, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+        // Active identity with 1 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v1(&rep_engine, &id1, 2, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p02 * 100_f64).round() as i128, 100);
+        // Inactive identity with 0 reputation
+        let (t03, p03) = calculate_reppoe_threshold_v1(&rep_engine, &id2, 2, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0x00000008));
+        assert_eq!((p03 * 1_000_000_f64).round() as i128, 0);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn reppoe_much_rep_trapezoid_v2() {
+        // Test the behavior of the algorithm when one node has 99% reputation and another node has 1%
+        let mut rep_engine = ReputationEngine::new(1000);
+        let id0 = PublicKeyHash::from_bytes(&[0; 20]).unwrap();
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
+        rep_engine.ars_mut().push_activity(vec![id0]);
+        rep_engine.ars_mut().push_activity(vec![id1]);
+        add_rep(&mut rep_engine, 10, id0, u32::max_value() - 4);
+        add_rep(&mut rep_engine, 10, id1, 1);
+
+        // Test big values that result in < 100%
+        // Active identity with 99% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        // 1 / 2000 = 500 / 1_000_000
+        assert_eq!((p01 * 1_000_000_f64).round() as i128, 500);
+        // Active identity with 1 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v2(&rep_engine, &id1, 1, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0xFFFF_FFFF / 2000));
+        // 1 / 2000 = 500 / 1_000_000
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 500);
+        // Inactive identity with 0 reputation
+        let (t03, p03) = calculate_reppoe_threshold_v2(&rep_engine, &id2, 1, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0x00000001));
+        assert_eq!((p03 * 1_000_000_f64).round() as i128, 0);
+
+        // Repeat test with 2 witnesses
+        // Active identity with 99% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v2(&rep_engine, &id0, 2, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0x010624dd));
+        // 8 / 2000 = 4_000 / 1_000_000
+        assert_eq!((p01 * 1_000_000_f64).round() as i128, 4_000);
+        // Active identity with 1 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v2(&rep_engine, &id1, 2, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x010624dd));
+        // 8 / 2000 = 4_000 / 1_000_000
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 4_000);
+        // Inactive identity with 0 reputation
+        let (t03, p03) = calculate_reppoe_threshold_v2(&rep_engine, &id2, 2, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0x00000008));
+        assert_eq!((p03 * 1_000_000_f64).round() as i128, 0);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn reppoe_much_rep_trapezoid_v3() {
+        // Test the behavior of the algorithm when one node has 99% reputation and another node has 1%
+        let mut rep_engine = ReputationEngine::new(1000);
+        let id0 = PublicKeyHash::from_bytes(&[0; 20]).unwrap();
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+        let id2 = PublicKeyHash::from_bytes(&[2; 20]).unwrap();
+        rep_engine.ars_mut().push_activity(vec![id0]);
+        rep_engine.ars_mut().push_activity(vec![id1]);
+        add_rep(&mut rep_engine, 10, id0, u32::max_value() - 4);
+        add_rep(&mut rep_engine, 10, id1, 1);
+
+        // Test big values that result in < 100%
+        // Active identity with 99% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 1, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xDFFF_FFFE));
+        assert_eq!((p01 * 100_f64).round() as i128, 87);
+        // Active identity with 1 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v3(&rep_engine, &id1, 1, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x20000001));
+        assert_eq!((p02 * 100_f64).round() as i128, 13);
+        // Inactive identity with 0 reputation
+        let (t03, p03) = calculate_reppoe_threshold_v3(&rep_engine, &id2, 1, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0x00000001));
+        assert_eq!((p03 * 1_000_000_f64).round() as i128, 0);
+
+        // Repeat test with 2 witnesses
+        // Active identity with 99% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v3(&rep_engine, &id0, 2, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+        // Active identity with 1 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v3(&rep_engine, &id1, 2, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x40000002));
+        assert_eq!((p02 * 100_f64).round() as i128, 25);
+        // Inactive identity with 0 reputation
+        let (t03, p03) = calculate_reppoe_threshold_v3(&rep_engine, &id2, 2, 2000);
+        assert_eq!(t03, Hash::with_first_u32(0x00000002));
+        assert_eq!((p03 * 1_000_000_f64).round() as i128, 0);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn reppoe_100_reputed_nodes_v1() {
+        // Test the behavior of the algorithm when 100 nodes have equally large reputation
+        let mut rep_engine = ReputationEngine::new(1000);
+        let gen_id = |i| PublicKeyHash::from_bytes(&[i; 20]).unwrap();
+        let id_rep = gen_id(0);
+        let id_no_active = gen_id(255);
+        rep_engine.ars_mut().push_activity((0..100).map(gen_id));
+        rep_engine
+            .trs_mut()
+            .gain(
+                Alpha(10),
+                (0..100).map(|i| {
+                    let id = gen_id(i);
+                    (id, Reputation(10_000))
+                }),
+            )
+            .unwrap();
+
+        // Active identity with 1% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v1(&rep_engine, &id_rep, 1, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0x028f5c28));
+        assert_eq!((p01 * 1_000_000_f64).round() as i128, 10_000);
+        // Inactive identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v1(&rep_engine, &id_no_active, 1, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x000010c6));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 1);
+
+        // Repeat test with 2 witnesses
+        // Active identity with 1% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v1(&rep_engine, &id_rep, 2, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0x051eb851));
+        assert_eq!((p01 * 1_000_000_f64).round() as i128, 20_000);
+        // Inactive identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v1(&rep_engine, &id_no_active, 2, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x0000218d));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 2);
+
+        // Repeat test with 100 witnesses
+        // Active identity with 1% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v1(&rep_engine, &id_rep, 100, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+        // Inactive identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v1(&rep_engine, &id_no_active, 100, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x00068d8d));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 100);
+
+        // Repeat test with 101 witnesses
+        // Active identity with 1% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v1(&rep_engine, &id_rep, 101, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+        // Inactive identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v1(&rep_engine, &id_no_active, 101, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p02 * 100_f64).round() as i128, 100);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn reppoe_100_reputed_nodes_v2() {
+        // Test the behavior of the algorithm when 100 nodes have equally large reputation
+        let mut rep_engine = ReputationEngine::new(1000);
+        let gen_id = |i| PublicKeyHash::from_bytes(&[i; 20]).unwrap();
+        let id_rep = gen_id(0);
+        let id_no_active = gen_id(255);
+        rep_engine.ars_mut().push_activity((0..100).map(gen_id));
+        rep_engine
+            .trs_mut()
+            .gain(
+                Alpha(10),
+                (0..100).map(|i| {
+                    let id = gen_id(i);
+                    (id, Reputation(10_000))
+                }),
+            )
+            .unwrap();
+
+        // Active identity with 1% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v2(&rep_engine, &id_rep, 1, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0x0020c49b));
+        assert_eq!((p01 * 1_000_000_f64).round() as i128, 500);
+        // Inactive identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v2(&rep_engine, &id_no_active, 1, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x000010c6));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 1);
+
+        // Repeat test with 2 witnesses
+        // Active identity with 1% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v2(&rep_engine, &id_rep, 2, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0x00418937));
+        assert_eq!((p01 * 1_000_000_f64).round() as i128, 1000);
+        // Inactive identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v2(&rep_engine, &id_no_active, 2, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x0000218d));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 2);
+
+        // Repeat test with 100 witnesses
+        // Active identity with 1% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v2(&rep_engine, &id_rep, 100, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0x0ccccccc));
+        assert_eq!((p01 * 1_000_000_f64).round() as i128, 50000);
+        // Inactive identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v2(&rep_engine, &id_no_active, 100, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x00068d8d));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 100);
+
+        // Repeat test with 101 witnesses
+        // Active identity with 1% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v2(&rep_engine, &id_rep, 101, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xffffffff));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+        // Inactive identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v2(&rep_engine, &id_no_active, 101, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0xffffffff));
+        assert_eq!((p02 * 100_f64).round() as i128, 100);
+    }
+
+    // FIXME: Allow for now, wait for https://github.com/rust-lang/rust/issues/67058 to reach stable
+    #[allow(clippy::cast_possible_truncation)]
+    #[test]
+    fn reppoe_100_reputed_nodes_v3() {
+        // Test the behavior of the algorithm when 100 nodes have equally large reputation
+        let mut rep_engine = ReputationEngine::new(1000);
+        let gen_id = |i| PublicKeyHash::from_bytes(&[i; 20]).unwrap();
+        let id_rep = gen_id(0);
+        let id_no_active = gen_id(255);
+        rep_engine.ars_mut().push_activity((0..100).map(gen_id));
+        rep_engine
+            .trs_mut()
+            .gain(
+                Alpha(10),
+                (0..100).map(|i| {
+                    let id = gen_id(i);
+                    (id, Reputation(10_000))
+                }),
+            )
+            .unwrap();
+
+        // Active identity with 1% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v3(&rep_engine, &id_rep, 1, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0x028f5c28));
+        assert_eq!((p01 * 1_000_000_f64).round() as i128, 10_000);
+        // Inactive identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v3(&rep_engine, &id_no_active, 1, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x000010c6));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 1);
+
+        // Repeat test with 2 witnesses
+        // Active identity with 1% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v3(&rep_engine, &id_rep, 2, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0x051eb851));
+        assert_eq!((p01 * 1_000_000_f64).round() as i128, 20_000);
+        // Inactive identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v3(&rep_engine, &id_no_active, 2, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x0000218d));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 2);
+
+        // Repeat test with 100 witnesses
+        // Active identity with 1% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v3(&rep_engine, &id_rep, 100, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+        // Inactive identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v3(&rep_engine, &id_no_active, 100, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x00068d8d));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 100);
+
+        // Repeat test with 100 witnesses
+        // Active identity with 1% of the reputation
+        let (t01, p01) = calculate_reppoe_threshold_v3(&rep_engine, &id_rep, 101, 2000);
+        assert_eq!(t01, Hash::with_first_u32(0xFFFF_FFFF));
+        assert_eq!((p01 * 100_f64).round() as i128, 100);
+        // Inactive identity with 0 reputation
+        let (t02, p02) = calculate_reppoe_threshold_v3(&rep_engine, &id_no_active, 101, 2000);
+        assert_eq!(t02, Hash::with_first_u32(0x00069e54));
+        assert_eq!((p02 * 1_000_000_f64).round() as i128, 101);
+    }
+
+    #[test]
+    // FIXME: Allow for now, since there is no safe cast function from a usize to float yet
+    #[allow(clippy::cast_possible_truncation)]
+    fn reppoe_worst_case() {
+        // Check the worst case reppoe probability in mainnet with an empty ARS, a data request with
+        // the maximum number of witnesses, and taking into account the extra commit rounds.
+
+        fn max_num_witnesses_for_dr_weigth(max_dr_weight: u32) -> u16 {
+            let mut dr = DRTransaction::default();
+            let mut num_witnesses = 1;
+
+            while dr.weight() < max_dr_weight {
+                dr.body.dr_output.witnesses = num_witnesses;
+                num_witnesses += 1;
+            }
+
+            num_witnesses - 1
+        }
+
+        // TODO: copied from chain.rs, make public instead?
+        fn calculate_backup_witnesses(witnesses: u16, commit_round: u16) -> u16 {
+            let exponent = u32::from(commit_round).saturating_sub(1);
+            let coefficient = 2_u16.saturating_pow(exponent);
+
+            witnesses.saturating_mul(coefficient) / 2
+        }
+
+        let consensus_constants = witnet_config::config::consensus_constants_from_partial(
+            &witnet_data_structures::chain::PartialConsensusConstants::default(),
+            &witnet_config::defaults::Mainnet,
+        );
+        let max_dr_weight = consensus_constants.max_dr_weight;
+        // Need to use extra_rounds + 1 because this variable represents the additional rounds
+        let max_commit_rounds = consensus_constants.extra_rounds + 1;
+        let minimum_difficulty = consensus_constants.minimum_difficulty;
+
+        let max_witnesses = max_num_witnesses_for_dr_weigth(max_dr_weight);
+        let max_backup_witnesses = calculate_backup_witnesses(max_witnesses, max_commit_rounds);
+
+        assert_eq!(max_witnesses, 126);
+        assert_eq!(max_witnesses + max_backup_witnesses, 630);
+
+        // Empty ARS
+        let rep_engine = ReputationEngine::new(1000);
+        let id1 = PublicKeyHash::from_bytes(&[1; 20]).unwrap();
+
+        let (_t00, p00) = calculate_reppoe_threshold_v3(
+            &rep_engine,
+            &id1,
+            max_witnesses + max_backup_witnesses,
+            minimum_difficulty,
+        );
+
+        assert_eq!((p00 * 100_f64).round() as i128, 32);
     }
 }


### PR DESCRIPTION
Implement https://github.com/witnet/WIPs/pull/58

This branch is based on the tapi2 branch, however the automated WIP activation is not handled in this PR (`active_wips.wip0016()` will always return false).

Close #1960