### PR TITLE
Fix/bridge/do not ignore further drs if one fails to read

### DIFF
--- a/bridges/centralized-ethereum/src/actors/eth_poller.rs
+++ b/bridges/centralized-ethereum/src/actors/eth_poller.rs
@@ -131,8 +131,6 @@ impl EthPoller {
                                         process_posted_request(i.into(), &wrb_contract).await
                                     {
                                         dr_database_addr.do_send(set_dr_info_bridge);
-                                    } else {
-                                        break;
                                     }
                                 }
                                 WitnetQueryStatus::Reported => {
@@ -141,8 +139,6 @@ impl EthPoller {
                                         process_posted_request(i.into(), &wrb_contract).await
                                     {
                                         dr_database_addr.do_send(set_dr_info_bridge);
-                                    } else {
-                                        break;
                                     }
                                 }
                                 WitnetQueryStatus::Deleted => {


### PR DESCRIPTION
This fixes this bug in which an invalid request or a request that cannot be read or decoded otherwise prevents further posted or reported requests in the WRB from being processed.