### PR TITLE
Update env_logger to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4913,7 +4913,7 @@ dependencies = [
  "ansi_term 0.12.1",
  "bytecount",
  "ctrlc",
- "env_logger 0.7.1",
+ "env_logger 0.9.0",
  "failure",
  "futures 0.3.17",
  "hex 0.4.3",
@@ -4960,7 +4960,7 @@ dependencies = [
  "actix",
  "async-jsonrpc-client",
  "ctrlc",
- "env_logger 0.7.1",
+ "env_logger 0.9.0",
  "futures-util",
  "hex 0.4.3",
  "log 0.4.11",
@@ -4983,7 +4983,7 @@ name = "witnet-ethereum-bridge"
 version = "0.1.0"
 dependencies = [
  "async-jsonrpc-client",
- "env_logger 0.7.1",
+ "env_logger 0.9.0",
  "ethabi 9.0.1",
  "futures 0.1.30",
  "futures-locks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ travis-ci = { repository = "https://github.com/witnet/witnet-rust", branch = "ma
 ansi_term = "0.12.1"
 bytecount = "0.6.0"
 ctrlc = "3.1.3"
-env_logger = "0.7.1"
+env_logger = "0.9.0"
 failure = "0.1.8"
 futures = "0.3.8"
 hex = "0.4.1"

--- a/bridges/centralized-ethereum/Cargo.toml
+++ b/bridges/centralized-ethereum/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 actix = { version = "0.12.0", default-features = false }
 async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"], branch = "fix-tcp-leak" }
 ctrlc = "3.1.3"
-env_logger = "0.7.1"
+env_logger = "0.9.0"
 futures-util = { version = "0.3.8", features = ["compat"] }
 hex = "0.4.3"
 log = "0.4.8"

--- a/bridges/ethereum/Cargo.toml
+++ b/bridges/ethereum/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 async-jsonrpc-client = { git = "https://github.com/witnet/async-jsonrpc-client", features = ["tcp"], branch = "fix-tcp-leak" }
-env_logger = "0.7.1"
+env_logger = "0.9.0"
 ethabi = "9.0.0"
 futures = "0.1.28"
 futures-locks = "0.5.0"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -83,7 +83,7 @@ fn configure_logger(opts: &LogOptions) -> env_logger::Builder {
         } else {
             None
         })
-        .format_module_path(opts.module_path)
+        .format_target(opts.module_path)
         .filter_level(log::LevelFilter::Info)
         .filter_module("witnet", opts.level)
         .filter_module("witnet_node", opts.level)


### PR DESCRIPTION
This changes the default colors for the `DEBUG` and `TRACE` words

>    Update default colors for debug (white => blue) and trace (black => cyan)

Sample:

![Captura de pantalla de 2021-10-26 15-41-12](https://user-images.githubusercontent.com/44604217/138891143-7ca207aa-390f-4761-8109-50aa18f02810.png)