### PR TITLE
chore: fix clippy warnings for Rust 1.67

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,6 +19,7 @@ jobs:
         -D clippy::cast-sign-loss
         -D clippy::checked-conversions
         -A clippy::upper-case-acronyms
+        -A clippy::uninlined-format-args
 
     steps:
       - uses: actions/checkout@v1

--- a/Justfile
+++ b/Justfile
@@ -34,6 +34,7 @@ export CLIPPY_LINTS := '-D warnings
     -D clippy::cast-sign-loss
     -D clippy::checked-conversions
     -A clippy::upper-case-acronyms
+    -A clippy::uninlined-format-args
 '
 
 # run clippy

--- a/wallet/src/repository/wallets/mod.rs
+++ b/wallet/src/repository/wallets/mod.rs
@@ -58,10 +58,10 @@ impl<T: Database> Wallets<T> {
 
     /// Create a wallet based on name, description, IV, salt and account. The name is stored in the
     /// public wallets DB, while all parameters are stored in the private encrypted wallet DB
-    pub fn create<'a, D: Database>(
+    pub fn create<D: Database>(
         &self,
         wallet_db: &D,
-        wallet_data: types::CreateWalletData<'a>,
+        wallet_data: types::CreateWalletData<'_>,
     ) -> Result<()> {
         let types::CreateWalletData {
             id,


### PR DESCRIPTION
Ignoring [uninlined-format-args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) for now to avoid making this PR too big.