### PR TITLE
chore: update secp256k1 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3765,9 +3765,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "secp256k1"
-version = "0.17.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
+checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
 dependencies = [
  "secp256k1-sys",
  "serde",
@@ -3775,9 +3775,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.1.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2c26f0d3552a0f12e639ae8a64afc2e3db9c52fe32f5fc6c289d38519f220"
+checksum = "67e4b6455ee49f5901c8985b88f98fb0a0e1d90a6661f5a03f4888bd987dad29"
 dependencies = [
  "cc",
 ]
@@ -5563,7 +5563,6 @@ dependencies = [
  "protobuf",
  "protobuf-convert",
  "rand 0.7.3",
- "secp256k1",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -5619,7 +5618,6 @@ dependencies = [
  "log 0.4.11",
  "pin-project-lite 0.2.6",
  "rand 0.7.3",
- "secp256k1",
  "sentry",
  "serde",
  "serde_json",

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,7 +22,7 @@ hmac = "0.7.1"
 memzero = "0.1.0"
 rand = "0.7.3"
 ring = "0.16.11"
-secp256k1 = "0.17.2"
+secp256k1 = "0.20.3"
 serde = { version = "1.0.104", optional = true }
 sha2 = "0.8.1"
 tiny-bip39 = "0.7.0"

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -1,8 +1,7 @@
 //! Signature module
 
 use crate::key::CryptoEngine;
-use failure::Fail;
-use secp256k1::{Message, SecretKey};
+use secp256k1::{Error, Message, SecretKey};
 
 /// Signature
 pub type Signature = secp256k1::Signature;
@@ -10,36 +9,25 @@ pub type Signature = secp256k1::Signature;
 /// PublicKey
 pub type PublicKey = secp256k1::PublicKey;
 
-/// The error type for operations with signatures
-#[derive(Debug, PartialEq, Fail)]
-pub enum SignatureError {
-    #[fail(display = "Fail in verify process")]
-    /// Fail in verify process
-    VerifyError,
-}
-
-/// Sign data with provided secret key
-/// - Returns an Error if data is all zeros or is not a 32-byte array
-pub fn sign(
-    secp: &CryptoEngine,
-    secret_key: SecretKey,
-    data: &[u8],
-) -> Result<Signature, failure::Error> {
+/// Sign `data` with provided secret key. `data` must be the 32-byte output of a cryptographically
+/// secure hash function, otherwise this function is not secure.
+/// - Returns an Error if data is not a 32-byte array
+pub fn sign(secp: &CryptoEngine, secret_key: SecretKey, data: &[u8]) -> Result<Signature, Error> {
     let msg = Message::from_slice(data)?;
 
     Ok(secp.sign(&msg, &secret_key))
 }
-/// Verify signature with a provided public key
+/// Verify signature with a provided public key.
+/// - Returns an Error if data is not a 32-byte array
 pub fn verify(
     secp: &CryptoEngine,
     public_key: &PublicKey,
     data: &[u8],
     sig: &Signature,
-) -> Result<(), failure::Error> {
-    let msg = Message::from_slice(data).unwrap();
+) -> Result<(), Error> {
+    let msg = Message::from_slice(data)?;
 
     secp.verify(&msg, sig, public_key)
-        .map_err(|_| SignatureError::VerifyError.into())
 }
 
 #[cfg(test)]

--- a/data_structures/Cargo.toml
+++ b/data_structures/Cargo.toml
@@ -27,7 +27,6 @@ rand = "0.7.3"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_cbor = "0.11.1"
 serde_json = "1.0.48"
-secp256k1 = "0.17.2"
 vrf = "0.2.3"
 
 witnet_crypto = { path = "../crypto" }

--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -12,10 +12,6 @@ use bech32::{FromBase32, ToBase32};
 use bls_signatures_rs::{bn256, bn256::Bn256, MultiSignature};
 use failure::Fail;
 use ordered_float::OrderedFloat;
-use secp256k1::{
-    PublicKey as Secp256k1_PublicKey, SecretKey as Secp256k1_SecretKey,
-    Signature as Secp256k1_Signature,
-};
 use serde::{Deserialize, Serialize};
 
 use partial_struct::PartialStruct;
@@ -23,6 +19,10 @@ use witnet_crypto::{
     hash::{calculate_sha256, Sha256},
     key::ExtendedSK,
     merkle::merkle_tree_root as crypto_merkle_tree_root,
+    secp256k1::{
+        PublicKey as Secp256k1_PublicKey, SecretKey as Secp256k1_SecretKey,
+        Signature as Secp256k1_Signature,
+    },
 };
 use witnet_protected::Protected;
 use witnet_reputation::{ActiveReputationSet, TotalReputationSet};
@@ -4298,7 +4298,7 @@ mod tests {
     #[test]
     fn secp256k1_from_into_secpk256k1_signatures() {
         use crate::chain::Secp256k1Signature;
-        use secp256k1::{
+        use witnet_crypto::secp256k1::{
             Message as Secp256k1_Message, Secp256k1, SecretKey as Secp256k1_SecretKey,
             Signature as Secp256k1_Signature,
         };
@@ -4319,7 +4319,7 @@ mod tests {
     #[test]
     fn secp256k1_from_into_signatures() {
         use crate::chain::Signature;
-        use secp256k1::{
+        use witnet_crypto::secp256k1::{
             Message as Secp256k1_Message, Secp256k1, SecretKey as Secp256k1_SecretKey,
             Signature as Secp256k1_Signature,
         };
@@ -4340,7 +4340,7 @@ mod tests {
     #[test]
     fn secp256k1_from_into_public_keys() {
         use crate::chain::PublicKey;
-        use secp256k1::{
+        use witnet_crypto::secp256k1::{
             PublicKey as Secp256k1_PublicKey, Secp256k1, SecretKey as Secp256k1_SecretKey,
         };
 
@@ -4358,7 +4358,7 @@ mod tests {
     #[test]
     fn secp256k1_from_into_secret_keys() {
         use crate::chain::SecretKey;
-        use secp256k1::SecretKey as Secp256k1_SecretKey;
+        use witnet_crypto::secp256k1::SecretKey as Secp256k1_SecretKey;
 
         let secret_key =
             Secp256k1_SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");

--- a/data_structures/src/vrf.rs
+++ b/data_structures/src/vrf.rs
@@ -223,7 +223,7 @@ mod tests {
         // Test that the public key derived by the VRF crate is the same as the
         // public key derived by the secp256k1 crate
         use crate::chain::PublicKey;
-        use secp256k1::{
+        use witnet_crypto::secp256k1::{
             PublicKey as Secp256k1_PublicKey, Secp256k1, SecretKey as Secp256k1_SecretKey,
         };
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -22,7 +22,6 @@ jsonrpc-pubsub = "15.1.0"
 log = "0.4.8"
 rand = "0.7.3"
 pin-project-lite = "0.2"
-secp256k1 = "0.17.2"
 sentry = { version = "0.23", features = ["log"], optional = true }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.47"

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -999,7 +999,7 @@ pub fn build_block(
 mod tests {
     use std::convert::TryInto;
 
-    use secp256k1::{
+    use witnet_crypto::secp256k1::{
         PublicKey as Secp256k1_PublicKey, Secp256k1, SecretKey as Secp256k1_SecretKey,
     };
 

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -2960,7 +2960,7 @@ mod tests {
     use witnet_protected::Protected;
     use witnet_validations::validations::block_reward;
 
-    use secp256k1::{
+    use witnet_crypto::secp256k1::{
         PublicKey as Secp256k1_PublicKey, Secp256k1, SecretKey as Secp256k1_SecretKey,
     };
 

--- a/validations/src/tests/mod.rs
+++ b/validations/src/tests/mod.rs
@@ -483,7 +483,7 @@ where
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::VerifyTransactionSignatureFail {
             hash,
-            msg: "Fail in verify process".to_string(),
+            msg: "secp: signature failed verification".to_string(),
         },
     );
 
@@ -496,7 +496,7 @@ where
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::VerifyTransactionSignatureFail {
             hash,
-            // A "Fail in verify process" msg would also be correct here
+            // A "secp: signature failed verification" msg would also be correct here
             msg: TransactionError::PublicKeyHashMismatch {
                 expected_pkh: MY_PKH_1.parse().unwrap(),
                 signature_pkh,
@@ -2706,7 +2706,7 @@ fn commitment_signatures() {
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::VerifyTransactionSignatureFail {
             hash,
-            msg: "Fail in verify process".to_string(),
+            msg: "secp: signature failed verification".to_string(),
         },
     );
 

--- a/wallet/src/repository/error.rs
+++ b/wallet/src/repository/error.rs
@@ -79,6 +79,8 @@ pub enum Error {
     UnknownFeeType,
     #[fail(display = "Wallet not found")]
     WalletNotFound,
+    #[fail(display = "Secp256k1 error: {}", _0)]
+    Secp256k1(#[cause] witnet_crypto::secp256k1::Error),
 }
 
 impl From<failure::Error> for Error {
@@ -145,5 +147,11 @@ impl From<TransactionError> for Error {
             }
             _ => Error::TransactionCreation(err),
         }
+    }
+}
+
+impl From<witnet_crypto::secp256k1::Error> for Error {
+    fn from(err: witnet_crypto::secp256k1::Error) -> Self {
+        Error::Secp256k1(err)
     }
 }


### PR DESCRIPTION
And use re-exported version from witnet_crypto in other crates.

Also remove `SignatureError` which was not used anywhere, preferring `secp256k1::Error` instead.