### PR TITLE
feat(cli): searchRequests command

### DIFF
--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -235,6 +235,19 @@ pub fn exec_cmd(
             print_data_request,
             create_local_tally,
         ),
+        Command::SearchRequests {
+            node,
+            start,
+            end,
+            hex_dr_bytes,
+            same_as_dr_tx,
+        } => rpc::search_requests(
+            node.unwrap_or(config.jsonrpc.server_address),
+            start,
+            end,
+            hex_dr_bytes,
+            same_as_dr_tx,
+        ),
         Command::GetPeers { node } => rpc::get_peers(node.unwrap_or(config.jsonrpc.server_address)),
         Command::GetKnownPeers { node } => {
             rpc::get_known_peers(node.unwrap_or(config.jsonrpc.server_address))
@@ -319,7 +332,6 @@ pub enum Command {
         /// Socket address of the Witnet node to query
         #[structopt(short = "n", long = "node")]
         node: Option<SocketAddr>,
-        /// init
         /// First epoch for which to return block hashes
         /// If negative, return block hashes from the last n epochs
         #[structopt(
@@ -329,7 +341,6 @@ pub enum Command {
             default_value = "0"
         )]
         start: i64,
-        /// end
         /// If negative, return the last n block hashes from this epoch range.
         /// If zero, unlimited
         #[structopt(
@@ -583,6 +594,45 @@ pub enum Command {
         print_data_request: bool,
         #[structopt(long = "run-tally", help = "Re-run tally stage locally")]
         create_local_tally: bool,
+    },
+    #[structopt(
+        name = "searchRequests",
+        about = "Search data requests with a specific bytecode"
+    )]
+    SearchRequests {
+        /// Socket address of the Witnet node to query
+        #[structopt(short = "n", long = "node")]
+        node: Option<SocketAddr>,
+        /// First epoch for which to search for requests
+        /// If negative, search the last n epochs
+        #[structopt(
+            long = "start",
+            alias = "s",
+            allow_hyphen_values = true,
+            default_value = "0"
+        )]
+        start: i64,
+        /// If negative, search the last n blocks from this epoch range.
+        /// If zero, unlimited
+        #[structopt(
+            long = "end",
+            alias = "e",
+            allow_hyphen_values = true,
+            default_value = "4294967294"
+        )]
+        end: i64,
+        #[structopt(
+            long = "hex-dr-bytes",
+            value_name = "bytecode",
+            help = "Data request bytecode in hexadecimal format"
+        )]
+        hex_dr_bytes: Option<String>,
+        #[structopt(
+            long = "same-as-dr-tx",
+            value_name = "data request transaction hash",
+            help = "Search all the data requests that have the exact same bytecode as this one"
+        )]
+        same_as_dr_tx: Option<String>,
     },
     #[structopt(
         name = "peers",


### PR DESCRIPTION
This PR implements a new CLI command: `searchRequests`. This can be used to find all the data requests that have the same bytecode. One common use case is to check the status of price feed contracts, or any periodic request.

Example: get all the requests from the CFX/USDT price feed starting from epoch 670000. The `--start` parameter is very important because the default behavior is to search all the blocks since the genesis, which may take a while.

```
$ witnet node searchRequests --start 670000 --hex-dr-bytes 0adf0308dce89889061254123a68747470733a2f2f6170692e62696e616e63652e636f6d2f6170692f76332f7469636b65722f70726963653f73796d626f6c3d434658555344541a168418778218646570726963658218571a000f4240185b1257123668747470733a2f2f7777772e6f6b65782e636f6d2f6170692f696e6465782f76332f4346582d5553442f636f6e7374697475656e74731a1d8518778218666464617461821864646c6173748218571a000f4240185b1247122e68747470733a2f2f646174612e676174656170692e696f2f617069322f312f7469636b65722f6366785f757364741a15841877821864646c6173748218571a000f4240185b1264123d68747470733a2f2f7777772e6d78632e636f6d2f6f70656e2f6170692f76322f6d61726b65742f7469636b65723f73796d626f6c3d4346585f555344541a23871877821861646461746182181800821867646c61737418728218571a000f4240185b125b123568747470733a2f2f6170692e626b65782e63632f76322f712f7469636b65722f70726963653f73796d626f6c3d4346585f555344541a228618778218616464617461821818008218646570726963658218571a000f4240185b1a0d0a0908051205fa3fc000001003220d0a0908051205fa3fc000001003100a186420012846308094ebdc03
```

The output is a list of data request transaction hashes, one per line, which can then be manually inspected using the block explorer or the `dataRequestReport` command.

To make this easier to use, this command also supports reading the bytecode from an existing transaction, instead of passing the bytecode as an argument. This will also print the bytecode.

```
$ witnet node searchRequests --start 670000 --same-as-dr-tx fd83169556b85f65b65f1db0b20d53a1cd087958750979263f8eefcc1aa0f77f
Loading config from: /witnet.toml
Setting log level to: INFO, source: Config
[2021-09-30T13:07:36Z INFO  witnet::cli::node::json_rpc_client] Connecting to JSON-RPC server at 127.0.0.1:21338
[2021-09-30T13:07:36Z INFO  witnet::cli::node::json_rpc_client] Searching for this dr_output_bytes: 0adf0308dce89889061254123a68747470733a2f2f6170692e62696e616e63652e636f6d2f6170692f76332f7469636b65722f70726963653f73796d626f6c3d434658555344541a168418778218646570726963658218571a000f4240185b1257123668747470733a2f2f7777772e6f6b65782e636f6d2f6170692f696e6465782f76332f4346582d5553442f636f6e7374697475656e74731a1d8518778218666464617461821864646c6173748218571a000f4240185b1247122e68747470733a2f2f646174612e676174656170692e696f2f617069322f312f7469636b65722f6366785f757364741a15841877821864646c6173748218571a000f4240185b1264123d68747470733a2f2f7777772e6d78632e636f6d2f6f70656e2f6170692f76322f6d61726b65742f7469636b65723f73796d626f6c3d4346585f555344541a23871877821861646461746182181800821867646c61737418728218571a000f4240185b125b123568747470733a2f2f6170692e626b65782e63632f76322f712f7469636b65722f70726963653f73796d626f6c3d4346585f555344541a228618778218616464617461821818008218646570726963658218571a000f4240185b1a0d0a0908051205fa3fc000001003220d0a0908051205fa3fc000001003100a186420012846308094ebdc03
[2021-09-30T13:07:36Z INFO  witnet::cli::node::json_rpc_client] Processing 4250 blocks
fd83169556b85f65b65f1db0b20d53a1cd087958750979263f8eefcc1aa0f77f
af24ac39d523f89319adbf46bad293659ba3438d9c63da35ecbd95a1644adb55
```
