### PR TITLE
feat: kickstart development of `witnet_toolkit` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
  "byteorder",
  "digest 0.8.1",
  "failure",
- "hex 0.4.2",
+ "hex 0.4.3",
  "rustc-hex",
  "serde_json",
  "sha2",
@@ -986,7 +986,7 @@ checksum = "c52991643379afc90bfe2df3c64d53983e59c35a82ba6e75c997cfc2880d8524"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",
- "hex 0.4.2",
+ "hex 0.4.3",
  "serde",
  "serde_json",
  "sha3",
@@ -1554,9 +1554,9 @@ checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -3660,9 +3660,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -3858,9 +3858,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
 dependencies = [
  "clap",
  "lazy_static",
@@ -3869,9 +3869,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -4562,7 +4562,7 @@ checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
 dependencies = [
  "byteorder",
  "crunchy",
- "hex 0.4.2",
+ "hex 0.4.3",
  "static_assertions",
 ]
 
@@ -4893,7 +4893,7 @@ dependencies = [
  "futures 0.3.8",
  "futures-timer",
  "headers",
- "hex 0.4.2",
+ "hex 0.4.3",
  "jsonrpc-core 17.0.0",
  "log 0.4.11",
  "parking_lot 0.11.0",
@@ -5035,7 +5035,7 @@ dependencies = [
  "env_logger",
  "failure",
  "futures 0.3.8",
- "hex 0.4.2",
+ "hex 0.4.3",
  "itertools",
  "lazy_static",
  "log 0.4.11",
@@ -5052,6 +5052,7 @@ dependencies = [
  "witnet_data_structures",
  "witnet_node",
  "witnet_rad",
+ "witnet_toolkit",
  "witnet_util",
  "witnet_validations",
  "witnet_wallet",
@@ -5145,7 +5146,7 @@ dependencies = [
  "byteorder",
  "digest 0.8.1",
  "failure",
- "hex 0.4.2",
+ "hex 0.4.3",
  "hmac",
  "memzero",
  "rand 0.7.3",
@@ -5170,7 +5171,7 @@ dependencies = [
  "ethereum-types 0.11.0",
  "exonum-build",
  "failure",
- "hex 0.4.2",
+ "hex 0.4.3",
  "itertools",
  "lazy_static",
  "log 0.4.11",
@@ -5283,7 +5284,7 @@ dependencies = [
  "cbor-codec",
  "failure",
  "futures 0.3.8",
- "hex 0.4.2",
+ "hex 0.4.3",
  "if_rust_version",
  "json",
  "log 0.4.11",
@@ -5316,6 +5317,18 @@ dependencies = [
  "rocksdb",
  "witnet_crypto",
  "witnet_protected",
+]
+
+[[package]]
+name = "witnet_toolkit"
+version = "0.1.0"
+dependencies = [
+ "failure",
+ "hex 0.4.3",
+ "serde_json",
+ "structopt",
+ "witnet_data_structures",
+ "witnet_rad",
 ]
 
 [[package]]
@@ -5359,7 +5372,7 @@ dependencies = [
  "futures 0.1.30",
  "futures 0.3.8",
  "futures-util",
- "hex 0.4.2",
+ "hex 0.4.3",
  "itertools",
  "jsonrpc-core 15.1.0",
  "jsonrpc-pubsub",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "An in-progress open source implementation of the Witnet protocol 
 edition = "2018"
 
 [workspace]
-members = ["config", "node", "crypto", "data_structures", "p2p", "storage", "wallet", "validations", "protected", "reputation", "net", "bridges/ethereum", "bridges/centralized-ethereum", "futures_utils"]
+members = ["config", "node", "crypto", "data_structures", "p2p", "storage", "wallet", "validations", "protected", "reputation", "net", "toolkit", "bridges/ethereum", "bridges/centralized-ethereum", "futures_utils"]
 
 [features]
 default = ["wallet", "node", "telemetry"]
@@ -46,6 +46,7 @@ witnet_crypto = { path = "./crypto" }
 witnet_data_structures = { path = "./data_structures" }
 witnet_node = { path = "./node", optional = true }
 witnet_rad = { path = "./rad" }
+witnet_toolkit = { path = "./toolkit" }
 witnet_util = { path = "./util" }
 witnet_validations = { path = "./validations" }
 witnet_wallet = { path = "./wallet", optional = true }

--- a/toolkit/Cargo.toml
+++ b/toolkit/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "witnet_toolkit"
+version = "0.1.0"
+authors = ["Adán SDPC <adan.sdpc@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+failure = "0.1.8"
+hex = "0.4.3"
+serde_json = "1.0.66"
+structopt = "0.3.22"
+witnet_data_structures = { path = "../data_structures" }
+witnet_rad = { path = "../rad" }

--- a/toolkit/src/cli/arguments.rs
+++ b/toolkit/src/cli/arguments.rs
@@ -1,0 +1,22 @@
+//! Structures used as arguments for CLI subcommands.
+
+use structopt::StructOpt;
+
+/// Arguments for the `--decode-data-request` method.
+#[derive(Debug, StructOpt)]
+pub(crate) struct DecodeDataRequest {
+    #[structopt(long, help = "Hexadecimal serialization of the data request output.")]
+    pub hex: Option<String>,
+}
+
+/// Arguments for the `--try-data-request` method.
+#[derive(Debug, StructOpt)]
+pub(crate) struct TryDataRequest {
+    #[structopt(long, help = "Hexadecimal serialization of the data request output.")]
+    pub hex: Option<String>,
+    #[structopt(
+        long,
+        help = "Whether to return the full execution trace, including partial results after each operator."
+    )]
+    pub full_trace: Option<bool>,
+}

--- a/toolkit/src/cli/commands.rs
+++ b/toolkit/src/cli/commands.rs
@@ -1,0 +1,22 @@
+//! Structures used for defining the available CLI commands and subcommands.
+
+use structopt::StructOpt;
+
+use super::arguments;
+
+#[derive(Debug, StructOpt)]
+pub(crate) enum SubCommand {
+    #[structopt(name = "decode-data-request", about = "Decodes a data request.")]
+    DecodeDataRequest(arguments::DecodeDataRequest),
+    #[structopt(
+        name = "try-data-request",
+        about = "Tries a data request locally so as to preview what its result could be as of now."
+    )]
+    TryDataRequest(arguments::TryDataRequest),
+}
+
+#[derive(Debug, StructOpt)]
+pub(crate) struct Command {
+    #[structopt(subcommand)]
+    pub subcommand: SubCommand,
+}

--- a/toolkit/src/cli/data_requests.rs
+++ b/toolkit/src/cli/data_requests.rs
@@ -1,0 +1,34 @@
+//! Implementations of CLI methods related to Witnet data requests.
+
+use witnet_data_structures::chain::DataRequestOutput;
+use witnet_rad::RADRequestExecutionReport;
+
+use crate::{errors::Error, lib};
+
+use super::arguments;
+
+/// Decode a data request from a `DecodeDataRequest` structure.
+pub(crate) fn decode_from_args(
+    args: arguments::DecodeDataRequest,
+) -> Result<DataRequestOutput, Error> {
+    if let Some(hex) = args.hex {
+        lib::data_requests::decode_from_hex(hex)
+    } else {
+        Err(Error::DataRequestNoBytes)
+    }
+}
+
+/// Try a data request from a `DecodeDataRequest` structure.
+///
+/// By default, a full trace is provided, i.e.: all execution details including the partial results
+/// after each operator.
+///
+/// Full trace mode can be disabled by setting `--full_trace` option to `false`.  
+pub(crate) fn try_from_args(
+    args: arguments::TryDataRequest,
+) -> Result<RADRequestExecutionReport, Error> {
+    let request = decode_from_args(arguments::DecodeDataRequest { hex: args.hex })?.data_request;
+    let full_trace = args.full_trace.unwrap_or(true);
+
+    lib::data_requests::try_data_request(&request, full_trace)
+}

--- a/toolkit/src/cli/mod.rs
+++ b/toolkit/src/cli/mod.rs
@@ -1,0 +1,34 @@
+//! A convenient and lightweight CLI providing Witnet related utilities.
+//!
+//! In comparison to the former `witnet-rust` CLI, this one is "standalone", i.e. all the commands
+//! provided here are processed locally, without any need to connect to a Witnet node.
+
+mod arguments;
+pub(crate) mod commands;
+pub(crate) mod data_requests;
+
+use crate::errors::Error;
+
+/// This function acts as the main router and error handler for CLI commands.
+pub(crate) fn process_command(command: commands::Command) -> i32 {
+    match command.subcommand {
+        // `--decode-data-request`
+        commands::SubCommand::DecodeDataRequest(args) => data_requests::decode_from_args(args)
+            .and_then(|decoded| serde_json::to_string(&decoded).map_err(Error::JsonSerialize)),
+        // `--try-data-request`
+        commands::SubCommand::TryDataRequest(args) => data_requests::try_from_args(args)
+            .and_then(|report| serde_json::to_string(&report).map_err(Error::JsonSerialize)),
+    }
+    // The output of successful commands is printed to `stdout`, and a `0` exit code is returned
+    .map(|result| {
+        println!("{}", result);
+
+        0
+    })
+    // The output of failed commands is printed to `stderr`, and a `1` exit code is returned
+    .unwrap_or_else(|error| {
+        eprintln!("{}", error.to_string());
+
+        1
+    })
+}

--- a/toolkit/src/errors.rs
+++ b/toolkit/src/errors.rs
@@ -1,0 +1,24 @@
+///! Crate level errors.
+///
+/// TODO: this can be refactored to separate CLI errors from library errors, which should make it
+///  easier to convert the CLI part into a conditional compile.
+use failure::Fail;
+
+#[derive(Debug, Fail)]
+#[fail(display = "error")]
+pub enum Error {
+    #[fail(display = "No bytes have been provided. Please use the --hex argument.")]
+    DataRequestNoBytes,
+    #[fail(
+        display = "The string provided in the --hex field is not a valid hexadecimal byte string: {}",
+        _0
+    )]
+    DataRequestHexNotValid(#[cause] hex::FromHexError),
+    #[fail(
+        display = "The string provided in the --hex field is not a valid Protocol Buffers byte string: {}",
+        _0
+    )]
+    DataRequestProtoBufNotValid(#[cause] failure::Error),
+    #[fail(display = "Error when serializing the result: {}", _0)]
+    JsonSerialize(#[cause] serde_json::Error),
+}

--- a/toolkit/src/lib/data_requests.rs
+++ b/toolkit/src/lib/data_requests.rs
@@ -1,0 +1,37 @@
+//! Functions providing convenient utilities for working with Witnet data requests.
+use witnet_data_structures::{
+    chain::{DataRequestOutput, RADRequest},
+    proto::ProtobufConvert,
+};
+use witnet_rad::{script::RadonScriptExecutionSettings, RADRequestExecutionReport};
+
+use crate::errors::Error;
+
+/// Decode a data request from its Protocol Buffers hexadecimal string representation.
+pub fn decode_from_hex(hex: String) -> Result<DataRequestOutput, Error> {
+    let pb_bytes = hex::decode(hex).map_err(Error::DataRequestHexNotValid)?;
+    let request =
+        DataRequestOutput::from_pb_bytes(&pb_bytes).map_err(Error::DataRequestProtoBufNotValid)?;
+
+    Ok(request)
+}
+
+/// Locally try a data request.
+///
+/// By default, a full trace is provided, i.e.: all execution details including the partial results
+/// after each operator.
+///
+/// Full trace mode can be disabled by setting `full_trace` to `false`.  
+pub fn try_data_request(
+    request: &RADRequest,
+    full_trace: bool,
+) -> Result<RADRequestExecutionReport, Error> {
+    let settings = if full_trace {
+        RadonScriptExecutionSettings::enable_all()
+    } else {
+        RadonScriptExecutionSettings::disable_all()
+    };
+    let report = witnet_rad::try_data_request(request, settings, None);
+
+    Ok(report)
+}

--- a/toolkit/src/lib/mod.rs
+++ b/toolkit/src/lib/mod.rs
@@ -1,0 +1,1 @@
+pub mod data_requests;

--- a/toolkit/src/main.rs
+++ b/toolkit/src/main.rs
@@ -1,0 +1,37 @@
+//! # Witnet Toolkit
+//!
+//! Provides convenient and simple to use methods for building any kind of Witnet related tools,
+//! either as libraries, FFIs or CLIs.
+//!
+//! ## Usage
+//!
+//! This crate can fundamentally be used in two different ways: as a CLI tool or as a Rust library.
+//!
+//! ### As a CLI tool
+//!
+//! When compiling this crate, the target binary is a CLI that can be used either standalone or
+//! wrapped as a FFI for performing Witnet related operations in programming languages different
+//! than Rust.
+//!
+//! ### As a Rust library
+//!
+//! The `lib` module contains helper functions that can be easily imported into other Rust projects
+//! in order to create Witnet related software using Rust.
+
+use structopt::StructOpt;
+
+use cli::commands::Command;
+
+mod cli;
+pub mod errors;
+pub mod lib;
+
+/// The main entrypoint for the `witnet_toolkit` binary.
+///
+/// This basically handles the core functionality of the CLI, and ensures that the process exits
+/// gracefully.
+fn main() {
+    let command = Command::from_args();
+    let exit_code = cli::process_command(command);
+    std::process::exit(exit_code);
+}


### PR DESCRIPTION
# Witnet Toolkit
Provides convenient and simple to use methods for building any kind of Witnet related tools, either as libraries, FFIs or CLIs.

## Usage
This crate can fundamentally be used in two different ways: as a CLI tool or as a Rust library.

### As a CLI tool
When compiling this crate, the target binary is a CLI that can be used either standalone or wrapped as a FFI for performing Witnet related operations in programming languages different than Rust.

### As a Rust library
The `lib` module contains helper functions that can be easily imported into other Rust projects in order to create Witnet related software using Rust.