### PR TITLE
feat(nodestats): add counters to monitor failed data requests

### DIFF
--- a/data_structures/src/chain.rs
+++ b/data_structures/src/chain.rs
@@ -3195,8 +3195,12 @@ pub struct NodeStats {
     pub block_proposed_count: u32,
     /// Number of blocks included in the block chain
     pub block_mined_count: u32,
+    /// Number of times we could not solve a data request because the collateral requirement was too high
+    pub dr_insufficient_collateral_count: u32,
     /// Number of times we were eligible to participate in a Data Request
     pub dr_eligibility_count: u32,
+    /// Number of times we were eligible to participate in a Data Request but all our collateral was locked
+    pub dr_all_collateral_locked_count: u32,
     /// Number of proposed commits
     pub commits_proposed_count: u32,
     /// Number of commits included in a data request

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -393,6 +393,7 @@ impl ChainManager {
                 block_number_limit,
             ) {
                 log::debug!("Mining data request: Insufficient collateral, the data request need {} mature wits", Wit::from_nanowits(collateral_amount));
+                self.chain_state.node_stats.dr_insufficient_collateral_count += 1;
                 continue;
             }
 
@@ -520,6 +521,7 @@ impl ChainManager {
                                 available_balance,
                                 required_collateral,
                             );
+                            act.chain_state.node_stats.dr_all_collateral_locked_count += 1;
                             // Decrease the retrieval limit hoping that some other, cheaper,
                             // data request can be resolved instead
                             cloned_retrieval_count2.fetch_sub(added_retrieval_count, atomic::Ordering::Relaxed);

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -1212,13 +1212,17 @@ pub fn get_node_stats(addr: SocketAddr) -> Result<(), failure::Error> {
      - Proposed blocks: {}\n\
      - Blocks included in the block chain: {}\n\
     Data Request mining stats:\n\
+     - Times with insuffiencent collateral to mine a data request: {}\n\
      - Times with eligibility to mine a data request: {}\n\
+     - Times with no available collateral to mine a data request: {}\n\
      - Proposed commits: {}\n\
      - Accepted commits: {}\n\
      - Slashed commits: {}",
         node_stats.block_proposed_count,
         node_stats.block_mined_count,
+        node_stats.dr_insufficient_collateral_count,
         node_stats.dr_eligibility_count,
+        node_stats.dr_all_collateral_locked_count,
         node_stats.commits_proposed_count,
         node_stats.commits_count,
         node_stats.slashed_count


### PR DESCRIPTION
This is a first push towards adding some extra counters that can be used to monitor why your node fails to solve data requests. Currently this info is printed to the standard output, but that's not too useful for the average node operator. This was discussed [here](https://discord.com/channels/492453503390842880/492453503390842882/979090799264432198) at the moment of the Witnet node monitor demo on Discord.

This PR will fail the tests because it modifies NodeStats and thus the ChainState. However, I don't quite know how to create migrations for the ChainState, but I still wanted to get this out for comments. Any hints?