### PR TITLE
feat(node): avoid unused temporary allocation when counting TAPI votes

### DIFF
--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -2149,8 +2149,9 @@ impl ChainManager {
 
             try_join_all(aux)
                 .await
-                // Map Option<Vec<T>> to Vec<T>, this returns all the non-error results
-                .map(|x| x.into_iter().flatten().collect::<Vec<BlockHeader>>())
+                // Map Vec<Option<T>> to Vec<T>, this returns all the non-error results and ignores
+                // the errors.
+                .map(|x| x.into_iter().flatten())
         }
         .into_actor(self)
         .and_then(move |block_headers, act, _ctx| {


### PR DESCRIPTION
This removes an unneeded call to `.collect()`, because `try_join_all` does already collect the result into a `Vec` internally, so it is not needed.