### PR TITLE
chore: fix clippy warnings for rust 1.53

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -924,7 +924,6 @@ impl Wallet {
                 .unwrap_or_else(|| defaults.wallet_id_hash_function()),
             sync_address_batch_length: config
                 .sync_address_batch_length
-                .clone()
                 .unwrap_or_else(|| defaults.wallet_sync_address_batch_length()),
         }
     }
@@ -1254,7 +1253,7 @@ mod tests {
         assert_eq!(config.consensus_c, 51);
         assert_eq!(config.bucketing_ice_period, Duration::from_secs(13200));
         assert_eq!(config.bucketing_update_period, 200);
-        assert_eq!(config.reject_sybil_inbounds, true);
+        assert!(config.reject_sybil_inbounds);
         assert_eq!(config.reject_sybil_inbounds_range_limit, 14);
         assert_eq!(config.requested_blocks_batch_limit, 99);
     }

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -1209,7 +1209,7 @@ impl PublicKeyHash {
     }
 
     /// Serialize the PKH as hex bytes
-    pub fn to_hex(&self) -> String {
+    pub fn to_hex(self) -> String {
         self.hash
             .iter()
             .fold(String::new(), |acc, x| format!("{}{:02x}", acc, x))
@@ -5826,7 +5826,7 @@ mod tests {
             public_key: bls_pk.public_key[1..63].to_vec(),
             uncompressed: Default::default(),
         };
-        assert_eq!(bls_pk_2.is_valid(), false);
+        assert!(!bls_pk_2.is_valid());
     }
 
     #[test]
@@ -5835,7 +5835,7 @@ mod tests {
             public_key: vec![1; 65],
             uncompressed: Default::default(),
         };
-        assert_eq!(bls_pk.is_valid(), false);
+        assert!(!bls_pk.is_valid());
     }
 
     #[test]

--- a/data_structures/src/data_request.rs
+++ b/data_structures/src/data_request.rs
@@ -347,7 +347,7 @@ impl DataRequestPool {
 
     /// Get the data request info of the finished data requests, to be persisted to the storage
     pub fn finished_data_requests(&mut self) -> Vec<DataRequestInfo> {
-        std::mem::replace(&mut self.to_be_stored, vec![])
+        std::mem::take(&mut self.to_be_stored)
     }
 }
 

--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -2514,15 +2514,15 @@ mod tests {
 
     #[test]
     fn test_two_thirds_consensus() {
-        assert_eq!(two_thirds_consensus(2, 3), false);
-        assert_eq!(two_thirds_consensus(3, 3), true);
-        assert_eq!(two_thirds_consensus(2, 4), false);
-        assert_eq!(two_thirds_consensus(3, 4), true);
-        assert_eq!(two_thirds_consensus(21, 32), false);
-        assert_eq!(two_thirds_consensus(22, 32), true);
-        assert_eq!(two_thirds_consensus(22, 33), false);
-        assert_eq!(two_thirds_consensus(23, 33), true);
-        assert_eq!(two_thirds_consensus(22, 34), false);
-        assert_eq!(two_thirds_consensus(23, 34), true);
+        assert!(!two_thirds_consensus(2, 3));
+        assert!(two_thirds_consensus(3, 3));
+        assert!(!two_thirds_consensus(2, 4));
+        assert!(two_thirds_consensus(3, 4));
+        assert!(!two_thirds_consensus(21, 32));
+        assert!(two_thirds_consensus(22, 32));
+        assert!(!two_thirds_consensus(22, 33));
+        assert!(two_thirds_consensus(23, 33));
+        assert!(!two_thirds_consensus(22, 34));
+        assert!(two_thirds_consensus(23, 34));
     }
 }

--- a/data_structures/src/transaction_factory.rs
+++ b/data_structures/src/transaction_factory.rs
@@ -937,18 +937,15 @@ mod tests {
             }
         );
 
