### PR TITLE
feat(rad): decode JSON more efficiently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,12 +2118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
 name = "jsonrpc-core"
 version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5803,7 +5797,6 @@ dependencies = [
  "hex",
  "http",
  "if_rust_version",
- "json",
  "log 0.4.19",
  "minidom",
  "num_enum",
@@ -5811,6 +5804,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_cbor",
+ "serde_json",
  "url",
  "witnet_config",
  "witnet_crypto",

--- a/data_structures/src/chain/tapi.rs
+++ b/data_structures/src/chain/tapi.rs
@@ -138,7 +138,7 @@ impl TapiEngine {
             }
         }
         for n in 0..self.bit_tapi_counter.len() {
-            if let Some(mut bit_counter) = self.bit_tapi_counter.get_mut(n, &epoch_to_update) {
+            if let Some(bit_counter) = self.bit_tapi_counter.get_mut(n, &epoch_to_update) {
                 if !self.wip_activation.contains_key(&bit_counter.wip)
                     && !avoid_wip_list.contains(&bit_counter.wip)
                 {
@@ -639,7 +639,7 @@ mod tests {
         assert_eq!(tapi_counter.current_length, 1);
 
         assert_eq!(tapi_counter.get(0, &100).unwrap().votes, 0);
-        let mut votes_counter = tapi_counter.get_mut(0, &100).unwrap();
+        let votes_counter = tapi_counter.get_mut(0, &100).unwrap();
         votes_counter.votes += 1;
         assert_eq!(tapi_counter.get(0, &100).unwrap().votes, 1);
 

--- a/node/src/actors/inventory_manager/handlers.rs
+++ b/node/src/actors/inventory_manager/handlers.rs
@@ -512,7 +512,7 @@ mod tests {
             // Start relevant actors
             config_mngr::start(config);
             storage_mngr::start();
-            let inventory_manager = InventoryManager::default().start();
+            let inventory_manager = InventoryManager.start();
 
             // Create first block with value transfer transactions
             let block = build_block_with_vt_transactions(1);

--- a/node/src/actors/node.rs
+++ b/node/src/actors/node.rs
@@ -51,7 +51,7 @@ pub fn run(config: Arc<Config>, ops: NodeOps, callback: fn()) -> Result<(), fail
         SystemRegistry::set(peers_manager_addr);
 
         // Start ConnectionsManager actor
-        let connections_manager_addr = ConnectionsManager::default().start();
+        let connections_manager_addr = ConnectionsManager.start();
         SystemRegistry::set(connections_manager_addr);
 
         // Start SessionManager actor
@@ -69,7 +69,7 @@ pub fn run(config: Arc<Config>, ops: NodeOps, callback: fn()) -> Result<(), fail
         SystemRegistry::set(chain_manager_addr);
 
         // Start InventoryManager actor
-        let inventory_manager_addr = InventoryManager::default().start();
+        let inventory_manager_addr = InventoryManager.start();
         SystemRegistry::set(inventory_manager_addr);
 
         // Start RadManager actor

--- a/partial_struct/tests/partial_struct_derive.rs
+++ b/partial_struct/tests/partial_struct_derive.rs
@@ -81,5 +81,5 @@ fn test_partial_attr_partial() {
 
     let p = PartialObj::default();
 
-    assert_eq!(p.f, PartialAnotherObj::default());
+    assert_eq!(p.f, PartialAnotherObj);
 }

--- a/rad/Cargo.toml
+++ b/rad/Cargo.toml
@@ -15,14 +15,14 @@ if_rust_version = "1.0.0"
 # the http crate is used to perform additional validations before passing arguments to the surf http client
 # the version of http must be kept in sync with the version used by surf
 http = "0.2.1"
-json = "0.12.1"
 log = "0.4.8"
 minidom = { git = "https://github.com/witnet/xmpp-rs", rev = "bc8a33ff5da95ee4039ad7ee3376c100d9e35c74" }
 num_enum = "0.4.2"
 ordered-float = "3.0"
 rand = "0.7.3"
 serde = "1.0.111"
-serde_cbor = "0.11.1"
+serde_cbor = "0.11.2"
+serde_json = "1.0.96"
 # the url crate is used to perform additional validations before passing arguments to the surf http client
 # the version of url must be kept in sync with the version used by surf in the `witnet_net` crate
 url = "2.1.1"

--- a/wallet/src/actors/app/handlers/refresh_session.rs
+++ b/wallet/src/actors/app/handlers/refresh_session.rs
@@ -21,7 +21,7 @@ impl Handler<RefreshSessionRequest> for app::App {
     type Result = <RefreshSessionRequest as Message>::Result;
 
     fn handle(&mut self, msg: RefreshSessionRequest, ctx: &mut Self::Context) -> Self::Result {
-        let mut session = self
+        let session = self
             .state
             .sessions
             .get_mut(&msg.session_id)

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -1441,7 +1441,7 @@ where
         let mut state = self.state.write()?;
         // This line is needed because of this error:
         // - Cannot borrow `state` as mutable because it is also borrowed as immutable
-        let mut state = &mut *state;
+        let state = &mut *state;
 
         // Mark UTXOs as used so we don't double spend
         // Save the timestamp to after which the UTXO can be spent again


### PR DESCRIPTION
This should solve the stoppers for https://github.com/witnet/witnet-price-feeds/issues/210#issuecomment-1557134728.

This change may require activation through TAPI, provided that non-updated nodes will commit errors where updated nodes will report normally.

fix #2315 
fix #2338 

@Tommytrg Edit:
Also fix #2373

@aesedepece Edit:
Lol, it fixes itself?