### PR TITLE
Update function signature in signaling_info function

### DIFF
--- a/node/src/actors/json_rpc/api.rs
+++ b/node/src/actors/json_rpc/api.rs
@@ -1774,6 +1774,8 @@ pub async fn get_superblock(params: Result<GetSuperblockBlocksParams, Error>) ->
         Err(e) => Err(internal_error_s(e)),
     }
 }
+/// Get the list of protocol upgrades that are already active and the ones
+/// that are currently being polled for activation signaling
 pub async fn signaling_info() -> JsonRpcResult {
     let chain_manager_addr = ChainManager::from_registry();
 

--- a/node/src/actors/json_rpc/api.rs
+++ b/node/src/actors/json_rpc/api.rs
@@ -130,8 +130,8 @@ pub fn attach_regular_methods<H>(
     server.add_actix_method(system, "getSuperblock", |params: Params| {
         Box::pin(get_superblock(params.parse()))
     });
-    server.add_actix_method(system, "signalingInfo", |params: Params| {
-        Box::pin(signaling_info(params.parse()))
+    server.add_actix_method(system, "signalingInfo", |_params: Params| {
+        Box::pin(signaling_info())
     });
     server.add_actix_method(system, "priority", |_params: Params| Box::pin(priority()));
 }
@@ -1774,14 +1774,7 @@ pub async fn get_superblock(params: Result<GetSuperblockBlocksParams, Error>) ->
         Err(e) => Err(internal_error_s(e)),
     }
 }
-
-/// Get the blocks that pertain to the superblock index
-pub async fn signaling_info(params: Result<(), Error>) -> JsonRpcResult {
-    match params {
-        Ok(()) => (),
-        Err(e) => return Err(e),
-    };
-
+pub async fn signaling_info() -> JsonRpcResult {
     let chain_manager_addr = ChainManager::from_registry();
 
     let info = chain_manager_addr


### PR DESCRIPTION
- [refactor(jsonrpc): ignore params in signaling_info function](https://github.com/witnet/witnet-rust/commit/0d42a2dd18b4d1eec052700f1a2400dac202790b)
- [docs(jsonrpc): replace signaling_info comment with an appropiate one](https://github.com/witnet/witnet-rust/commit/15c13c602c138b142b8716643fdd7871f7188012)