### PR TITLE
Use global secp256k1 context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3865,9 +3865,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "secp256k1"
-version = "0.20.3"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
+checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
 dependencies = [
  "secp256k1-sys",
  "serde",
@@ -3875,9 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957da2573cde917463ece3570eab4a0b3f19de6f1646cde62e6fd3868f566036"
+checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3865,9 +3865,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "secp256k1"
-version = "0.22.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26947345339603ae8395f68e2f3d85a6b0a8ddfe6315818e80b8504415099db0"
+checksum = "b7649a0b3ffb32636e60c7ce0d70511eda9c52c658cd0634e194d5a19943aeff"
 dependencies = [
  "secp256k1-sys",
  "serde",
@@ -3875,9 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
+checksum = "7058dc8eaf3f2810d7828680320acda0b25a288f6d288e19278e249bbf74226b"
 dependencies = [
  "cc",
 ]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,7 +22,7 @@ hmac = "0.7.1"
 memzero = "0.1.0"
 rand = "0.7.3"
 ring = "0.16.11"
-secp256k1 = "0.22.1"
+secp256k1 = { version = "0.22.1", features = ["global-context"] }
 serde = { version = "1.0.104", optional = true }
 sha2 = "0.8.1"
 tiny-bip39 = "0.7.0"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,7 +22,7 @@ hmac = "0.7.1"
 memzero = "0.1.0"
 rand = "0.7.3"
 ring = "0.16.11"
-secp256k1 = "0.20.3"
+secp256k1 = "0.22.1"
 serde = { version = "1.0.104", optional = true }
 sha2 = "0.8.1"
 tiny-bip39 = "0.7.0"

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -22,7 +22,7 @@ hmac = "0.7.1"
 memzero = "0.1.0"
 rand = "0.7.3"
 ring = "0.16.11"
-secp256k1 = { version = "0.22.1", features = ["global-context"] }
+secp256k1 = { version = "0.24.0", features = ["global-context"] }
 serde = { version = "1.0.104", optional = true }
 sha2 = "0.8.1"
 tiny-bip39 = "0.7.0"

--- a/crypto/src/key.rs
+++ b/crypto/src/key.rs
@@ -19,7 +19,7 @@ use bech32::{FromBase32, ToBase32 as _};
 use byteorder::{BigEndian, ReadBytesExt as _};
 use failure::Fail;
 use hmac::{Hmac, Mac};
-use secp256k1::{PublicKey, SecretKey};
+use secp256k1::{PublicKey, Scalar, SecretKey};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -300,8 +300,8 @@ impl ExtendedSK {
 
         let (chain_code, mut secret_key) = get_chain_code_and_secret(&index_bytes, hmac512)?;
 
-        secret_key
-            .add_assign(&self.secret_key[..])
+        secret_key = secret_key
+            .add_tweak(&Scalar::from(self.secret_key))
             .map_err(KeyDerivationError::Secp256k1Error)?;
 
         Ok(ExtendedSK {

--- a/crypto/src/signature.rs
+++ b/crypto/src/signature.rs
@@ -4,7 +4,7 @@ use crate::key::CryptoEngine;
 use secp256k1::{Error, Message, SecretKey};
 
 /// Signature
-pub type Signature = secp256k1::Signature;
+pub type Signature = secp256k1::ecdsa::Signature;
 
 /// PublicKey
 pub type PublicKey = secp256k1::PublicKey;
@@ -15,7 +15,7 @@ pub type PublicKey = secp256k1::PublicKey;
 pub fn sign(secp: &CryptoEngine, secret_key: SecretKey, data: &[u8]) -> Result<Signature, Error> {
     let msg = Message::from_slice(data)?;
 
-    Ok(secp.sign(&msg, &secret_key))
+    Ok(secp.sign_ecdsa(&msg, &secret_key))
 }
 /// Verify signature with a provided public key.
 /// - Returns an Error if data is not a 32-byte array
@@ -27,14 +27,14 @@ pub fn verify(
 ) -> Result<(), Error> {
     let msg = Message::from_slice(data)?;
 
-    secp.verify(&msg, sig, public_key)
+    secp.verify_ecdsa(&msg, sig, public_key)
 }
 
 #[cfg(test)]
 mod tests {
     use crate::hash::{calculate_sha256, Sha256};
     use crate::signature::{sign, verify};
-    use secp256k1::{PublicKey, Secp256k1, SecretKey, Signature};
+    use secp256k1::{ecdsa::Signature, PublicKey, Secp256k1, SecretKey};
 
     #[test]
     fn test_sign_and_verify() {

--- a/data_structures/src/chain/mod.rs
+++ b/data_structures/src/chain/mod.rs
@@ -26,8 +26,8 @@ use witnet_crypto::{
     key::ExtendedSK,
     merkle::merkle_tree_root as crypto_merkle_tree_root,
     secp256k1::{
-        PublicKey as Secp256k1_PublicKey, SecretKey as Secp256k1_SecretKey,
-        Signature as Secp256k1_Signature,
+        ecdsa::Signature as Secp256k1_Signature, PublicKey as Secp256k1_PublicKey,
+        SecretKey as Secp256k1_SecretKey,
     },
 };
 use witnet_protected::Protected;
@@ -4397,8 +4397,8 @@ mod tests {
     fn secp256k1_from_into_secpk256k1_signatures() {
         use crate::chain::Secp256k1Signature;
         use witnet_crypto::secp256k1::{
-            Message as Secp256k1_Message, Secp256k1, SecretKey as Secp256k1_SecretKey,
-            Signature as Secp256k1_Signature,
+            ecdsa::Signature as Secp256k1_Signature, Message as Secp256k1_Message, Secp256k1,
+            SecretKey as Secp256k1_SecretKey,
         };
 
         let data = [0xab; 32];
@@ -4406,7 +4406,7 @@ mod tests {
         let secret_key =
             Secp256k1_SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
         let msg = Secp256k1_Message::from_slice(&data).unwrap();
-        let signature = secp.sign(&msg, &secret_key);
+        let signature = secp.sign_ecdsa(&msg, &secret_key);
 
         let witnet_signature = Secp256k1Signature::from(signature);
         let signature_into: Secp256k1_Signature = witnet_signature.try_into().unwrap();
@@ -4418,8 +4418,8 @@ mod tests {
     fn secp256k1_from_into_signatures() {
         use crate::chain::Signature;
         use witnet_crypto::secp256k1::{
-            Message as Secp256k1_Message, Secp256k1, SecretKey as Secp256k1_SecretKey,
-            Signature as Secp256k1_Signature,
+            ecdsa::Signature as Secp256k1_Signature, Message as Secp256k1_Message, Secp256k1,
+            SecretKey as Secp256k1_SecretKey,
         };
 
         let data = [0xab; 32];
@@ -4427,7 +4427,7 @@ mod tests {
         let secret_key =
             Secp256k1_SecretKey::from_slice(&[0xcd; 32]).expect("32 bytes, within curve order");
         let msg = Secp256k1_Message::from_slice(&data).unwrap();
-        let signature = secp.sign(&msg, &secret_key);
+        let signature = secp.sign_ecdsa(&msg, &secret_key);
 
         let witnet_signature = Signature::from(signature);
         let signature_into: Secp256k1_Signature = witnet_signature.try_into().unwrap();

--- a/data_structures/src/chain/mod.rs
+++ b/data_structures/src/chain/mod.rs
@@ -4013,9 +4013,7 @@ pub fn block_example() -> Block {
 mod tests {
     use witnet_crypto::{
         merkle::{merkle_tree_root, InclusionProof},
-        secp256k1::{
-            PublicKey as Secp256k1_PublicKey, Secp256k1, SecretKey as Secp256k1_SecretKey,
-        },
+        secp256k1::{PublicKey as Secp256k1_PublicKey, SecretKey as Secp256k1_SecretKey},
         signature::sign,
     };
 
@@ -6460,13 +6458,12 @@ mod tests {
     fn sign_tx<H: Hashable>(mk: [u8; 32], tx: &H) -> KeyedSignature {
         let Hash::SHA256(data) = tx.hash();
 
-        let secp = &Secp256k1::new();
         let secret_key =
             Secp256k1_SecretKey::from_slice(&mk).expect("32 bytes, within curve order");
-        let public_key = Secp256k1_PublicKey::from_secret_key(secp, &secret_key);
+        let public_key = Secp256k1_PublicKey::from_secret_key_global(&secret_key);
         let public_key = PublicKey::from(public_key);
 
-        let signature = sign(secp, secret_key, &data).unwrap();
+        let signature = sign(secret_key, &data).unwrap();
 
         KeyedSignature {
             signature: Signature::from(signature),

--- a/node/src/actors/chain_manager/actor.rs
+++ b/node/src/actors/chain_manager/actor.rs
@@ -11,7 +11,6 @@ use crate::{
     },
     config_mngr, signature_mngr, storage_mngr,
 };
-use witnet_crypto::key::CryptoEngine;
 use witnet_data_structures::{
     chain::{
         ChainInfo, ChainState, CheckpointBeacon, CheckpointVRF, GenesisBlockInfo, PublicKeyHash,
@@ -52,8 +51,6 @@ impl Actor for ChainManager {
                 ctx.stop();
             })
             .ok();
-
-        self.secp = Some(CryptoEngine::new());
     }
 }
 

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -147,10 +147,7 @@ impl Handler<EpochNotification<EveryEpochPayload>> for ChainManager {
                         reputation_engine: Some(_),
                         ..
                     } => {
-                        if self.epoch_constants.is_none()
-                            || self.vrf_ctx.is_none()
-                            || self.secp.is_none()
-                        {
+                        if self.epoch_constants.is_none() || self.vrf_ctx.is_none() {
                             log::error!("{}", ChainManagerError::ChainNotReady);
                             return;
                         }

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -17,7 +17,7 @@ use prettytable::{cell, row, Table};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use witnet_crypto::{
     hash::calculate_sha256,
-    key::{CryptoEngine, ExtendedPK, ExtendedSK},
+    key::{ExtendedPK, ExtendedSK},
 };
 use witnet_data_structures::{
     chain::{
@@ -837,7 +837,7 @@ pub fn master_key_export(
         Ok(private_key_slip32) => {
             let private_key_slip32: String = private_key_slip32;
             let private_key = ExtendedSK::from_slip32(&private_key_slip32).unwrap().0;
-            let public_key = ExtendedPK::from_secret_key(&CryptoEngine::new(), &private_key);
+            let public_key = ExtendedPK::from_secret_key(&private_key);
             let pkh = PublicKey::from(public_key.key).pkh();
             if let Some(base_path) = write_to_path {
                 let path = base_path.join(format!("private_key_{}.txt", pkh));
@@ -1912,9 +1912,8 @@ mod tests {
 
     #[test]
     fn verify_claim_output() {
-        use witnet_crypto::{
-            secp256k1::Secp256k1,
-            signature::{verify, PublicKey as SecpPublicKey, Signature as SecpSignature},
+        use witnet_crypto::signature::{
+            verify, PublicKey as SecpPublicKey, Signature as SecpSignature,
         };
 
         let json_output = r#"
@@ -1939,7 +1938,6 @@ mod tests {
         assert_eq!(address, signature_with_data.address);
 
         // Required fields for Secpk1 signature verification
-        let secp = Secp256k1::new();
         let signed_data = calculate_sha256(signature_with_data.identifier.as_bytes());
         let public_key =
             SecpPublicKey::from_slice(&hex::decode(signature_with_data.public_key).unwrap())
@@ -1948,6 +1946,6 @@ mod tests {
             SecpSignature::from_compact(&hex::decode(signature_with_data.signature).unwrap())
                 .unwrap();
 
-        assert!(verify(&secp, &public_key, signed_data.as_ref(), &signature).is_ok());
+        assert!(verify(&public_key, signed_data.as_ref(), &signature).is_ok());
     }
 }

--- a/validations/src/tests/mod.rs
+++ b/validations/src/tests/mod.rs
@@ -7,8 +7,7 @@ use std::{
 use itertools::Itertools;
 
 use witnet_crypto::{
-    key::CryptoEngine,
-    secp256k1::{PublicKey as Secp256k1_PublicKey, Secp256k1, SecretKey as Secp256k1_SecretKey},
+    secp256k1::{PublicKey as Secp256k1_PublicKey, SecretKey as Secp256k1_SecretKey},
     signature::sign,
 };
 use witnet_data_structures::{
@@ -68,21 +67,19 @@ fn active_wips_from_mainnet(block_epoch: Epoch) -> ActiveWips {
 fn verify_signatures_test(
     signatures_to_verify: Vec<SignaturesToVerify>,
 ) -> Result<(), failure::Error> {
-    let secp = &CryptoEngine::new();
     let vrf = &mut VrfCtx::secp256k1().unwrap();
 
-    verify_signatures(signatures_to_verify, vrf, secp).map(|_| ())
+    verify_signatures(signatures_to_verify, vrf).map(|_| ())
 }
 
 fn sign_tx<H: Hashable>(mk: [u8; 32], tx: &H) -> KeyedSignature {
     let Hash::SHA256(data) = tx.hash();
 
-    let secp = &Secp256k1::new();
     let secret_key = Secp256k1_SecretKey::from_slice(&mk).expect("32 bytes, within curve order");
-    let public_key = Secp256k1_PublicKey::from_secret_key(secp, &secret_key);
+    let public_key = Secp256k1_PublicKey::from_secret_key_global(&secret_key);
     let public_key = PublicKey::from(public_key);
 
-    let signature = sign(secp, secret_key, &data).unwrap();
+    let signature = sign(secret_key, &data).unwrap();
 
     KeyedSignature {
         signature: Signature::from(signature),

--- a/validations/src/tests/mod.rs
+++ b/validations/src/tests/mod.rs
@@ -565,7 +565,7 @@ where
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::VerifyTransactionSignatureFail {
             hash,
-            msg: "secp: signature failed verification".to_string(),
+            msg: "signature failed verification".to_string(),
         },
     );
 
@@ -578,7 +578,7 @@ where
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::VerifyTransactionSignatureFail {
             hash,
-            // A "secp: signature failed verification" msg would also be correct here
+            // A "signature failed verification" msg would also be correct here
             msg: TransactionError::PublicKeyHashMismatch {
                 expected_pkh: MY_PKH_1.parse().unwrap(),
                 signature_pkh,
@@ -3051,7 +3051,7 @@ fn commitment_signatures() {
         x.unwrap_err().downcast::<TransactionError>().unwrap(),
         TransactionError::VerifyTransactionSignatureFail {
             hash,
-            msg: "secp: signature failed verification".to_string(),
+            msg: "signature failed verification".to_string(),
         },
     );
 

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -8,7 +8,6 @@ use std::{
 use itertools::Itertools;
 use witnet_crypto::{
     hash::{calculate_sha256, Sha256},
-    key::CryptoEngine,
     merkle::{merkle_tree_root as crypto_merkle_tree_root, ProgressiveMerkleTree},
     signature::{verify, PublicKey, Signature},
 };
@@ -2147,7 +2146,6 @@ pub fn compare_block_candidates(
 pub fn verify_signatures(
     signatures_to_verify: Vec<SignaturesToVerify>,
     vrf: &mut VrfCtx,
-    secp: &CryptoEngine,
 ) -> Result<Vec<Hash>, failure::Error> {
     let mut vrf_hashes = vec![];
     for x in signatures_to_verify {
@@ -2190,7 +2188,7 @@ pub fn verify_signatures(
                 public_key,
                 data,
                 signature,
-            } => verify(secp, &public_key, &data, &signature).map_err(|e| {
+            } => verify(&public_key, &data, &signature).map_err(|e| {
                 TransactionError::VerifyTransactionSignatureFail {
                     hash: {
                         let mut sha256 = [0; 32];
@@ -2204,7 +2202,7 @@ pub fn verify_signatures(
                 public_key,
                 data,
                 signature,
-            } => verify(secp, &public_key, &data, &signature).map_err(|_e| {
+            } => verify(&public_key, &data, &signature).map_err(|_e| {
                 BlockError::VerifySignatureFail {
                     hash: {
                         let mut sha256 = [0; 32];
@@ -2218,7 +2216,6 @@ pub fn verify_signatures(
                 let secp_message = superblock_vote.secp256k1_signature_message();
                 let secp_message_hash = calculate_sha256(&secp_message);
                 verify(
-                    secp,
                     &superblock_vote
                         .secp256k1_signature
                         .public_key

--- a/wallet/src/account.rs
+++ b/wallet/src/account.rs
@@ -1,5 +1,5 @@
 use crate::{constants, types};
-use witnet_crypto::key::{CryptoEngine, ExtendedSK, KeyPath};
+use witnet_crypto::key::{ExtendedSK, KeyPath};
 
 /// Result type for accounts-related operations that can fail.
 pub type Result<T> = std::result::Result<T, failure::Error>;
@@ -20,23 +20,19 @@ pub fn account_keypath(index: u32) -> KeyPath {
 ///
 /// The account index is kind of the account id and indicates in which
 /// branch the HD-Wallet derivation tree these account keys are.
-pub fn gen_account(
-    engine: &CryptoEngine,
-    account_index: u32,
-    master_key: &ExtendedSK,
-) -> Result<types::Account> {
+pub fn gen_account(account_index: u32, master_key: &ExtendedSK) -> Result<types::Account> {
     let account_keypath = account_keypath(account_index);
-    let account_key = master_key.derive(engine, &account_keypath)?;
+    let account_key = master_key.derive(&account_keypath)?;
 
     let external = {
         let keypath = KeyPath::default().index(0);
 
-        account_key.derive(engine, &keypath)?
+        account_key.derive(&keypath)?
     };
     let internal = {
         let keypath = KeyPath::default().index(1);
 
-        account_key.derive(engine, &keypath)?
+        account_key.derive(&keypath)?
     };
 
     let account = types::Account {

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -9,10 +9,7 @@ use crate::{
     model, params,
     types::{ChainEntry, DynamicSink, GetBlockChainParams},
 };
-use witnet_crypto::{
-    key::{CryptoEngine, ExtendedSK},
-    mnemonic,
-};
+use witnet_crypto::{key::ExtendedSK, mnemonic};
 use witnet_data_structures::{
     chain::{
         Block, CheckpointBeacon, DataRequestInfo, Hashable, OutputPointer, RADRequest,
@@ -41,7 +38,6 @@ impl Worker {
         node: params::NodeParams,
         params: params::Params,
     ) -> Addr<Self> {
-        let engine = CryptoEngine::new();
         let wallets = Arc::new(repository::Wallets::new(db::PlainDb::new(db.clone())));
 
         SyncArbiter::start(concurrency, move || Self {
@@ -50,7 +46,6 @@ impl Worker {
             node: node.clone(),
             params: params.clone(),
             rng: rand::rngs::OsRng,
-            engine: engine.clone(),
         })
     }
 
@@ -138,8 +133,7 @@ impl Worker {
                     self.params.id_hash_iterations,
                 );
                 let default_account_index = 0;
-                let default_account =
-                    account::gen_account(&self.engine, default_account_index, &master_key)?;
+                let default_account = account::gen_account(default_account_index, &master_key)?;
                 (id, default_account, Some(master_key))
             }
         };
@@ -338,7 +332,6 @@ impl Worker {
             session_id.clone(),
             wallet_db,
             self.params.clone(),
-            self.engine.clone(),
         )?);
         let data = wallet.public_data()?;
 

--- a/wallet/src/actors/worker/mod.rs
+++ b/wallet/src/actors/worker/mod.rs
@@ -11,7 +11,6 @@ pub mod methods;
 
 pub use error::*;
 pub use handlers::*;
-use witnet_crypto::key::CryptoEngine;
 
 pub type Result<T> = result::Result<T, Error>;
 
@@ -20,7 +19,6 @@ pub struct Worker {
     wallets: Arc<repository::Wallets<db::PlainDb>>,
     node: params::NodeParams,
     params: params::Params,
-    engine: CryptoEngine,
     rng: rand::rngs::OsRng,
 }
 

--- a/wallet/src/repository/wallet/tests/factories.rs
+++ b/wallet/src/repository/wallet/tests/factories.rs
@@ -80,10 +80,8 @@ fn wallet_inner(
         &source,
     )
     .unwrap();
-    let engine = CryptoEngine::new();
     let default_account_index = 0;
-    let default_account =
-        account::gen_account(&engine, default_account_index, &master_key).unwrap();
+    let default_account = account::gen_account(default_account_index, &master_key).unwrap();
 
     let mut rng = rand::rngs::OsRng;
     let salt = crypto::salt(&mut rng, params.db_salt_length);
@@ -118,7 +116,7 @@ fn wallet_inner(
         .unwrap();
 
     let session_id = types::SessionId::from(String::from(id));
-    let wallet = Wallet::unlock(id, session_id, db.clone(), params, engine).unwrap();
+    let wallet = Wallet::unlock(id, session_id, db.clone(), params).unwrap();
 
     (wallet, db)
 }


### PR DESCRIPTION
This avoids passing a `&Secp256k1` argument to every function that needs to validate signatures.