### PR TITLE
gitfix(jsonrpc): read simple positional argument in getBalance

### DIFF
--- a/node/src/actors/json_rpc/api.rs
+++ b/node/src/actors/json_rpc/api.rs
@@ -1316,7 +1316,7 @@ pub async fn get_balance(params: Params) -> JsonRpcResult {
             ));
         };
 
-        simple = false;
+        simple = params.get(1).and_then(Value::as_bool).unwrap_or(false);
     } else {
         let params: GetBalanceParams = params.parse()?;
         pkh = params.pkh;


### PR DESCRIPTION
The  initial suggestion was:
```rs
  simple = params.get(1).unwrap_or(false);
```
But, we also have to call `parse` over the possible `String` so the one-liner would be:
```rs
  simple = params.get(1).and_then(|v| v.as_str().map(|s| s.parse().unwrap_or(false))).unwrap_or(false);
```

As the previous line looks a bit hard to read, I have used an `if let` which seems more readable.