### PR TITLE
feat: implement burning of slashed collateral (WIP0023)

### DIFF
--- a/data_structures/src/data_request.rs
+++ b/data_structures/src/data_request.rs
@@ -483,6 +483,7 @@ pub fn calculate_witness_reward(
     errors_count: usize,
     reward: u64,
     collateral: u64,
+    wip0023_active: bool,
 ) -> (u64, u64) {
     let honests_count = (commits_count - liars_count - errors_count) as u64;
 
@@ -495,12 +496,17 @@ pub fn calculate_witness_reward(
         let slashed_collateral_reward = collateral * liars_count / honests_count;
         let slashed_collateral_remainder = (collateral * liars_count) % honests_count;
 
-        (
-            reward + collateral + slashed_collateral_reward,
-            slashed_collateral_remainder,
-        )
+        if wip0023_active {
+            (reward + collateral, 0)
+        } else {
+            (
+                reward + collateral + slashed_collateral_reward,
+                slashed_collateral_remainder,
+            )
+        }
     }
 }
+
 /// Count how many commitments will be considered "errors" and how many will
 /// be considered "lies". This tells apart the case in which the committed value was
 /// an error from any other type of out-of-consensus situation, like non-reveals.
@@ -571,6 +577,7 @@ where
                 errors_count,
                 dr_output.witness_reward,
                 collateral,
