### PR TITLE
feat(node): more rewind params

### DIFF
--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -378,10 +378,27 @@ impl Message for IsConfirmedBlock {
     type Result = Result<bool, failure::Error>;
 }
 
-/// Rewind
+/// Additional configuration for the rewind method
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+pub struct RewindMode {
+    /// Validate block and transaction signatures
+    #[serde(default)]
+    pub validate_signatures: bool,
+    /// Write all the blocks, transactions, and data request reports to storage, regardless of
+    /// whether they already exist or not
+    #[serde(default)]
+    pub write_items_to_storage: bool,
+}
+
+/// Rewind chain state back to some epoch
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct Rewind {
-    /// Epoch
-    pub epoch: u32,
+    /// Epoch of the last block that will be consolidated by the rewind method
+    #[serde(default)]
+    pub epoch: Option<Epoch>,
+    /// Additional configuration for the rewind method
+    #[serde(default)]
+    pub mode: RewindMode,
 }
 
 impl Message for Rewind {


### PR DESCRIPTION
Add some flags to the rewind JSON-RPC method to allow manually fixing storage with missing items, issue #2102 

Command to process all the blocks again to fix missing entries in storage:

```json
{"jsonrpc":"2.0","id":"1","method":"rewind","params":{"mode":{"write_items_to_storage": true}}}
```

The original use case of trying to recover a forked node still works with the same syntax:

```json
{"jsonrpc":"2.0","id":"1","method":"rewind","params":[10000]}
```

The main blocker is that if there is actually a missing block, the rewind process stops and the node enters the normal synchronization process which is much slower than a rewind. But eventually it fixes the issue, it is just very slow.

Marking as a draft while I check if I can implement some "resume" functionality to avoid the slow synchronization.