### PR TITLE
chore: fix clippy warnings for Rust 1.65

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,6 +19,8 @@ jobs:
         -D clippy::cast-sign-loss
         -D clippy::checked-conversions
         -A clippy::upper-case-acronyms
+        -A clippy::result-large-err
+        -A special_module_name
 
     steps:
       - uses: actions/checkout@v1

--- a/Justfile
+++ b/Justfile
@@ -34,6 +34,8 @@ export CLIPPY_LINTS := '-D warnings
     -D clippy::cast-sign-loss
     -D clippy::checked-conversions
     -A clippy::upper-case-acronyms
+    -A clippy::result-large-err
+    -A special_module_name
 '
 
 # run clippy

--- a/config/src/loaders/toml.rs
+++ b/config/src/loaders/toml.rs
@@ -76,7 +76,7 @@ mod tests {
     fn test_load_empty_config_from_file() {
         super::FILE_CONTENTS.with(|cell| cell.set(""));
         let filename = Path::new("config.toml");
-        let config = super::from_file(&filename).unwrap();
+        let config = super::from_file(filename).unwrap();
 
         assert_eq!(config, PartialConfig::default());
     }
@@ -93,7 +93,7 @@ inbound_limit = 999
             )
         });
         let filename = Path::new("config.toml");
-        let config = super::from_file(&filename).unwrap();
+        let config = super::from_file(filename).unwrap();
 
         assert_eq!(config.environment, Environment::Testnet);
         assert_eq!(config.connections.inbound_limit, Some(999));

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -31,7 +31,7 @@ impl AsRef<[u8]> for Sha256 {
 /// Calculate the SHA256 hash
 pub fn calculate_sha256(bytes: &[u8]) -> Sha256 {
     let mut hasher = sha2::Sha256::new();
-    hasher.input(&bytes);
+    hasher.input(bytes);
     let mut hash = [0; 32];
     hash.copy_from_slice(&hasher.result());
     Sha256(hash)

--- a/crypto/src/merkle.rs
+++ b/crypto/src/merkle.rs
@@ -27,7 +27,7 @@ pub fn merkle_tree_root(hashes: &[Sha256]) -> Sha256 {
 /// Calculate `sha256(a || b)` where || means concatenation
 pub fn sha256_concat(a: Sha256, b: Sha256) -> Sha256 {
     let mut h = a.0.to_vec();
-    h.extend(&b.0);
+    h.extend(b.0);
     calculate_sha256(&h)
 }
 

--- a/crypto/tests/merkle.rs
+++ b/crypto/tests/merkle.rs
@@ -19,7 +19,7 @@ fn one() {
 // Helper function to test hash order
 fn hash_concat(Sha256(a): Sha256, Sha256(b): Sha256) -> Sha256 {
     let mut h = a.to_vec();
-    h.extend(&b);
+    h.extend(b);
     calculate_sha256(&h)
 }
 

--- a/data_structures/build.rs
+++ b/data_structures/build.rs
@@ -18,7 +18,7 @@ fn main() {
 
     exonum_build::protobuf_generate(
         "../schemas/witnet",
-        &["../schemas/witnet"],
+        ["../schemas/witnet"],
         "witnet_proto_mod.rs",
     );
 }

--- a/data_structures/src/chain/mod.rs
+++ b/data_structures/src/chain/mod.rs
@@ -652,8 +652,8 @@ impl Hashable for DataRequestOutput {
 impl Hashable for PublicKey {
     fn hash(&self) -> Hash {
         let mut v = vec![];
-        v.extend(&[self.compressed]);
-        v.extend(&self.bytes);
+        v.extend([self.compressed]);
+        v.extend(self.bytes);
 
         calculate_sha256(&v).into()
     }
@@ -3502,7 +3502,7 @@ impl ReputationEngine {
 fn pkh_alpha_hash(pkh: &PublicKeyHash, alpha: Alpha) -> Hash {
     let alpha_bytes: &[u8] = &alpha.0.to_be_bytes();
     let mut pkh_bytes = Vec::with_capacity(pkh.hash.len() + alpha_bytes.len());
-    pkh_bytes.extend(&pkh.hash);
+    pkh_bytes.extend(pkh.hash);
     pkh_bytes.extend(alpha_bytes);
 
     calculate_sha256(&pkh_bytes).into()

--- a/data_structures/src/proto/mod.rs
+++ b/data_structures/src/proto/mod.rs
@@ -70,8 +70,8 @@ impl ProtobufConvert for chain::PublicKey {
     fn to_pb(&self) -> Self::ProtoStruct {
         let mut m = witnet::PublicKey::new();
         let mut v = vec![];
-        v.extend(&[self.compressed]);
-        v.extend(&self.bytes);
+        v.extend([self.compressed]);
+        v.extend(self.bytes);
         m.set_public_key(v);
 
         m

--- a/node/src/actors/json_rpc/json_rpc_methods.rs
+++ b/node/src/actors/json_rpc/json_rpc_methods.rs
@@ -1284,7 +1284,7 @@ pub async fn get_balance(params: Params) -> JsonRpcResult {
         .map(|res| {
             res.map_err(internal_error)
                 .and_then(|dr_info| match dr_info {
-                    Ok(x) => match serde_json::to_value(&x) {
+                    Ok(x) => match serde_json::to_value(x) {
                         Ok(x) => Ok(x),
                         Err(e) => {
                             let err = internal_error_s(e);
@@ -1663,7 +1663,7 @@ pub async fn rewind(params: Result<(Epoch,), jsonrpc_core::Error>) -> JsonRpcRes
         .map(|res| {
             res.map_err(internal_error)
                 .and_then(|success| match success {
-                    Ok(x) => match serde_json::to_value(&x) {
+                    Ok(x) => match serde_json::to_value(x) {
                         Ok(x) => Ok(x),
                         Err(e) => {
                             let err = internal_error_s(e);

--- a/node/tests/data_request_examples.rs
+++ b/node/tests/data_request_examples.rs
@@ -59,7 +59,7 @@ fn run_dr_locally_with_data(
         log::info!("Running retrieval for {}", r.url);
         retrieval_results.push(witnet_rad::run_retrieval_with_data(
             r,
-            *d,
+            d,
             RadonScriptExecutionSettings::disable_all(),
             all_wips_active(),
         )?);

--- a/protected/src/lib.rs
+++ b/protected/src/lib.rs
@@ -37,13 +37,13 @@ impl<T: Into<Vec<u8>>> From<T> for Protected {
 
 impl AsRef<[u8]> for Protected {
     fn as_ref(&self) -> &[u8] {
-        &*self.0
+        &self.0
     }
 }
 
 impl AsMut<[u8]> for Protected {
     fn as_mut(&mut self) -> &mut [u8] {
-        &mut *self.0
+        &mut self.0
     }
 }
 

--- a/rad/src/types/mod.rs
+++ b/rad/src/types/mod.rs
@@ -56,7 +56,7 @@ pub enum RadonTypes {
 impl RadonTypes {
     pub fn hash(self) -> Result<Hash, RadError> {
         self.encode()
-            .map(|vector: Vec<u8>| calculate_sha256(&*vector))
+            .map(|vector: Vec<u8>| calculate_sha256(&vector))
             .map(Hash::from)
             .map_err(|_| RadError::Hash)
     }

--- a/storage/src/backends/rocksdb.rs
+++ b/storage/src/backends/rocksdb.rs
@@ -16,7 +16,7 @@ struct Error(#[fail(cause)] rocksdb::Error);
 
 impl Storage for Backend {
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        let result = Backend::get(self, &key)
+        let result = Backend::get(self, key)
             .map(|opt| opt.map(|dbvec| dbvec.to_vec()))
             .map_err(Error)?;
         Ok(result)
@@ -28,7 +28,7 @@ impl Storage for Backend {
     }
 
     fn delete(&self, key: &[u8]) -> Result<()> {
-        Backend::delete(self, &key).map_err(Error)?;
+        Backend::delete(self, key).map_err(Error)?;
         Ok(())
     }
 
@@ -111,7 +111,7 @@ mod rocksdb_mock {
             DB::default()
         }
 
-        fn search<K: AsRef<[u8]>>(&self, key: &K) -> Option<usize> {
+        fn search<K: AsRef<[u8]> + ?Sized>(&self, key: &K) -> Option<usize> {
             for (i, (k, _)) in self.data.read().unwrap().iter().enumerate() {
                 if key.as_ref() == k.as_slice() {
                     return Some(i);
@@ -120,7 +120,7 @@ mod rocksdb_mock {
             None
         }
 
-        pub fn get<K: AsRef<[u8]>>(&self, key: &K) -> Result<Option<Vec<u8>>> {
+        pub fn get<K: AsRef<[u8]> + ?Sized>(&self, key: &K) -> Result<Option<Vec<u8>>> {
             Ok(self
                 .search(key)
                 .map(|idx| self.data.read().unwrap()[idx].1.clone()))
@@ -138,7 +138,7 @@ mod rocksdb_mock {
             Ok(())
         }
 
-        pub fn delete<K: AsRef<[u8]>>(&self, key: &K) -> Result<()> {
+        pub fn delete<K: AsRef<[u8]> + ?Sized>(&self, key: &K) -> Result<()> {
             self.search(key)
                 .map(|idx| self.data.write().unwrap().remove(idx));
             Ok(())

--- a/toolkit/src/cli/data_requests.rs
+++ b/toolkit/src/cli/data_requests.rs
@@ -38,7 +38,7 @@ pub(crate) fn decode_from_args(
 /// By default, a full trace is provided, i.e.: all execution details including the partial results
 /// after each operator.
 ///
-/// Full trace mode can be disabled by setting `--full_trace` option to `false`.  
+/// Full trace mode can be disabled by setting `--full_trace` option to `false`.
 pub(crate) fn try_from_args(
     args: arguments::TryDataRequest,
 ) -> Result<RADRequestExecutionReport, Error> {

--- a/wallet/src/actors/app/methods.rs
+++ b/wallet/src/actors/app/methods.rs
@@ -408,7 +408,7 @@ impl App {
 
                 // If the node is synced start synchronization for this wallet
                 if slf.state.node_state == Some(StateMachine::Synced)
-                    || slf.state.node_state == None
+                    || slf.state.node_state.is_none()
                 {
                     let sink = slf.state.get_sink(&session_id);
                     slf.params

--- a/wallet/src/model.rs
+++ b/wallet/src/model.rs
@@ -364,7 +364,7 @@ pub struct Beacon {
 impl fmt::Display for Beacon {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "blk {} ({})", hex::encode(&self.block_hash), self.epoch)
+        write!(f, "blk {} ({})", hex::encode(self.block_hash), self.epoch)
     }
 }
 

--- a/wallet/src/repository/keys.rs
+++ b/wallet/src/repository/keys.rs
@@ -209,7 +209,7 @@ pub fn master_key() -> Key<&'static str, ExtendedSK> {
 /// Path information associated to a pkh (account, keychain and index).
 #[inline]
 pub fn pkh(pkh: &PublicKeyHash) -> Key<Vec<u8>, model::Path> {
-    Key::new([b"pkh-", pkh.as_ref()].concat().to_vec())
+    Key::new([b"pkh-", pkh.as_ref()].concat())
 }
 
 /// An custom key decided by the client to store something.

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -456,7 +456,7 @@ where
 
             batch.put(&keys::address(account, keychain, index), &address)?;
             batch.put(&keys::address_path(account, keychain, index), &path)?;
-            batch.put(&keys::address_pkh(account, keychain, index), &pkh)?;
+            batch.put(&keys::address_pkh(account, keychain, index), pkh)?;
             batch.put(&keys::address_info(account, keychain, index), &info)?;
             batch.put(
                 &keys::pkh(&pkh),
@@ -467,7 +467,7 @@ where
                 },
             )?;
 
-            batch.put(&keys::account_next_index(account, keychain), &next_index)?;
+            batch.put(&keys::account_next_index(account, keychain), next_index)?;
 
             self.db.write(batch)?;
         }
@@ -1007,7 +1007,7 @@ where
             movement.transaction.confirmed = true;
             batch.put(
                 &keys::transactions_index(txn_hash.as_ref()),
-                &movement.db_key,
+                movement.db_key,
             )?;
             batch.put(
                 &keys::transaction_hash(account, movement.db_key),
@@ -1040,7 +1040,7 @@ where
             )?;
             batch.put(
                 &keys::address_pkh(account, address.keychain, address.index),
-                &address.pkh,
+                address.pkh,
             )?;
         }
 

--- a/wallet/src/repository/wallet/tests/mod.rs
+++ b/wallet/src/repository/wallet/tests/mod.rs
@@ -313,7 +313,7 @@ fn test_balance() {
         available: 99u64,
         locked: 0u64,
     };
-    db.put(&keys::account_balance(0), &new_balance).unwrap();
+    db.put(&keys::account_balance(0), new_balance).unwrap();
 
     let (wallet, _db) = factories::wallet(Some(db));
 


### PR DESCRIPTION
Fix the most trivial ones, and add temporary "allow" directives for the rest.