-        assert_eq!(
-            build_vtt_tx_with_timestamp(
-                vec![pay_bob(100)],
-                0,
-                &mut own_utxos,
-                own_pkh,
-                &all_utxos,
-                1_000_001
-            )
-            .is_ok(),
-            true
-        );
+        assert!(build_vtt_tx_with_timestamp(
+            vec![pay_bob(100)],
+            0,
+            &mut own_utxos,
+            own_pkh,
+            &all_utxos,
+            1_000_001
+        )
+        .is_ok());
     }
 
     #[test]

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -1293,7 +1293,7 @@ mod tests {
         assert_eq!(block.txns.len(), 2);
 
         // Check that exist Mint Transaction
-        assert_eq!(block.txns.mint.is_empty(), false);
+        assert!(!block.txns.mint.is_empty());
 
         // Check that the included transaction is the only one that fits the `max_block_weight`
         assert_eq!(block.txns.value_transfer_txns[0], vt_tx1);
@@ -1387,7 +1387,7 @@ mod tests {
         assert_eq!(block.txns.len(), 2);
 
         // Check that exist Mint Transaction
-        assert_eq!(block.txns.mint.is_empty(), false);
+        assert!(!block.txns.mint.is_empty());
 
         // Check that the included transaction is the only one that fits the `max_block_weight`
         assert_eq!(block.txns.value_transfer_txns[0], vt_tx2);
@@ -1476,7 +1476,7 @@ mod tests {
         assert_eq!(block.txns.len(), 2);
 
         // Check that exist Mint Transaction
-        assert_eq!(block.txns.mint.is_empty(), false);
+        assert!(!block.txns.mint.is_empty());
 
         // Check that the included transaction is the only one that fits the `max_block_weight`
         assert_eq!(block.txns.data_request_txns[0], dr_tx1);
@@ -1567,7 +1567,7 @@ mod tests {
         assert_eq!(block.txns.len(), 2);
 
         // Check that exist Mint Transaction
-        assert_eq!(block.txns.mint.is_empty(), false);
+        assert!(!block.txns.mint.is_empty());
 
         // Check that the included transaction is the only one that fits the `max_block_weight`
         assert_eq!(block.txns.data_request_txns[0], dr_tx2);

--- a/node/src/actors/sessions_manager/beacons.rs
+++ b/node/src/actors/sessions_manager/beacons.rs
@@ -127,7 +127,7 @@ mod tests {
         let va = beacon(0);
 
         let mut b = Beacons::default();
-        assert_eq!(b.already_sent(), false);
+        assert!(!b.already_sent());
         // Since we are waiting for 0 beacons
         assert_eq!(b.total_count(), 0);
         // Before calling clear for the first time, insert always accepts new beacons
@@ -138,14 +138,14 @@ mod tests {
         let (pb, pnb) = b.send().unwrap();
         assert_eq!(pb.len(), 2);
         assert!(pnb.is_empty());
-        assert_eq!(b.already_sent(), true);
+        assert!(b.already_sent());
 
         // Wait for two beacons
         b.clear([k0, k1].iter().cloned());
         assert_eq!(b.total_count(), 0);
         // The already_sent flag is cleared on new epoch
         b.new_epoch();
-        assert_eq!(b.already_sent(), false);
+        assert!(!b.already_sent());
         assert_eq!(b.total_count(), 0);
         // Try to send before receiving any beacons
         let (pb, pnb) = b.send().unwrap();
@@ -166,7 +166,7 @@ mod tests {
         assert_eq!(b.total_count(), 0);
         // The already_sent flag is cleared on new epoch
         b.new_epoch();
-        assert_eq!(b.already_sent(), false);
+        assert!(!b.already_sent());
         assert_eq!(b.total_count(), 0);
         b.insert(k0, va.clone());
         assert_eq!(b.total_count(), 1);
@@ -181,7 +181,7 @@ mod tests {
         let (pb, pnb) = b.send().unwrap();
         assert_eq!(pb_to_sorted_vec(pb), vec![(k0, vb.clone()), (k1, vb)]);
         assert!(pnb.is_empty());
-        assert_eq!(b.already_sent(), true);
+        assert!(b.already_sent());
     }
 
     #[test]
@@ -197,7 +197,7 @@ mod tests {
         assert_eq!(b.total_count(), 0);
         // The already_sent flag is cleared on new epoch
         b.new_epoch();
-        assert_eq!(b.already_sent(), false);
+        assert!(!b.already_sent());
         assert_eq!(b.total_count(), 0);
         b.insert(k0, va.clone());
         assert_eq!(b.total_count(), 1);
@@ -212,7 +212,7 @@ mod tests {
         let (pb, pnb) = b.send().unwrap();
         assert_eq!(pb_to_sorted_vec(pb), vec![(k0, vb.clone()), (k1, vb)]);
         assert!(pnb.is_empty());
-        assert_eq!(b.already_sent(), true);
+        assert!(b.already_sent());
     }
 
     #[test]
@@ -229,7 +229,7 @@ mod tests {
         assert_eq!(b.total_count(), 1);
         // The already_sent flag is cleared on new epoch
         b.new_epoch();
-        assert_eq!(b.already_sent(), false);
+        assert!(!b.already_sent());
         // But the beacons are only cleared when calling .clear()
         assert_eq!(b.total_count(), 1);
         b.insert(k1, va.clone());
@@ -238,7 +238,7 @@ mod tests {
         let (pb, pnb) = b.send().unwrap();
         assert_eq!(pb_to_sorted_vec(pb), vec![(k0, va.clone()), (k1, va)]);
         assert!(pnb.is_empty());
-        assert_eq!(b.already_sent(), true);
+        assert!(b.already_sent());
     }
 
     #[test]
@@ -253,7 +253,7 @@ mod tests {
         assert_eq!(b.total_count(), 0);
         // The already_sent flag is cleared on new epoch
         b.new_epoch();
-        assert_eq!(b.already_sent(), false);
+        assert!(!b.already_sent());
         assert_eq!(b.total_count(), 0);
         b.insert(k0, va.clone());
         assert_eq!(b.total_count(), 1);
@@ -261,7 +261,7 @@ mod tests {
         let (pb, pnb) = b.send().unwrap();
         assert_eq!(pb_to_sorted_vec(pb), vec![(k0, va.clone())]);
         assert_eq!(pnb_to_sorted_vec(pnb), vec![k1]);
-        assert_eq!(b.already_sent(), true);
+        assert!(b.already_sent());
 
         b.insert(k1, va);
         assert_eq!(b.total_count(), 2);
@@ -281,7 +281,7 @@ mod tests {
         assert_eq!(b.total_count(), 0);
         // The already_sent flag is cleared on new epoch
         b.new_epoch();
-        assert_eq!(b.already_sent(), false);
+        assert!(!b.already_sent());
         assert_eq!(b.total_count(), 0);
         b.insert(k0, va.clone());
         assert_eq!(b.total_count(), 1);
@@ -298,7 +298,7 @@ mod tests {
         assert_eq!(pb_to_sorted_vec(pb), vec![(k1, va)]);
         // The first peer is not marked as "out of consensus" because it has already disconnected
         assert_eq!(pnb_to_sorted_vec(pnb), vec![]);
-        assert_eq!(b.already_sent(), true);
+        assert!(b.already_sent());
     }
 
     #[test]
@@ -313,7 +313,7 @@ mod tests {
         assert_eq!(b.total_count(), 0);
         // The already_sent flag is cleared on new epoch
         b.new_epoch();
-        assert_eq!(b.already_sent(), false);
+        assert!(!b.already_sent());
         assert_eq!(b.total_count(), 0);
         b.insert(k0, va.clone());
         assert_eq!(b.total_count(), 1);
@@ -326,6 +326,6 @@ mod tests {
         assert_eq!(pb_to_sorted_vec(pb), vec![(k0, va)]);
         // The second peer is marked as "out of consensus" because it has not sent any beacon
         assert_eq!(pnb_to_sorted_vec(pnb), vec![k1]);
-        assert_eq!(b.already_sent(), true);
+        assert!(b.already_sent());
     }
 }

--- a/partial_struct/tests/partial_struct_derive.rs
+++ b/partial_struct/tests/partial_struct_derive.rs
@@ -61,7 +61,7 @@ fn test_partial_attr_skip() {
     let p = PartialObj::default();
 
     assert_eq!(p.a, None);
-    assert_eq!(p.b, false);
+    assert!(!p.b);
 }
 
 #[test]

--- a/reputation/src/ars.rs
+++ b/reputation/src/ars.rs
@@ -183,10 +183,10 @@ mod tests {
     fn insert_id() {
         let mut ars = ActiveReputationSet::new(2);
         let id1 = "Alice".to_string();
-        assert_eq!(ars.contains(&id1), false);
+        assert!(!ars.contains(&id1));
 
         ars.push_activity(vec![id1.clone()]);
-        assert_eq!(ars.contains(&id1), true);
+        assert!(ars.contains(&id1));
         assert_eq!(ars.map[&id1], 1);
         assert_eq!(ars.active_identities_number(), 1);
     }
@@ -195,10 +195,10 @@ mod tests {
     fn insert_id_twice_in_same_time() {
         let mut ars = ActiveReputationSet::new(2);
         let id1 = "Alice".to_string();
-        assert_eq!(ars.contains(&id1), false);
+        assert!(!ars.contains(&id1));
 
         ars.push_activity(vec![id1.clone(), id1.clone()]);
-        assert_eq!(ars.contains(&id1), true);
+        assert!(ars.contains(&id1));
         assert_eq!(ars.map[&id1], 1);
         assert_eq!(ars.active_identities_number(), 1);
     }
@@ -207,15 +207,15 @@ mod tests {
     fn insert_id_twice() {
         let mut ars = ActiveReputationSet::new(2);
         let id1 = "Alice".to_string();
-        assert_eq!(ars.contains(&id1), false);
+        assert!(!ars.contains(&id1));
 
         ars.push_activity(vec![id1.clone()]);
-        assert_eq!(ars.contains(&id1), true);
+        assert!(ars.contains(&id1));
         assert_eq!(ars.map[&id1], 1);
         assert_eq!(ars.active_identities_number(), 1);
 
         ars.push_activity(vec![id1.clone()]);
-        assert_eq!(ars.contains(&id1), true);
+        assert!(ars.contains(&id1));
         assert_eq!(ars.map[&id1], 2);
         assert_eq!(ars.active_identities_number(), 1);
     }
@@ -226,28 +226,28 @@ mod tests {
         let id1 = "Alice".to_string();
         let id2 = "Bob".to_string();
         let id3 = "Charlie".to_string();
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(!ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
 
         ars.push_activity(vec![id1.clone()]);
-        assert_eq!(ars.contains(&id1), true);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.map[&id1], 1);
         assert_eq!(ars.active_identities_number(), 1);
 
         ars.push_activity(vec![id2.clone()]);
-        assert_eq!(ars.contains(&id1), true);
-        assert_eq!(ars.contains(&id2), true);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(ars.contains(&id1));
+        assert!(ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.map[&id2], 1);
         assert_eq!(ars.active_identities_number(), 2);
 
         ars.push_activity(vec![id3.clone()]);
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), true);
-        assert_eq!(ars.contains(&id3), true);
+        assert!(!ars.contains(&id1));
+        assert!(ars.contains(&id2));
+        assert!(ars.contains(&id3));
         assert_eq!(ars.map[&id3], 1);
         assert_eq!(ars.active_identities_number(), 2);
     }
@@ -258,37 +258,37 @@ mod tests {
         let id1 = "Alice".to_string();
         let id2 = "Bob".to_string();
         let id3 = "Charlie".to_string();
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(!ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 0);
         assert_eq!(ars.active_identities_number(), 0);
 
         let _res = ars.update(vec![id1.clone()], 1);
-        assert_eq!(ars.contains(&id1), true);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 1);
         assert_eq!(ars.active_identities_number(), 1);
 
         let _res = ars.update(vec![id2.clone()], 2);
-        assert_eq!(ars.contains(&id1), true);
-        assert_eq!(ars.contains(&id2), true);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(ars.contains(&id1));
+        assert!(ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 2);
         assert_eq!(ars.active_identities_number(), 2);
 
         let _res = ars.update(vec![id2.clone()], 3);
-        assert_eq!(ars.contains(&id1), true);
-        assert_eq!(ars.contains(&id2), true);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(ars.contains(&id1));
+        assert!(ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 3);
         assert_eq!(ars.active_identities_number(), 2);
 
         let _res = ars.update(vec![id3.clone()], 4);
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), true);
-        assert_eq!(ars.contains(&id3), true);
+        assert!(!ars.contains(&id1));
+        assert!(ars.contains(&id2));
+        assert!(ars.contains(&id3));
         assert_eq!(ars.last_update, 4);
         assert_eq!(ars.active_identities_number(), 2);
     }
@@ -299,37 +299,37 @@ mod tests {
         let id1 = "Alice".to_string();
         let id2 = "Bob".to_string();
         let id3 = "Charlie".to_string();
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(!ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 0);
         assert_eq!(ars.active_identities_number(), 0);
 
         let _res = ars.update(vec![id1.clone()], 1);
-        assert_eq!(ars.contains(&id1), true);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 1);
         assert_eq!(ars.active_identities_number(), 1);
 
         let _res = ars.update(vec![id2.clone()], 2);
-        assert_eq!(ars.contains(&id1), true);
-        assert_eq!(ars.contains(&id2), true);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(ars.contains(&id1));
+        assert!(ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 2);
         assert_eq!(ars.active_identities_number(), 2);
 
         let _res = ars.update(vec![id3.clone()], 10);
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), true);
+        assert!(!ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(ars.contains(&id3));
         assert_eq!(ars.last_update, 10);
         assert_eq!(ars.active_identities_number(), 1);
 
         let _res = ars.update(vec![id3.clone()], 20);
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), true);
+        assert!(!ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(ars.contains(&id3));
         assert_eq!(ars.last_update, 20);
         assert_eq!(ars.active_identities_number(), 1);
     }
@@ -340,23 +340,23 @@ mod tests {
         let id1 = "Alice".to_string();
         let id2 = "Bob".to_string();
         let id3 = "Charlie".to_string();
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(!ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 0);
         assert_eq!(ars.active_identities_number(), 0);
 
         let _res = ars.update(vec![id1.clone()], 1);
-        assert_eq!(ars.contains(&id1), true);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 1);
         assert_eq!(ars.active_identities_number(), 1);
 
         let _res = ars.update(vec![id2.clone()], 10);
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), true);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(!ars.contains(&id1));
+        assert!(ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 10);
         assert_eq!(ars.active_identities_number(), 1);
 
@@ -364,9 +364,9 @@ mod tests {
         let _res = ars.update(vec![id3.clone()], 12);
         assert_eq!(ars.active_identities_number(), 2);
         let _res = ars.update(vec![id3.clone()], 13);
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), true);
+        assert!(!ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(ars.contains(&id3));
         assert_eq!(ars.last_update, 13);
         assert_eq!(ars.active_identities_number(), 1);
     }
@@ -377,16 +377,16 @@ mod tests {
         let id1 = "Alice".to_string();
         let id2 = "Bob".to_string();
         let id3 = "Charlie".to_string();
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(!ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 0);
         assert_eq!(ars.active_identities_number(), 0);
 
         let _res = ars.update(vec![id1.clone()], 10);
-        assert_eq!(ars.contains(&id1), true);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 10);
         assert_eq!(ars.active_identities_number(), 1);
 
@@ -423,32 +423,32 @@ mod tests {
         let id1 = "Alice".to_string();
         let id2 = "Bob".to_string();
         let id3 = "Charlie".to_string();
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(!ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 0);
         assert_eq!(ars.active_identities_number(), 0);
 
         let _res = ars.update(vec![id1.clone()], 10);
-        assert_eq!(ars.contains(&id1), true);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 10);
         assert_eq!(ars.active_identities_number(), 1);
 
         let _res = ars.update(vec![id2.clone()], 11);
-        assert_eq!(ars.contains(&id1), true);
-        assert_eq!(ars.contains(&id2), true);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(ars.contains(&id1));
+        assert!(ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 11);
         assert_eq!(ars.active_identities_number(), 2);
 
         let _res = ars.update(vec![id2.clone()], 21);
         let _res = ars.update(vec![id2.clone()], 23);
         let _res = ars.update(vec![id2.clone()], 24);
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), true);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(!ars.contains(&id1));
+        assert!(ars.contains(&id2));
+        assert!(!ars.contains(&id3));
         assert_eq!(ars.last_update, 24);
         assert_eq!(ars.active_identities_number(), 1);
     }

--- a/reputation/src/trs.rs
+++ b/reputation/src/trs.rs
@@ -913,9 +913,9 @@ mod tests {
         ];
         assert_eq!(trs.get_total_sum(), Reputation(0));
         assert_eq!(trs.num_identities(), 0);
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), false);
+        assert!(!ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(!ars.contains(&id3));
 
         trs.gain(Alpha(4), v4).unwrap();
         assert_eq!(trs.get_total_sum(), Reputation(4096));
@@ -924,25 +924,25 @@ mod tests {
         assert_eq!(trs.num_identities(), 3);
 
         ars.push_activity(vec![id1.clone(), id2.clone(), id3.clone()]);
-        assert_eq!(ars.contains(&id1), true);
-        assert_eq!(ars.contains(&id2), true);
-        assert_eq!(ars.contains(&id3), true);
+        assert!(ars.contains(&id1));
+        assert!(ars.contains(&id2));
+        assert!(ars.contains(&id3));
         assert_eq!(ars.active_identities_number(), 3);
         assert_eq!(trs.get_sum(ars.active_identities()), Reputation(4096));
 
         ars.push_activity(vec![id2.clone(), id3.clone()]);
         ars.push_activity(vec![id2.clone(), id3.clone()]);
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), true);
-        assert_eq!(ars.contains(&id3), true);
+        assert!(!ars.contains(&id1));
+        assert!(ars.contains(&id2));
+        assert!(ars.contains(&id3));
         assert_eq!(ars.active_identities_number(), 2);
         assert_eq!(trs.get_sum(ars.active_identities()), Reputation(3072));
 
         ars.push_activity(vec![id3.clone()]);
         ars.push_activity(vec![id3.clone()]);
