### PR TITLE
fix(mining): use correct reppoe_threshold version

### DIFF
--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -336,7 +336,7 @@ impl ChainManager {
             // TODO: pass difficulty as an argument to this function (from consensus constants)
             let minimum_reppoe_difficulty = 2000;
             let active_wips = ActiveWips {
-                active_wips: Default::default(),
+                active_wips: self.chain_state.tapi_engine.wip_activation.clone(),
                 block_epoch: current_epoch,
             };
             let (target_hash, probability) = calculate_reppoe_threshold(


### PR DESCRIPTION
This is broken since the tapi branch merge (#1985), I originally included the fix in #1976 but that's not merged yet.