### PR TITLE
feat(node): allow to configure max_open_files rocksdb option

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -314,6 +314,8 @@ pub struct Storage {
     pub master_key_import_path: Option<PathBuf>,
     /// Keep a map of "address" to "list of UTXOs" in memory, to speed up getBalance and getUtxoInfo methods
     pub utxos_in_memory: bool,
+    /// RocksDB option max_open_files. -1 means unlimited.
+    pub max_open_files: i32,
 }
 
 /// JsonRPC API configuration
@@ -740,6 +742,9 @@ impl Storage {
                 .utxos_in_memory
                 .to_owned()
                 .unwrap_or_else(|| defaults.storage_utxos_in_memory()),
+            max_open_files: config
+                .max_open_files
+                .unwrap_or_else(|| defaults.storage_max_open_files()),
         }
     }
 
@@ -749,6 +754,7 @@ impl Storage {
             db_path: Some(self.db_path.clone()),
             master_key_import_path: self.master_key_import_path.clone(),
             utxos_in_memory: Some(self.utxos_in_memory),
+            max_open_files: Some(self.max_open_files),
         }
     }
 }
@@ -1281,6 +1287,7 @@ mod tests {
             db_path: Some(PathBuf::from("other")),
             master_key_import_path: None,
             utxos_in_memory: None,
+            max_open_files: None,
         };
         let config = Storage::from_partial(&partial_config, &Testnet);
 

--- a/config/src/defaults.rs
+++ b/config/src/defaults.rs
@@ -50,6 +50,11 @@ pub trait Defaults {
         false
     }
 
+    /// Unlimited number of open files by default
+    fn storage_max_open_files(&self) -> i32 {
+        -1
+    }
+
     /// Default period for bootstrap peers
     fn connections_bootstrap_peers_period(&self) -> Duration {
         Duration::from_secs(5)

--- a/node/src/storage_mngr.rs
+++ b/node/src/storage_mngr.rs
@@ -366,8 +366,11 @@ pub fn create_appropriate_backend(
         }
         config::StorageBackend::RocksDB => {
             let path = conf.db_path.as_path();
-
-            let db = backends::rocksdb::Backend::open_default(path).map_err(|e| as_failure!(e))?;
+            let mut options = backends::rocksdb::Options::default();
+            options.create_if_missing(true);
+            options.set_max_open_files(conf.max_open_files);
+            let db =
+                backends::rocksdb::Backend::open(&options, path).map_err(|e| as_failure!(e))?;
 
             wrap_storage_as_nodestorage(db, conf)
         }

--- a/storage/src/backends/rocksdb.rs
+++ b/storage/src/backends/rocksdb.rs
@@ -10,6 +10,9 @@ use crate::storage::{Result, Storage, StorageIterator, WriteBatch, WriteBatchIte
 /// Rocksdb backend
 pub type Backend = rocksdb::DB;
 
+/// Rocksdb Options
+pub type Options = rocksdb::Options;
+
 #[derive(Debug, Fail)]
 #[fail(display = "RocksDB error: {}", _0)]
 struct Error(#[fail(cause)] rocksdb::Error);
@@ -234,4 +237,7 @@ mod rocksdb_mock {
             Ok(())
         }
     }
+
+    #[derive(Default)]
+    pub struct Options {}
 }


### PR DESCRIPTION
The default value is "unlimited", which is the same as the previous behavior.

#2309