### PR TITLE
fix(node): do not consolidate genesis block twice during resync

### DIFF
--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -361,7 +361,8 @@ impl ChainManager {
         .and_then(|(), act, ctx| {
             log::info!("Successfully persisted empty chain state into storage");
             act.update_state_machine(StateMachine::WaitingConsensus, ctx);
-            act.initialize_from_storage_fut()
+
+            act.initialize_from_storage_fut(true)
         });
 
         Box::pin(fut)


### PR DESCRIPTION
Currently the rewind command is broken because the genesis block is consolidated twice, resulting in error "UTXO did already exist". This pull request fixes it.