### PR TITLE
fix(config): set missing fields of tapi struct to false

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -378,6 +378,7 @@ pub struct Mempool {
 /// Allow miners to oppose activation of future protocol improvements even if their nodes
 /// do implement the required logic.
 #[derive(Deserialize, Serialize, Default, Debug, Clone, PartialEq)]
+#[serde(default)]
 pub struct Tapi {
     /// Oppose WIP0014
     pub oppose_wip0014: bool,

--- a/config/src/loaders/toml.rs
+++ b/config/src/loaders/toml.rs
@@ -228,4 +228,24 @@ enabled = false
         assert_eq!(empty_config.mining, PartialMining::default());
         assert_eq!(config_disabled.mining.enabled, Some(false),);
     }
+
+    #[test]
+    fn test_configure_tapi_missing_fields() {
+        // Check that the tapi table does not need to explicitly set all the new "oppose_wip" fields
+        // and they default to "false"
+        let empty_config = super::from_str("[tapi]").unwrap();
+        let config_oppose_0016 = super::from_str(
+            r"
+[tapi]
+oppose_wip0016 = true
+    ",
+        )
+        .unwrap();
+
+        assert_eq!(empty_config.tapi, Tapi::default());
+        assert!(!empty_config.tapi.oppose_wip0014);
+        assert!(!empty_config.tapi.oppose_wip0016);
+        assert!(!config_oppose_0016.tapi.oppose_wip0014);
+        assert!(config_oppose_0016.tapi.oppose_wip0016);
+    }
 }


### PR DESCRIPTION
Previously, setting

    [tapi]
    oppose_wip0016 = true

Would result in this error:

```
Loading config from: witnet.toml
Error: Error parsing config file: missing field `oppose_wip0014` for key `tapi` at line 68 column 1
```