+                active_wips.wip0023(),
             )
         } else {
             calculate_witness_reward_before_second_hard_fork(

--- a/data_structures/src/mainnet_validations.rs
+++ b/data_structures/src/mainnet_validations.rs
@@ -48,6 +48,7 @@ pub fn wip_info() -> HashMap<String, Epoch> {
     active_wips.insert("WIP0014-0016".to_string(), 549141);
     active_wips.insert("WIP0017-0018-0019".to_string(), 683541);
     active_wips.insert("WIP0020-0021".to_string(), 1059861);
+    // active_wips.insert("WIP0023".to_string(), 1441920 + 26880 + 21);
 
     active_wips
 }
@@ -61,6 +62,7 @@ fn test_wip_info() -> HashMap<String, Epoch> {
     active_wips.insert("WIP0014-0016".to_string(), 0);
     active_wips.insert("WIP0017-0018-0019".to_string(), 0);
     active_wips.insert("WIP0020-0021".to_string(), 0);
+    // active_wips.insert("WIP0023".to_string(), 0);
 
     active_wips
 }
@@ -137,18 +139,18 @@ impl TapiEngine {
                 }
 
                 // Hardcoded information about WIPs in vote processing
-                let bit = 2;
-                let wip_0020 = BitVotesCounter {
+                let bit = 4;
+                let wip_0023 = BitVotesCounter {
                     votes: 0,
                     period: 26880,
-                    wip: "WIP0020-0021".to_string(),
+                    wip: "WIP0023".to_string(),
                     // Start signaling on
-                    // 5 April 2022 @ 9:00:00 UTC
-                    init: 1032960,
+                    // 14 October 2022 @ 9:00:00 UTC
+                    init: 1441920,
                     end: u32::MAX,
                     bit,
                 };
-                voting_wips[bit] = Some(wip_0020);
+                voting_wips[bit] = Some(wip_0023);
             }
             Environment::Testnet | Environment::Development => {
                 // In non-mainnet chains, all the WIPs that are active in mainnet are considered
@@ -158,18 +160,18 @@ impl TapiEngine {
                 }
 
                 // Hardcoded information about WIPs in vote processing
-                let bit = 2;
-                let wip_0020 = BitVotesCounter {
+                let bit = 4;
+                let wip_0023 = BitVotesCounter {
                     votes: 0,
                     period: 50,
-                    wip: "WIP0020-0021".to_string(),
+                    wip: "WIP0023".to_string(),
                     // Start voting at
                     // TODO: insert date here
                     init: 0,
                     end: u32::MAX,
                     bit,
                 };
-                voting_wips[bit] = Some(wip_0020);
+                voting_wips[bit] = Some(wip_0023);
             }
         };
 
@@ -444,6 +446,10 @@ impl ActiveWips {
     pub fn wip0021(&self) -> bool {
         self.wip_active("WIP0020-0021")
     }
+
+    pub fn wip0023(&self) -> bool {
+        self.wip_active("WIP0023")
+    }
 }
 
 #[cfg(test)]
@@ -716,9 +722,9 @@ mod tests {
         let mut t = TapiEngine::default();
 
         let (epoch, old_wips) = t.initialize_wip_information(Environment::Mainnet);
-        // The first block whose vote must be counted is the one from WIP0021
-        let init_epoch_wip002021 = 1032960;
-        assert_eq!(epoch, init_epoch_wip002021);
+        // The first block whose vote must be counted is the one from WIP0023
+        let init_epoch_wip0023 = 1441920;
+        assert_eq!(epoch, init_epoch_wip0023);
         // The TapiEngine was just created, there list of old_wips must be empty
         assert_eq!(old_wips, HashSet::new());
         // The list of active WIPs should match those defined in `wip_info`
@@ -730,10 +736,10 @@ mod tests {
 
         // Test initialize_wip_information with a non-empty TapiEngine
         let (epoch, old_wips) = t.initialize_wip_information(Environment::Mainnet);
-        // WIP0021 is already included and it won't be updated
-        let name_wip002021 = "WIP0020-0021".to_string();
+        // WIP0023 is already included and it won't be updated
+        let name_wip0023 = "WIP0023".to_string();
         let mut hs = HashSet::new();
-        hs.insert(name_wip002021);
+        hs.insert(name_wip0023);
         assert_eq!(old_wips, hs);
 
         // There is no new WIPs to update so we obtain the max value

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -212,6 +212,11 @@ impl ChainManager {
 
                 let tapi_version = act.tapi_signals_mask(current_epoch);
 
+                let active_wips = ActiveWips {
+                    active_wips: act.chain_state.tapi_engine.wip_activation.clone(),
+                    block_epoch: current_epoch,
+                };
+
                 // Build the block using the supplied beacon and eligibility proof
                 let (block_header, txns) = build_block(
                     (
@@ -234,6 +239,7 @@ impl ChainManager {
                     initial_block_reward,
                     halving_period,
                     tapi_version,
+                    &active_wips,
                 );
 
                 // Sign the block hash
@@ -806,6 +812,7 @@ pub fn build_block(
     initial_block_reward: u64,
     halving_period: u32,
     tapi_signals: u32,
+    active_wips: &ActiveWips,
 ) -> (BlockHeader, BlockTransactions) {
     let (transactions_pool, unspent_outputs_pool, dr_pool) = pools_ref;
     let epoch = beacon.checkpoint;
@@ -879,6 +886,7 @@ pub fn build_block(
                     errors_count,
                     dr_state.data_request.witness_reward,
                     collateral,
+                    active_wips.wip0023(),
                 )
             } else {
                 calculate_witness_reward_before_second_hard_fork(
@@ -1009,6 +1017,7 @@ pub fn build_block(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::convert::TryInto;
 
     use witnet_crypto::secp256k1::{
@@ -1049,6 +1058,11 @@ mod tests {
         let block_number = 1;
         let collateral_minimum = 1_000_000_000;
 
+        let active_wips: ActiveWips = ActiveWips {
+            active_wips: HashMap::default(),
+            block_epoch: 0,
+        };
+
         // Build empty block (because max weight is zero)
         let (block_header, txns) = build_block(
             (&mut transaction_pool, &unspent_outputs_pool, &dr_pool),
@@ -1067,6 +1081,7 @@ mod tests {
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
             0,
+            &active_wips,
         );
         let block = Block::new(block_header, KeyedSignature::default(), txns);
 
@@ -1118,6 +1133,11 @@ mod tests {
         let block_number = 1;
         let collateral_minimum = 1_000_000_000;
 
+        let active_wips: ActiveWips = ActiveWips {
+            active_wips: HashMap::default(),
+            block_epoch: 0,
+        };
+
         // Build empty block (because max weight is zero)
 
         let (block_header, txns) = build_block(
@@ -1137,6 +1157,7 @@ mod tests {
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
             0,
+            &active_wips,
         );
 
         // Create a KeyedSignature
@@ -1241,6 +1262,11 @@ mod tests {
         let block_number = 1;
         let collateral_minimum = 1_000_000_000;
 
+        let active_wips: ActiveWips = ActiveWips {
+            active_wips: HashMap::default(),
+            block_epoch: 0,
+        };
+
         // Build block with
 
         let (block_header, txns) = build_block(
@@ -1260,6 +1286,7 @@ mod tests {
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
             0,
+            &active_wips,
         );
         let block = Block::new(block_header, KeyedSignature::default(), txns);
 
@@ -1336,6 +1363,11 @@ mod tests {
         let block_number = 1;
         let collateral_minimum = 1_000_000_000;
 
+        let active_wips: ActiveWips = ActiveWips {
+            active_wips: HashMap::default(),
+            block_epoch: 0,
+        };
+
         // Build block with
 
         let (block_header, txns) = build_block(
@@ -1355,6 +1387,7 @@ mod tests {
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
             0,
+            &active_wips,
         );
         let block = Block::new(block_header, KeyedSignature::default(), txns);
 
@@ -1445,6 +1478,11 @@ mod tests {
         let block_number = 1;
         let collateral_minimum = 1_000_000_000;
 
+        let active_wips: ActiveWips = ActiveWips {
+            active_wips: HashMap::default(),
+            block_epoch: 0,
+        };
+
         // Build block with
 
         let (block_header, txns) = build_block(
@@ -1464,6 +1502,7 @@ mod tests {
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
             0,
+            &active_wips,
         );
         let block = Block::new(block_header, KeyedSignature::default(), txns);
 
@@ -1537,6 +1576,11 @@ mod tests {
         let block_number = 1;
         let collateral_minimum = 1_000_000_000;
 
+        let active_wips: ActiveWips = ActiveWips {
+            active_wips: HashMap::default(),
+            block_epoch: 0,
+        };
+
         // Build block with
 
         let (block_header, txns) = build_block(
@@ -1556,6 +1600,7 @@ mod tests {
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
             0,
+            &active_wips,
         );
         let block = Block::new(block_header, KeyedSignature::default(), txns);
 

--- a/node/src/actors/inventory_manager/handlers.rs
+++ b/node/src/actors/inventory_manager/handlers.rs
@@ -324,6 +324,7 @@ mod tests {
         actors::chain_manager::mining::build_block, config_mngr, storage_mngr,
         utils::test_actix_system,
     };
+    use std::collections::HashMap;
     use std::sync::Arc;
     use witnet_config::config::{Config, StorageBackend};
     use witnet_data_structures::{
@@ -332,6 +333,7 @@ mod tests {
             TransactionsPool, ValueTransferOutput,
         },
         data_request::DataRequestPool,
+        mainnet_validations::ActiveWips,
         transaction::{Transaction, VTTransaction, VTTransactionBody},
         utxo_pool::UnspentOutputsPool,
         vrf::BlockEligibilityClaim,
@@ -407,6 +409,11 @@ mod tests {
         let block_proof = BlockEligibilityClaim::default();
         let collateral_minimum = 1_000_000_000;
 
+        let active_wips: ActiveWips = ActiveWips {
+            active_wips: HashMap::default(),
+            block_epoch: 0,
+        };
+
         // Build block with
 
         let (block_header, txns) = build_block(
@@ -426,6 +433,7 @@ mod tests {
             INITIAL_BLOCK_REWARD,
             HALVING_PERIOD,
             0,
+            &active_wips,
         );
 
         Block::new(block_header, KeyedSignature::default(), txns)

--- a/validations/src/tests/mod.rs
+++ b/validations/src/tests/mod.rs
@@ -4404,12 +4404,14 @@ fn dr_pool_with_dr_in_tally_all_errors(
     let liars_count = liars_count + commits_count - reveals_count;
     // Calculate tally change assuming that the consensus will be error, and therefore errors will
     // be rewarded
+    let active_wips = current_active_wips();
     let (reward, _) = calculate_witness_reward(
         commits_count,
         liars_count,
         0,
         dr_output.witness_reward,
         ONE_WIT,
+        active_wips.wip0023(),
     );
 
     (
@@ -4519,12 +4521,14 @@ fn dr_pool_with_dr_in_tally_stage_generic(
     // To calculate witness reward we take into account than non-revealers are considered liars
     let liars_count = liars_count + commits_count - reveals_count;
     // Calculate witness reward
+    let active_wips = current_active_wips();
     let (reward, _) = calculate_witness_reward(
         commits_count,
         liars_count,
         errors_count,
         dr_output.witness_reward,
         ONE_WIT,
+        active_wips.wip0023(),
     );
 
     (
@@ -4756,7 +4760,13 @@ fn tally_invalid_consensus() {
     let dr_output = example_data_request_output(5, 200, 20);
     let (dr_pool, dr_pointer, rewarded, slashed, error_witnesses, _dr_pkh, change, reward) =
         dr_pool_with_dr_in_tally_stage(dr_output, 5, 4, 0, reveal_value, vec![]);
-    assert_eq!(reward, 200 + ONE_WIT + (ONE_WIT / 4));
+
+    let active_wips = current_active_wips();
+    if active_wips.wip0023() {
+        assert_eq!(reward, 200 + ONE_WIT);
+    } else {
+        assert_eq!(reward, 200 + ONE_WIT + (ONE_WIT / 4));
+    }
 
     // Tally value: integer(0)
     let tally_value = vec![0x00];
@@ -5145,7 +5155,13 @@ fn tally_valid() {
     let dr_output = example_data_request_output(5, 200, 20);
     let (dr_pool, dr_pointer, rewarded, slashed, error_witnesses, dr_pkh, change, reward) =
         dr_pool_with_dr_in_tally_stage(dr_output, 5, 4, 0, reveal_value, vec![]);
-    assert_eq!(reward, 200 + ONE_WIT + (ONE_WIT / 4));
+
+    let active_wips = current_active_wips();
+    if active_wips.wip0023() {
+        assert_eq!(reward, 200 + ONE_WIT);
+    } else {
+        assert_eq!(reward, 200 + ONE_WIT + (ONE_WIT / 4));
+    }
 
     // Tally value: integer(0)
     let tally_value = vec![0x00];
@@ -5199,7 +5215,13 @@ fn tally_too_many_outputs() {
     let dr_output = example_data_request_output(5, 200, 20);
     let (dr_pool, dr_pointer, rewarded, slashed, error_witnesses, dr_pkh, change, reward) =
         dr_pool_with_dr_in_tally_stage(dr_output, 5, 4, 0, reveal_value, vec![]);
-    assert_eq!(reward, 200 + ONE_WIT + (ONE_WIT / 4));
+
+    let active_wips = current_active_wips();
+    if active_wips.wip0023() {
+        assert_eq!(reward, 200 + ONE_WIT);
+    } else {
+        assert_eq!(reward, 200 + ONE_WIT + (ONE_WIT / 4));
+    }
 
     // Tally value: integer(0)
     let tally_value = vec![0x00];
@@ -5283,7 +5305,13 @@ fn tally_invalid_change() {
     let dr_output = example_data_request_output(5, 200, 20);
     let (dr_pool, dr_pointer, rewarded, slashed, error_witnesses, dr_pkh, change, reward) =
         dr_pool_with_dr_in_tally_stage(dr_output, 5, 4, 0, reveal_value, vec![]);
-    assert_eq!(reward, 200 + ONE_WIT + (ONE_WIT / 4));
+
+    let active_wips = current_active_wips();
+    if active_wips.wip0023() {
+        assert_eq!(reward, 200 + ONE_WIT);
+    } else {
+        assert_eq!(reward, 200 + ONE_WIT + (ONE_WIT / 4));
+    }
 
     // Tally value: integer(0)
     let tally_value = vec![0x00];
@@ -5512,7 +5540,13 @@ fn tally_valid_3_reveals_dr_liar() {
     let dr_output = example_data_request_output_with_mode_filter(3, 200, 20);
     let (dr_pool, dr_pointer, rewarded, slashed, error_witnesses, dr_pkh, change, reward) =
         dr_pool_with_dr_in_tally_stage_with_dr_liar(dr_output, 3, 3, 1, reveal_value, liar_value);
-    assert_eq!(reward, 200 + ONE_WIT + ONE_WIT / 2);
+
+    let active_wips = current_active_wips();
+    if active_wips.wip0023() {
+        assert_eq!(reward, 200 + ONE_WIT);
+    } else {
+        assert_eq!(reward, 200 + ONE_WIT + ONE_WIT / 2);
+    }
 
     // Tally value: integer(0)
     let tally_value = vec![0x00];
@@ -5559,7 +5593,13 @@ fn tally_valid_3_reveals_dr_liar_invalid() {
     let dr_output = example_data_request_output_with_mode_filter(3, 200, 20);
     let (dr_pool, dr_pointer, rewarded, slashed, error_witnesses, dr_pkh, _change, reward) =
         dr_pool_with_dr_in_tally_stage_with_dr_liar(dr_output, 3, 3, 1, reveal_value, liar_value);
-    assert_eq!(reward, 200 + ONE_WIT + ONE_WIT / 2);
+
+    let active_wips = current_active_wips();
+    if active_wips.wip0023() {
+        assert_eq!(reward, 200 + ONE_WIT);
+    } else {
+        assert_eq!(reward, 200 + ONE_WIT + ONE_WIT / 2);
+    }
 
     // Tally value: integer(0)
     let tally_value = vec![0x00];
@@ -5613,7 +5653,13 @@ fn tally_valid_5_reveals_1_liar_1_error() {
     let dr_output = example_data_request_output_with_mode_filter(5, 200, 20);
     let (dr_pool, dr_pointer, rewarded, slashed, error_witnesses, dr_pkh, change, reward) =
         dr_pool_with_dr_in_tally_stage_with_errors(dr_output, 5, 5, 1, 1, reveal_value, liar_value);
-    assert_eq!(reward, 200 + ONE_WIT + ONE_WIT / 3);
+
+    let active_wips = current_active_wips();
+    if active_wips.wip0023() {
+        assert_eq!(reward, 200 + ONE_WIT);
+    } else {
+        assert_eq!(reward, 200 + ONE_WIT + ONE_WIT / 3);
+    }
 
     // Tally value: integer(0)
     let tally_value = vec![0x00];
@@ -5839,7 +5885,13 @@ fn tally_dishonest_reward() {
     let dr_output = example_data_request_output_with_mode_filter(3, 200, 20);
     let (dr_pool, dr_pointer, rewarded, slashed, error_witnesses, dr_pkh, _change, reward) =
         dr_pool_with_dr_in_tally_stage_with_dr_liar(dr_output, 3, 3, 1, reveal_value, liar_value);
-    assert_eq!(reward, 200 + ONE_WIT + ONE_WIT / 2);
+
+    let active_wips = current_active_wips();
+    if active_wips.wip0023() {
+        assert_eq!(reward, 200 + ONE_WIT);
+    } else {
+        assert_eq!(reward, 200 + ONE_WIT + ONE_WIT / 2);
+    }
 
     // Tally value: integer(0)
     let tally_value = vec![0x00];
@@ -5901,7 +5953,13 @@ fn create_tally_validation_dr_liar() {
             reveal_value.result.encode().unwrap(),
             liar_value.result.encode().unwrap(),
         );
-    assert_eq!(reward, 200 + ONE_WIT + ONE_WIT / 2);
+
+    let active_wips = current_active_wips();
+    if active_wips.wip0023() {
+        assert_eq!(reward, 200 + ONE_WIT);
+    } else {
+        assert_eq!(reward, 200 + ONE_WIT + ONE_WIT / 2);
+    }
 
     // Create the RadonReport using the reveals and the RADTally script
     let min_consensus = 0.51;
@@ -5972,7 +6030,13 @@ fn create_tally_validation_5_reveals_1_liar_1_error() {
             reveal_value.result.encode().unwrap(),
             liar_value.result.encode().unwrap(),
         );
-    assert_eq!(reward, 200 + ONE_WIT + ONE_WIT / 3);
+
+    let active_wips = current_active_wips();
+    if active_wips.wip0023() {
+        assert_eq!(reward, 200 + ONE_WIT);
+    } else {
+        assert_eq!(reward, 200 + ONE_WIT + ONE_WIT / 3);
+    }
 
     // Create the RadonReport using the reveals and the RADTally script
     let min_consensus = 0.51;
@@ -6050,7 +6114,13 @@ fn create_tally_validation_4_commits_2_reveals() {
             reveal_value.result.encode().unwrap(),
             vec![],
         );
-    assert_eq!(reward, 200 + 2 * ONE_WIT);
+
+    let active_wips = current_active_wips();
+    if active_wips.wip0023() {
+        assert_eq!(reward, 200 + ONE_WIT);
+    } else {
+        assert_eq!(reward, 200 + 2 * ONE_WIT);
+    }
 
     // Create the RadonReport using the reveals and the RADTally script
     let min_consensus = 0.51;
@@ -6372,12 +6442,22 @@ fn validate_calculate_witness_reward() {
         ..DataRequestOutput::default()
     };
 
+    let active_wips = current_active_wips();
+    let wip0023_active = active_wips.wip0023();
+
     // Case 0 commits
     let expected_reward = 0;
     let rest = 0;
     assert_eq!(
         (expected_reward, rest),
-        calculate_witness_reward(0, 0, 0, dr_output.witness_reward, dr_output.collateral)
+        calculate_witness_reward(
+            0,
+            0,
+            0,
+            dr_output.witness_reward,
+            dr_output.collateral,
+            wip0023_active,
+        )
     );
 
     // Case 0 reveals
@@ -6385,7 +6465,14 @@ fn validate_calculate_witness_reward() {
     let rest = 0;
     assert_eq!(
         (expected_reward, rest),
-        calculate_witness_reward(5, 5, 0, dr_output.witness_reward, dr_output.collateral)
+        calculate_witness_reward(
+            5,
+            5,
+            0,
+            dr_output.witness_reward,
+            dr_output.collateral,
+            wip0023_active,
+        )
     );
 
     // Case all honests
@@ -6393,23 +6480,52 @@ fn validate_calculate_witness_reward() {
     let rest = 0;
     assert_eq!(
         (expected_reward, rest),
-        calculate_witness_reward(5, 0, 0, dr_output.witness_reward, dr_output.collateral)
+        calculate_witness_reward(
+            5,
+            0,
+            0,
+            dr_output.witness_reward,
+            dr_output.collateral,
+            wip0023_active,
+        )
     );
 
     // Case 2 liars
-    let expected_reward = 1000 + 5000 + 5000 * 2 / 3;
-    let rest = 5000 * 2 % 3;
+    let expected_reward = if wip0023_active {
+        1000 + 5000
+    } else {
+        1000 + 5000 + 5000 * 2 / 3
+    };
+    let rest = if wip0023_active { 0 } else { 5000 * 2 % 3 };
     assert_eq!(
         (expected_reward, rest),
-        calculate_witness_reward(5, 2, 0, dr_output.witness_reward, dr_output.collateral)
+        calculate_witness_reward(
+            5,
+            2,
+            0,
+            dr_output.witness_reward,
+            dr_output.collateral,
+            wip0023_active,
+        )
     );
 
     // Case 1 liar and 1 non-revealer
-    let expected_reward = 1000 + 5000 + 5000 * 2 / 3;
-    let rest = 5000 * 2 % 3;
+    let expected_reward = if wip0023_active {
+        1000 + 5000
+    } else {
+        1000 + 5000 + 5000 * 2 / 3
+    };
+    let rest = if wip0023_active { 0 } else { 5000 * 2 % 3 };
     assert_eq!(
         (expected_reward, rest),
-        calculate_witness_reward(5, 2, 0, dr_output.witness_reward, dr_output.collateral)
+        calculate_witness_reward(
+            5,
+            2,
+            0,
+            dr_output.witness_reward,
+            dr_output.collateral,
+            wip0023_active
+        )
     );
 
     // Case 1 error
@@ -6417,15 +6533,33 @@ fn validate_calculate_witness_reward() {
     let rest = 0;
     assert_eq!(
         (expected_reward, rest),
-        calculate_witness_reward(5, 0, 1, dr_output.witness_reward, dr_output.collateral)
+        calculate_witness_reward(
+            5,
+            0,
+            1,
+            dr_output.witness_reward,
+            dr_output.collateral,
+            wip0023_active,
+        )
     );
 
     // Case 1 liar and 1 error
-    let expected_reward = 1000 + 5000 + 5000 / 3;
-    let rest = 5000 % 3;
+    let expected_reward = if wip0023_active {
+        1000 + 5000
+    } else {
+        1000 + 5000 + 5000 / 3
+    };
+    let rest = if wip0023_active { 0 } else { 5000 % 3 };
     assert_eq!(
         (expected_reward, rest),
-        calculate_witness_reward(5, 1, 1, dr_output.witness_reward, dr_output.collateral)
+        calculate_witness_reward(
+            5,
+            1,
+            1,
+            dr_output.witness_reward,
+            dr_output.collateral,
+            wip0023_active,
+        )
     );
 }
 
@@ -6904,8 +7038,12 @@ fn tally_valid_3_reveals_1_no_reveal_majority_of_errors() {
         vec![216, 39, 129, 24, 49],
     ];
     let (pkhs, dr_pkh, dr_pointer, dr_pool) = generic_tally_test_stddev_dr(4, reveals, stddev_cbor);
-    let reward = collateral + 1000 + collateral / 3;
-    let change = 1000 + 10;
+    let active_wips = current_active_wips();
+    let (reward, change) = if active_wips.wip0023() {
+        (collateral + 1000, 1000 + 10)
+    } else {
+        (collateral + 1000 + collateral / 3, 1000 + 10)
+    };
 
     // TODO: serialize tally value from RadError to make this test more clear
     let tally_value = vec![216, 39, 129, 24, 49];
@@ -7423,7 +7561,12 @@ fn tally_valid_rng_one_invalid_type() {
     let reveals = reveals.into_iter().map(|x| x.encode().unwrap()).collect();
     let (pkhs, dr_pkh, dr_pointer, dr_pool) = generic_tally_test_rng(4, reveals);
     let collateral = ONE_WIT;
-    let reward = collateral + 200 + collateral / 3;
+    let active_wips = current_active_wips();
+    let reward = if active_wips.wip0023() {
+        collateral + 200
+    } else {
+        collateral + 200 + collateral / 3
+    };
     let change = 200;
 
     let tally_value = RadonTypes::from(RadonBytes::from(

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -902,6 +902,7 @@ pub fn validate_tally_transaction<'a>(
             errors_count,
             dr_state.data_request.witness_reward,
             collateral,
+            active_wips.wip0023(),
         )
     } else {
         calculate_witness_reward_before_second_hard_fork(
@@ -1023,7 +1024,15 @@ pub fn validate_tally_transaction<'a>(
     }
 
     let expected_collateral_value = if commits_count > 0 {
-        collateral * u64::from(dr_state.data_request.witnesses)
+        if active_wips.wip0023() {
+            if honests_count > 0 {
+                collateral * (u64::from(dr_state.data_request.witnesses) - liars_count as u64)
+            } else {
+                collateral * u64::from(dr_state.data_request.witnesses)
+            }
+        } else {
+            collateral * u64::from(dr_state.data_request.witnesses)
+        }
     } else {
         // In case of no commits, collateral does not affect
         0


### PR DESCRIPTION
I made all relevant Tally tests conditional on WIP0023 being activated. I could not find a proper way of enabling all tests with a new WIP being activated, so I added a temporary placeholder in `wip_info()` and `test_wip_info()`. If you uncomment those, you can verify all tests pass with and without WIP0023 being active.

I was not sure if I should just update the WIP in `initialize_wip_information()` nor the associated tests, but for now I did.