### PR TITLE
fix(wallet): allow generating transactions without persisting change addresses

### DIFF
--- a/wallet/src/actors/app/handlers/create_data_req.rs
+++ b/wallet/src/actors/app/handlers/create_data_req.rs
@@ -33,6 +33,8 @@ pub struct CreateDataReqRequest {
     #[serde(deserialize_with = "deserialize_fee_backwards_compatible")]
     fee: Fee,
     fee_type: Option<FeeType>,
+    #[serde(default)]
+    preview: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -81,7 +83,11 @@ impl Handler<CreateDataReqRequest> for app::App {
         let fee = fee_compat(msg.fee, msg.fee_type);
 
         let f = fut::result(validated).and_then(move |request, slf: &mut Self, _ctx| {
-            let params = types::DataReqParams { request, fee };
+            let params = types::DataReqParams {
+                request,
+                fee,
+                preview: msg.preview,
+            };
 
             slf.create_data_req(&msg.session_id, &msg.wallet_id, params)
                 .map_ok(

--- a/wallet/src/actors/app/handlers/create_vtt.rs
+++ b/wallet/src/actors/app/handlers/create_vtt.rs
@@ -65,6 +65,8 @@ pub struct CreateVttRequest {
     utxo_strategy: UtxoSelectionStrategy,
     #[serde(default)]
     selected_utxos: HashSet<OutputPointer>,
+    #[serde(default)]
+    preview: bool,
 }
 
 /// Part of CreateVttResponse struct, containing additional data to be displayed in clients
@@ -124,6 +126,7 @@ impl Handler<CreateVttRequest> for app::App {
                 outputs,
                 utxo_strategy: msg.utxo_strategy.clone(),
                 selected_utxos: msg.selected_utxos.iter().map(|x| x.into()).collect(),
+                preview: msg.preview,
             };
 
             act.create_vtt(&msg.session_id, &msg.wallet_id, params)

--- a/wallet/src/actors/app/routes.rs
+++ b/wallet/src/actors/app/routes.rs
@@ -15,7 +15,7 @@ macro_rules! routes {
         {
             let api_addr = $api.clone();
             $io.add_method($method_jsonrpc, move |params: Params| {
-                log::debug!("Handling request for method: {}", $method_jsonrpc);
+                log::debug!("Handling request for method {}: {:?}", $method_jsonrpc, params);
                 let addr = api_addr.clone();
                 // Try to parse the request params into the actor message
                 let fut03 = future::ready(params.parse::<$actor_msg>())

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -352,7 +352,7 @@ impl Worker {
         let address = if external {
             wallet.gen_external_address(label)?
         } else {
-            wallet.gen_internal_address(label)?
+            wallet.gen_internal_address(label, false)?
         };
 
         Ok(address)

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -149,11 +149,13 @@ pub struct VttParams {
     pub outputs: Vec<ValueTransferOutput>,
     pub utxo_strategy: UtxoSelectionStrategy,
     pub selected_utxos: HashSet<model::OutPtr>,
+    pub preview: bool,
 }
 
 pub struct DataReqParams {
     pub fee: Fee,
     pub request: DataRequestOutput,
+    pub preview: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
This opens up the possibility of creating transactions in a wallet without persisting change addresses, which is needed in the case of fee estimations.

Fix #2384 