-        assert_eq!(ars.contains(&id1), false);
-        assert_eq!(ars.contains(&id2), false);
-        assert_eq!(ars.contains(&id3), true);
+        assert!(!ars.contains(&id1));
+        assert!(!ars.contains(&id2));
+        assert!(ars.contains(&id3));
         assert_eq!(ars.active_identities_number(), 1);
         assert_eq!(trs.get_sum(ars.active_identities()), Reputation(1024));
     }

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -1408,7 +1408,7 @@ mod tests {
 
         // Required fields for Secpk1 signature verification
         let secp = Secp256k1::new();
-        let signed_data = calculate_sha256(signature_with_data.identifier.as_bytes().as_ref());
+        let signed_data = calculate_sha256(signature_with_data.identifier.as_bytes());
         let public_key =
             SecpPublicKey::from_slice(&hex::decode(signature_with_data.public_key).unwrap())
                 .unwrap();

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -1176,7 +1176,7 @@ where
             self._gen_internal_address(state, None)?.pkh
         } else {
             // In case of DRTransaction, the first input pkh will be used
-            let first_input = inputs.first().clone().unwrap().output_pointer();
+            let first_input = inputs.first().unwrap().output_pointer();
             let key_balance = state.utxo_set.get(&first_input.into()).unwrap();
 
             key_balance.pkh

--- a/wallet/src/repository/wallet/tests/mod.rs
+++ b/wallet/src/repository/wallet/tests/mod.rs
@@ -1323,13 +1323,10 @@ fn test_export_xprv_key() {
         .export_master_key(password.clone())
         .unwrap()
         .starts_with("xprv"));
-    assert_eq!(
-        wallet
-            .export_master_key(password)
-            .unwrap()
-            .starts_with("xprvdouble"),
-        false
-    );
+    assert!(!wallet
+        .export_master_key(password)
+        .unwrap()
+        .starts_with("xprvdouble"));
 }
 
 #[test]


### PR DESCRIPTION
The new version will be released tomorrow (2021-06-17), but you can try the pre-release using

    RUSTUP_DIST_SERVER=https://dev-static.rust-lang.org rustup update stable