### PR TITLE
Fix: small issues in add_temp_superblock_votes

### DIFF
--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -965,7 +965,7 @@ impl ChainManager {
             log::debug!("add_temp_superblock_votes {:?}", superblock_vote);
             // Check if we already received this vote
             if self.chain_state.superblock_state.contains(&superblock_vote) {
-                return;
+                continue;
             }
 
             // Validate secp256k1 signature

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -210,7 +210,7 @@ pub struct ChainManager {
     /// Mint Percentage to share with the external address
     external_percentage: u8,
     /// List of superblock votes received while we are synchronizing
-    temp_superblock_votes: Vec<SuperBlockVote>,
+    temp_superblock_votes: HashSet<SuperBlockVote>,
     /// Commits and reveals to process later
     temp_commits_and_reveals: Vec<Transaction>,
     /// Value transfers and data requests to process later
@@ -1006,7 +1006,7 @@ impl ChainManager {
         let superblock_period = u32::from(consensus_constants.superblock_period);
 
         if self.sm_state != StateMachine::Synced {
-            self.temp_superblock_votes.push(superblock_vote.clone());
+            self.temp_superblock_votes.insert(superblock_vote.clone());
         }
 
         // Check if we already received this vote


### PR DESCRIPTION
This only affects nodes when synchronizing. For example my node had 2055 votes but only 346 were unique.