### PR TITLE
chore: remove allow for clippy lint field_reassign_with_default

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,6 @@ jobs:
         -D clippy::cast-precision-loss
         -D clippy::cast-sign-loss
         -D clippy::checked-conversions
-        -A clippy::field-reassign-with-default
         -A clippy::upper-case-acronyms
 
     steps:

--- a/Justfile
+++ b/Justfile
@@ -33,7 +33,6 @@ export CLIPPY_LINTS := '-D warnings
     -D clippy::cast-precision-loss
     -D clippy::cast-sign-loss
     -D clippy::checked-conversions
-    -A clippy::field-reassign-with-default
     -A clippy::upper-case-acronyms
 '
 

--- a/data_structures/src/mainnet_validations.rs
+++ b/data_structures/src/mainnet_validations.rs
@@ -447,11 +447,13 @@ mod tests {
         let mut tapi_counter = BitTapiCounter::default();
         assert!(tapi_counter.is_empty());
 
-        let mut aux = BitVotesCounter::default();
-        aux.init = 0;
-        aux.end = 50;
-        aux.wip = "Wip1".to_string();
-        aux.bit = 0;
+        let aux = BitVotesCounter {
+            init: 0,
+            end: 50,
+            wip: "Wip1".to_string(),
+            bit: 0,
+            ..Default::default()
+        };
         tapi_counter.insert(aux.clone());
         assert!(!tapi_counter.is_empty());
         assert!(tapi_counter.get(0, &100).is_none());
@@ -459,11 +461,13 @@ mod tests {
         assert!(!tapi_counter.contains(1, &aux));
         assert_eq!(tapi_counter.current_length, 1);
 
-        let mut aux2 = BitVotesCounter::default();
-        aux2.init = 75;
-        aux2.end = 125;
-        aux2.wip = "Wip2".to_string();
-        aux2.bit = 0;
+        let aux2 = BitVotesCounter {
+            init: 75,
+            end: 125,
+            wip: "Wip2".to_string(),
+            bit: 0,
+            ..Default::default()
+        };
         tapi_counter.insert(aux2.clone());
         assert_eq!(tapi_counter.get(0, &100).unwrap().wip, "Wip2".to_string());
         assert!(tapi_counter.get(1, &100).is_none());
@@ -484,19 +488,23 @@ mod tests {
         let mut tapi_counter = BitTapiCounter::default();
         assert!(tapi_counter.is_empty());
 
-        let mut aux = BitVotesCounter::default();
-        aux.init = 0;
-        aux.end = 50;
-        aux.wip = "Wip1".to_string();
-        aux.bit = 32;
+        let aux = BitVotesCounter {
+            init: 0,
+            end: 50,
+            wip: "Wip1".to_string(),
+            bit: 32,
+            ..Default::default()
+        };
         tapi_counter.insert(aux);
         assert!(tapi_counter.is_empty());
 
-        let mut aux = BitVotesCounter::default();
-        aux.init = 0;
-        aux.end = 50;
-        aux.wip = "Wip1".to_string();
-        aux.bit = 0;
+        let aux = BitVotesCounter {
+            init: 0,
+            end: 50,
+            wip: "Wip1".to_string(),
+            bit: 0,
+            ..Default::default()
+        };
         tapi_counter.insert(aux);
         assert_eq!(tapi_counter.current_length, 1);
 

--- a/data_structures/tests/inclusion_proofs.rs
+++ b/data_structures/tests/inclusion_proofs.rs
@@ -25,10 +25,11 @@ fn example_block(txns: BlockTransactions) -> Block {
         checkpoint: current_epoch,
         hash_prev_block: last_block_hash,
     };
-    let mut block_header = BlockHeader::default();
-    block_header.merkle_roots = BlockMerkleRoots::from_transactions(&txns);
-    block_header.beacon = block_beacon;
-
+    let block_header = BlockHeader {
+        merkle_roots: BlockMerkleRoots::from_transactions(&txns),
+        beacon: block_beacon,
+        ..Default::default()
+    };
     let block_sig = KeyedSignature::default();
 
     Block::new(block_header, block_sig, txns)

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -3447,16 +3447,20 @@ mod tests {
             ..BlockTransactions::default()
         };
 
-        let mut block_header = BlockHeader::default();
-        block_header.merkle_roots = BlockMerkleRoots::from_transactions(&txns);
-        block_header.beacon = block_beacon;
-        block_header.proof = BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap();
-
+        let block_header = BlockHeader {
+            merkle_roots: BlockMerkleRoots::from_transactions(&txns),
+            beacon: block_beacon,
+            proof: BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap(),
+            ..Default::default()
+        };
         let block_sig = sign_tx(*priv_key, &block_header);
 
         Block::new(block_header, block_sig, txns)
     }
 
+    // TODO: cannot use struct update syntax with ChainManager because it implements the
+    // Drop trait, but clippy seems to miss that?
+    #[allow(clippy::field_reassign_with_default)]
     #[test]
     fn test_process_candidate_malleability() {
         let _ = env_logger::builder().is_test(true).try_init();

--- a/rad/src/reducers/mod.rs
+++ b/rad/src/reducers/mod.rs
@@ -126,8 +126,10 @@ mod tests {
 
     #[test]
     fn test_reduce_average_median() {
-        let mut context = ReportContext::default();
-        context.active_wips = Some(current_active_wips());
+        let mut context = ReportContext {
+            active_wips: Some(current_active_wips()),
+            ..Default::default()
+        };
         let input = &RadonArray::from(vec![
             RadonFloat::from(1f64).into(),
             RadonFloat::from(2f64).into(),
@@ -143,8 +145,10 @@ mod tests {
     #[test]
     fn test_reduce_average_median_tapi_activation() {
         let mut active_wips = current_active_wips();
-        let mut context = ReportContext::default();
-        context.active_wips = Some(active_wips.clone());
+        let mut context = ReportContext {
+            active_wips: Some(active_wips.clone()),
+            ..Default::default()
+        };
         let input = &RadonArray::from(vec![
             RadonFloat::from(1f64).into(),
             RadonFloat::from(2f64).into(),

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -269,8 +269,10 @@ mod tests {
 
     #[test]
     fn test_operate_reduce_average_median() {
-        let mut context = ReportContext::default();
-        context.active_wips = Some(current_active_wips());
+        let mut context = ReportContext {
+            active_wips: Some(current_active_wips()),
+            ..Default::default()
+        };
         let input = &RadonArray::from(vec![
             RadonFloat::from(1f64).into(),
             RadonFloat::from(2f64).into(),

--- a/validations/src/tests/mod.rs
+++ b/validations/src/tests/mod.rs
@@ -7655,11 +7655,12 @@ fn test_block_with_drpool_and_utxo_set<F: FnMut(&mut Block) -> bool>(
         ..BlockTransactions::default()
     };
 
-    let mut block_header = BlockHeader::default();
-    block_header.merkle_roots = BlockMerkleRoots::from_transactions(&txns);
-    block_header.beacon = block_beacon;
-    block_header.proof = BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap();
-
+    let block_header = BlockHeader {
+        merkle_roots: BlockMerkleRoots::from_transactions(&txns),
+        beacon: block_beacon,
+        proof: BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap(),
+        ..Default::default()
+    };
     let block_sig = sign_tx(PRIV_KEY_1, &block_header);
     let mut b = Block::new(block_header, block_sig, txns);
 
@@ -7930,11 +7931,12 @@ fn block_difficult_proof() {
         ..BlockTransactions::default()
     };
 
-    let mut block_header = BlockHeader::default();
-    block_header.merkle_roots = BlockMerkleRoots::from_transactions(&txns);
-    block_header.beacon = block_beacon;
-    block_header.proof = BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap();
-
+    let block_header = BlockHeader {
+        merkle_roots: BlockMerkleRoots::from_transactions(&txns),
+        beacon: block_beacon,
+        proof: BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap(),
+        ..Default::default()
+    };
     let block_sig = sign_tx(PRIV_KEY_1, &block_header);
     let b = Block::new(block_header, block_sig, txns);
 
@@ -8631,11 +8633,12 @@ fn test_blocks_with_limits(
             checkpoint: current_epoch,
             hash_prev_block: last_block_hash,
         };
-        let mut block_header = BlockHeader::default();
-        block_header.merkle_roots = BlockMerkleRoots::from_transactions(&txns);
-        block_header.beacon = block_beacon;
-        block_header.proof = BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap();
-
+        let block_header = BlockHeader {
+            merkle_roots: BlockMerkleRoots::from_transactions(&txns),
+            beacon: block_beacon,
+            proof: BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap(),
+            ..Default::default()
+        };
         let block_sig = KeyedSignature::default();
         let mut b = Block::new(block_header, block_sig, txns);
 
@@ -9410,11 +9413,12 @@ fn validate_block_transactions_uses_block_number_in_utxo_diff() {
             ..BlockTransactions::default()
         };
 
-        let mut block_header = BlockHeader::default();
-        block_header.merkle_roots = BlockMerkleRoots::from_transactions(&txns);
-        block_header.beacon = block_beacon;
-        block_header.proof = BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap();
-
+        let block_header = BlockHeader {
+            merkle_roots: BlockMerkleRoots::from_transactions(&txns),
+            beacon: block_beacon,
+            proof: BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap(),
+            ..Default::default()
+        };
         let block_sig = sign_tx(PRIV_KEY_1, &block_header);
         let b = Block::new(block_header, block_sig, txns);
         let mut signatures_to_verify = vec![];
@@ -9573,11 +9577,12 @@ fn validate_commit_transactions_included_in_utxo_diff() {
 
         txns.commit_txns.push(c_tx);
 
-        let mut block_header = BlockHeader::default();
-        block_header.merkle_roots = BlockMerkleRoots::from_transactions(&txns);
-        block_header.beacon = block_beacon;
-        block_header.proof = BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap();
-
+        let block_header = BlockHeader {
+            merkle_roots: BlockMerkleRoots::from_transactions(&txns),
+            beacon: block_beacon,
+            proof: BlockEligibilityClaim::create(vrf, &secret_key, vrf_input).unwrap(),
+            ..Default::default()
+        };
         let block_sig = sign_tx(PRIV_KEY_1, &block_header);
         let b = Block::new(block_header, block_sig, txns);
         let mut signatures_to_verify = vec![];


### PR DESCRIPTION
That lint was temporarily ignored because of false positives (see #1803), but these false positives have been fixed since then.

(except in one case when using ChainManager, where I add an `#[allow(clippy::field_reassign_with_default)]`)