### PR TITLE
fix(net): prevent panicking when finding an unknown HTTP status code

### DIFF
--- a/data_structures/src/serialization_helpers.rs
+++ b/data_structures/src/serialization_helpers.rs
@@ -514,7 +514,7 @@ impl<'de> Visitor<'de> for RADRetrieveSerializationHelperVersionedVisitor {
             .ok_or_else(|| de::Error::missing_field("db_version"))?;
 
         match db_version {
-            0 | 1 | 2 => {
+            0..=2 => {
                 let kind = match db_version {
                     0 => RADType::Unknown,
                     1 => RADType::HttpGet,

--- a/node/tests/utils.rs
+++ b/node/tests/utils.rs
@@ -3,21 +3,21 @@ use witnet_node::utils::mode_consensus;
 #[test]
 fn test_mode_consensus() {
     // The mode consensus function selects the most common item from a list
-    let v = vec![1, 2, 3, 3, 3];
+    let v = [1, 2, 3, 3, 3];
     let c = mode_consensus(v.iter(), 51);
     assert_eq!(c, Some(&3));
 
     // When there is only one element, that element is the mode
-    let v = vec![3, 3, 3];
+    let v = [3, 3, 3];
     let c = mode_consensus(v.iter(), 51);
     assert_eq!(c, Some(&3));
 
-    let v = vec![3];
+    let v = [3];
     let c = mode_consensus(v.iter(), 51);
     assert_eq!(c, Some(&3));
 
     // But when there is a tie, there is no consensus
-    let v = vec![2, 2, 2, 3, 3, 3];
+    let v = [2, 2, 2, 3, 3, 3];
     let c = mode_consensus(v.iter(), 51);
     assert_eq!(c, None);
 
@@ -26,15 +26,15 @@ fn test_mode_consensus() {
     let c = mode_consensus(v.iter(), 51);
     assert_eq!(c, None);
 
-    let v = vec![1, 2, 3, 3, 3, 3, 3, 3];
+    let v = [1, 2, 3, 3, 3, 3, 3, 3];
     let c = mode_consensus(v.iter(), 70);
     assert_eq!(c, Some(&3));
 
-    let v = vec![1, 2, 2, 3, 3, 3, 3, 3];
+    let v = [1, 2, 2, 3, 3, 3, 3, 3];
     let c = mode_consensus(v.iter(), 70);
     assert_eq!(c, None);
 
-    let v = vec![
+    let v = [
         Some(1),
         Some(1),
         Some(1),
@@ -51,7 +51,7 @@ fn test_mode_consensus() {
     let c = mode_consensus(v.iter(), 60);
     assert_eq!(c, Some(&Some(1)));
 
-    let v = vec![
+    let v = [
         Some(1),
         Some(1),
         Some(1),
@@ -68,7 +68,7 @@ fn test_mode_consensus() {
     let c = mode_consensus(v.iter(), 60);
     assert_eq!(c, None);
 
-    let v = vec![
+    let v = [
         Some(1),
         Some(1),
         Some(1),

--- a/p2p/tests/peers.rs
+++ b/p2p/tests/peers.rs
@@ -144,13 +144,10 @@ fn p2p_peers_remove_from_new_with_index() {
 
     // Add address
     let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-    let src_address = Some(SocketAddr::new(
-        IpAddr::V4(Ipv4Addr::new(168, 0, 0, 12)),
-        8080,
-    ));
-    peers.add_to_new(vec![address], src_address).unwrap();
+    let src_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(168, 0, 0, 12)), 8080);
+    peers.add_to_new(vec![address], Some(src_address)).unwrap();
 
-    let index = peers.new_bucket_index(&address, &src_address.unwrap());
+    let index = peers.new_bucket_index(&address, &src_address);
 
     // Remove address
     assert_eq!(peers.remove_from_new_with_index(&[index]), vec![address]);

--- a/rad/src/filters/deviation.rs
+++ b/rad/src/filters/deviation.rs
@@ -608,9 +608,9 @@ mod tests {
 
     #[test]
     fn test_filter_deviation_standard_integer_three_int_sigma() {
-        let input = vec![1, 2, 3];
+        let input = [1, 2, 3];
         let sigmas = 1;
-        let expected = vec![2];
+        let expected = [2];
 
         let input_vec: Vec<RadonTypes> = input
             .iter()

--- a/rad/src/script.rs
+++ b/rad/src/script.rs
@@ -327,7 +327,7 @@ mod tests {
         let partial_expected = vec![
             input,
             RadonTypes::from(RadonMap::from(
-                vec![
+                [
                     (
                         String::from("base"),
                         RadonTypes::from(RadonString::from("stations")),
@@ -335,7 +335,7 @@ mod tests {
                     (
                         String::from("clouds"),
                         RadonTypes::from(RadonMap::from(
-                            vec![(
+                            [(
                                 String::from("all"),
                                 RadonTypes::from(RadonInteger::from(75)),
                             )]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -251,7 +251,7 @@ lazy_static! {
     };
 }
 
-static CONFIG_HELP: &str = r#"Load configuration from this file. If not specified will try to find a configuration
+static CONFIG_HELP: &str = r"Load configuration from this file. If not specified will try to find a configuration
 in these paths:
 - current path
 - standard configuration path:
@@ -260,7 +260,7 @@ in these paths:
   - C:\Users\<YOUR USER>\AppData\Roaming\witnet\witnet.toml
 - /etc/witnet/witnet.toml if in a *nix platform
 If no configuration is found. The default configuration is used, see `config` subcommand if
-you want to know more about the default config."#;
+you want to know more about the default config.";
 
 #[test]
 #[cfg(all(not(debug_assertions), feature = "telemetry"))]

--- a/src/cli/wallet/with_wallet.rs
+++ b/src/cli/wallet/with_wallet.rs
@@ -76,9 +76,9 @@ pub struct ConfigParams {
     concurrency: Option<usize>,
 }
 
-static WALLET_DB_HELP: &str = r#"Path to the wallet database. If not specified will use:
+static WALLET_DB_HELP: &str = r"Path to the wallet database. If not specified will use:
 - $XDG_DATA_HOME/witnet/wallet.db in Gnu/Linux
 - $HOME/Libary/Application\ Support/witnet/wallet.db in MacOS
 - {FOLDERID_LocalAppData}/witnet/wallet.db in Windows
 If one of the above directories cannot be determined,
-the current one will be used."#;
+the current one will be used.";

--- a/validations/src/tests/mod.rs
+++ b/validations/src/tests/mod.rs
@@ -6362,7 +6362,7 @@ fn create_tally_validation_dr_liar() {
         dr_pkh,
         &report,
         vec![rewarded[0], rewarded[1], dr_pkh],
-        vec![rewarded[0], rewarded[1], dr_pkh]
+        [rewarded[0], rewarded[1], dr_pkh]
             .iter()
             .cloned()
             .collect::<HashSet<PublicKeyHash>>(),
@@ -6457,7 +6457,7 @@ fn create_tally_validation_5_reveals_1_liar_1_error() {
             slashed[0],
             error_witnesses[0],
         ],
-        vec![
+        [
             rewarded[0],
             rewarded[1],
             rewarded[2],
@@ -6531,7 +6531,7 @@ fn create_tally_validation_4_commits_2_reveals() {
         dr_pkh,
         &report,
         vec![rewarded[0], rewarded[1]],
-        vec![rewarded[0], rewarded[1], slashed[0], slashed[1]]
+        [rewarded[0], rewarded[1], slashed[0], slashed[1]]
             .iter()
             .cloned()
             .collect::<HashSet<PublicKeyHash>>(),

--- a/wallet/tests/data_requests.rs
+++ b/wallet/tests/data_requests.rs
@@ -36,7 +36,7 @@ fn test_radon_types_json_serialization() {
     assert_eq!(serde_json::to_string(&radon_type).unwrap(), expected_json);
 
     let radon_type = RadonTypes::from(RadonMap::from(
-        vec![(
+        [(
             String::from("foo"),
             RadonTypes::from(RadonString::from("bar")),
         )]


### PR DESCRIPTION
This prevents a potential DoS attack to where witnessing nodes could be forced into a temporal desynchronization state and slashing could be triggered on them on purpose. 