### PR TITLE
feat: improve rocksdb error message

### DIFF
--- a/storage/src/backends/rocksdb.rs
+++ b/storage/src/backends/rocksdb.rs
@@ -11,7 +11,7 @@ use crate::storage::{Result, Storage};
 pub type Backend = rocksdb::DB;
 
 #[derive(Debug, Fail)]
-#[fail(display = "RocksDB error")]
+#[fail(display = "RocksDB error: {}", _0)]
 struct Error(#[fail(cause)] rocksdb::Error);
 
 impl Storage for Backend {


### PR DESCRIPTION
Old error:

```
Error when writing blocks to storage: RocksDB error
```

New error:

```
Error when writing blocks to storage: RocksDB error: IO error: No space left on deviceWhile appending to file: .witnet/000009.log: No space left on device
```