### PR TITLE
Tapi cleanup

### DIFF
--- a/data_structures/src/chain/tapi.rs
+++ b/data_structures/src/chain/tapi.rs
@@ -272,17 +272,6 @@ impl TapiEngine {
             }
         }
 
-        // Reset the active WIPs to those statically defined in `wip_info()` and only enables those
-        // that have been marked as `old_wips` above, thus forgetting about accidentally enabled
-        // WIPs, and WIPs that are no longer under signaling.
-        let mut truly_active = wip_info();
-        for (name, epoch) in &self.wip_activation {
-            if old_wips.contains(name) {
-                truly_active.insert(name.clone(), *epoch);
-            }
-        }
-        self.wip_activation = truly_active;
-
         (min_epoch, old_wips)
     }
 


### PR DESCRIPTION
The first commit removes the hardcoded WIP overwrites, this can definitely be merged.

The second one removes the voting structures for past accepted WIPs, but I'm not sure whether the accepted method is to remove them now or only when new WIPs are proposed.

The `test_initialize_wip_information` test fails due to the removal of accepted WIPs, but it will fail whenever anything is updated with respect to the `BitVotesCounter` since it is specific to one set of WIPs. Not quite sure if you want to keep that test or update it every time or ...?