### PR TITLE
fix(rad): parse JSON integers larger than u64::MAX

### DIFF
--- a/rad/src/script.rs
+++ b/rad/src/script.rs
@@ -555,6 +555,45 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_json_map_big_integers() {
+        use crate::types::float::RadonFloat;
+        use crate::types::map::RadonMap;
+        use crate::types::string::RadonString;
+
+        let input = RadonTypes::from(RadonString::from(r#"{"data": 122637770461000000000}"#));
+        let script = vec![(RadonOpCodes::StringParseJSONMap, None)];
+
+        let output = execute_contextfree_radon_script(input, &script).unwrap();
+
+        assert_eq!(
+            output,
+            RadonTypes::from(RadonMap::from(BTreeMap::from([(
+                "data".to_string(),
+                RadonTypes::from(RadonFloat::from(122637770461000000000.0))
+            )])))
+        );
+    }
+
+    #[test]
+    fn test_parse_json_array_big_integers() {
+        use crate::types::array::RadonArray;
+        use crate::types::float::RadonFloat;
+        use crate::types::string::RadonString;
+
+        let input = RadonTypes::from(RadonString::from(r#"[122637770461000000000]"#));
+        let script = vec![(RadonOpCodes::StringParseJSONArray, None)];
+
+        let output = execute_contextfree_radon_script(input, &script).unwrap();
+
+        assert_eq!(
+            output,
+            RadonTypes::from(RadonArray::from(vec![RadonTypes::from(RadonFloat::from(
+                122637770461000000000.0
+            ))]))
+        );
+    }
+
+    #[test]
     fn test_unpack_radon_script() {
         let cbor_vec = Value::Array(vec![
             Value::Integer(RadonOpCodes::StringParseJSONMap as i128),

--- a/rad/src/types/array.rs
+++ b/rad/src/types/array.rs
@@ -1,4 +1,4 @@
-use serde_cbor::value::{from_value, Value};
+use serde_cbor::value::Value;
 use std::{
     convert::{TryFrom, TryInto},
     fmt,
@@ -68,20 +68,23 @@ impl TryFrom<Value> for RadonArray {
     type Error = RadError;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        from_value::<Vec<Value>>(value)
-            .map(|value_vec| {
-                value_vec
-                    .iter()
-                    .map(|cbor_value| RadonTypes::try_from(cbor_value.to_owned()).ok())
-                    .fuse()
-                    .flatten()
-                    .collect::<Vec<RadonTypes>>()
-            })
-            .map_err(|_| RadError::Decode {
-                from: "cbor::value::Value",
-                to: RadonArray::radon_type_name(),
-            })
-            .map(Self::from)
+        match value {
+            Value::Array(a) => Ok(a),
+            _ => Err(()),
+        }
+        .map(|value_vec| {
+            value_vec
+                .iter()
+                .map(|cbor_value| RadonTypes::try_from(cbor_value.to_owned()).ok())
+                .fuse()
+                .flatten()
+                .collect::<Vec<RadonTypes>>()
+        })
+        .map_err(|_| RadError::Decode {
+            from: "cbor::value::Value",
+            to: RadonArray::radon_type_name(),
+        })
+        .map(Self::from)
     }
 }
 


### PR DESCRIPTION
Fix #2310, but this will probably need TAPI to not break anything. Also the output is a bit unexpected, instead of parsing the number "122637770461000000000" as an integer or as a float, it parses it as the integer "122637770461000007680" (which differs in the last digits).