### PR TITLE
Fix potential transaction malleability attack vectors

### DIFF
--- a/data_structures/src/transaction.rs
+++ b/data_structures/src/transaction.rs
@@ -118,7 +118,7 @@ impl<T> Memoized<T> {
 }
 
 /// Transaction data structure
-#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, ProtobufConvert)]
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, ProtobufConvert, Hash)]
 #[protobuf_convert(pb = "witnet::Transaction")]
 // FIXME(#649): Remove clippy skip error
 #[allow(clippy::large_enum_variant)]

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -101,7 +101,7 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
         );
 
         // Clear pending transactions HashSet
-        self.transactions_pool.clear_pending_transactions();
+        self.seen_transactions.clear();
 
         // Handle case consensus not achieved
         if !self.peers_beacons_received {

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -3015,9 +3015,21 @@ pub fn run_dr_locally(dr: &DataRequestOutput) -> Result<RadonTypes, failure::Err
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::{test_actix_system, ActorFutureToNormalFuture};
-    use witnet_config::{config::consensus_constants_from_partial, defaults::Testnet};
-    use witnet_crypto::signature::sign;
+    use crate::{
+        config_mngr,
+        utils::{test_actix_system, ActorFutureToNormalFuture},
+    };
+    use std::sync::Arc;
+    use witnet_config::{
+        config::{consensus_constants_from_partial, Config, StorageBackend},
+        defaults::Testnet,
+    };
+    use witnet_crypto::{
+        secp256k1::{
+            PublicKey as Secp256k1_PublicKey, Secp256k1, SecretKey as Secp256k1_SecretKey,
+        },
+        signature::sign,
+    };
     use witnet_data_structures::{
         chain::{
             BlockMerkleRoots, BlockTransactions, ChainInfo, Environment, Input, KeyedSignature,
@@ -3032,10 +3044,6 @@ mod tests {
     };
     use witnet_protected::Protected;
     use witnet_validations::validations::block_reward;
-
-    use witnet_crypto::secp256k1::{
-        PublicKey as Secp256k1_PublicKey, Secp256k1, SecretKey as Secp256k1_SecretKey,
-    };
 
     use super::*;
 
@@ -3150,6 +3158,14 @@ mod tests {
     #[test]
     fn get_superblock_beacon() {
         test_actix_system(|| async {
+            // Setup testing: use in-memory database instead of rocksdb
+            let mut config = Config::default();
+            config.storage.backend = StorageBackend::HashMap;
+            let config = Arc::new(config);
+            // Start relevant actors
+            config_mngr::start(config);
+            storage_mngr::start();
+
             let mut chain_manager = ChainManager::default();
             chain_manager.chain_state.chain_info = Some(ChainInfo {
                 environment: Environment::default(),
@@ -3547,6 +3563,14 @@ mod tests {
     fn test_process_candidate_malleability() {
         let _ = env_logger::builder().is_test(true).try_init();
         test_actix_system(|| async {
+            // Setup testing: use in-memory database instead of rocksdb
+            let mut config = Config::default();
+            config.storage.backend = StorageBackend::HashMap;
+            let config = Arc::new(config);
+            // Start relevant actors
+            config_mngr::start(config);
+            storage_mngr::start();
+
             let mut chain_manager = ChainManager::default();
 
             chain_manager.current_epoch = Some(2000000);
@@ -3665,6 +3689,14 @@ mod tests {
     fn test_add_transaction_malleability() {
         let _ = env_logger::builder().is_test(true).try_init();
         test_actix_system(|| async {
+            // Setup testing: use in-memory database instead of rocksdb
+            let mut config = Config::default();
+            config.storage.backend = StorageBackend::HashMap;
+            let config = Arc::new(config);
+            // Start relevant actors
+            config_mngr::start(config);
+            storage_mngr::start();
+
             let mut ctx = Context::new();
             let mut chain_manager = ChainManager::default();
 


### PR DESCRIPTION
Part of #2094

The worst that could happen is that a node misses some transactions, which does not sound very dangerous. However if a large portion of the network is affected by this bug, they could create empty blocks that reduce the throughput of the network.

The solution is the same as in #2092

```diff
-// A hashset of recently received transactions hashes
-// Used to avoid validating the same transaction more than once
-pending_transactions: HashSet<Hash>,
+/// Set that stores all the recently received transactions
+seen_transactions: HashSet<Transaction>,
```