### PR TITLE
Implement JSON-RPC method queryStakes

### DIFF
--- a/data_structures/src/staking/aux.rs
+++ b/data_structures/src/staking/aux.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Debug, Display, Formatter};
 use std::{rc::Rc, str::FromStr, sync::RwLock};
 
 use failure::Error;
@@ -95,6 +96,19 @@ where
             validator: Address::from_str(val).unwrap(),
             withdrawer: Address::from_str(val).unwrap(),
         }
+    }
+}
+
+impl<Address> Display for StakeKey<Address>
+where
+    Address: Display,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "validator: {} withdrawer: {}",
+            self.validator, self.withdrawer
+        )
     }
 }
 

--- a/data_structures/src/staking/errors.rs
+++ b/data_structures/src/staking/errors.rs
@@ -1,12 +1,25 @@
-use std::sync::PoisonError;
-
 use crate::staking::aux::StakeKey;
+use failure::Fail;
+use std::{
+    convert::From,
+    fmt::{Debug, Display},
+    sync::PoisonError,
+};
 
 /// All errors related to the staking functionality.
-#[derive(Debug, PartialEq)]
-pub enum StakesError<Address, Coins, Epoch> {
+#[derive(Debug, PartialEq, Fail)]
+pub enum StakesError<Address, Coins, Epoch>
+where
+    Address: Debug + Display + Sync + Send + 'static,
+    Coins: Debug + Display + Sync + Send + 'static,
+    Epoch: Debug + Display + Sync + Send + 'static,
+{
     /// The amount of coins being staked or the amount that remains after unstaking is below the
     /// minimum stakeable amount.
+    #[fail(
+        display = "The amount of coins being staked ({}) or the amount that remains after unstaking is below the minimum stakeable amount ({})",
+        amount, minimum
+    )]
     AmountIsBelowMinimum {
         /// The number of coins being staked or remaining after staking.
         amount: Coins,
@@ -14,6 +27,10 @@ pub enum StakesError<Address, Coins, Epoch> {
         minimum: Coins,
     },
     /// Tried to query `Stakes` for information that belongs to the past.
+    #[fail(
+        display = "Tried to query `Stakes` for information that belongs to the past. Query Epoch: {} Latest Epoch: {}",
+        epoch, latest
+    )]
     EpochInThePast {
         ///  The Epoch being referred.
         epoch: Epoch,
@@ -21,6 +38,10 @@ pub enum StakesError<Address, Coins, Epoch> {
         latest: Epoch,
     },
     /// An operation thrown an Epoch value that overflows.
+    #[fail(
+        display = "An operation thrown an Epoch value that overflows. Computed Epoch: {} Maximum Epoch: {}",
+        computed, maximum
+    )]
     EpochOverflow {
         /// The computed Epoch value.
         computed: u64,
@@ -28,18 +49,56 @@ pub enum StakesError<Address, Coins, Epoch> {
         maximum: Epoch,
     },
     /// Tried to query for a stake entry that is not registered in `Stakes`.
+    #[fail(
+        display = "Tried to query for a stake entry that is not registered in Stakes {}",
+        key
+    )]
     EntryNotFound {
         /// A validator and withdrawer address pair.
         key: StakeKey<Address>,
     },
     /// Tried to obtain a lock on a write-locked piece of data that is already locked.
+    #[fail(
+        display = "The authentication signature contained within a stake transaction is not valid for the given validator and withdrawer addresses"
+    )]
     PoisonedLock,
     /// The authentication signature contained within a stake transaction is not valid for the given validator and
     /// withdrawer addresses.
+    #[fail(
+        display = "The authentication signature contained within a stake transaction is not valid for the given validator and withdrawer addresses"
+    )]
     InvalidAuthentication,
+    /// Tried to query for a stake entry by validator that is not registered in `Stakes`.
+    #[fail(
+        display = "Tried to query for a stake entry by validator ({}) that is not registered in Stakes",
+        validator
+    )]
+    ValidatorNotFound {
+        /// A validator address.
+        validator: Address,
+    },
+    /// Tried to query for a stake entry by withdrawer that is not registered in `Stakes`.
+    #[fail(
+        display = "Tried to query for a stake entry by withdrawer ({}) that is not registered in Stakes",
+        withdrawer
+    )]
+    WithdrawerNotFound {
+        /// A withdrawer address.
+        withdrawer: Address,
+    },
+    /// Tried to query for a stake entry without providing a validator or a withdrawer address.
+    #[fail(
+        display = "Tried to query a stake entry without providing a validator or a withdrawer address"
+    )]
+    EmptyQuery,
 }
 
-impl<T, Address, Coins, Epoch> From<PoisonError<T>> for StakesError<Address, Coins, Epoch> {
+impl<T, Address, Coins, Epoch> From<PoisonError<T>> for StakesError<Address, Coins, Epoch>
+where
+    Address: Debug + Display + Sync + Send + 'static,
+    Coins: Debug + Display + Sync + Send + 'static,
+    Epoch: Debug + Display + Sync + Send + 'static,
+{
     fn from(_value: PoisonError<T>) -> Self {
         StakesError::PoisonedLock
     }

--- a/data_structures/src/staking/stake.rs
+++ b/data_structures/src/staking/stake.rs
@@ -3,6 +3,7 @@ use std::{marker::PhantomData, ops::*};
 use serde::{Deserialize, Serialize};
 
 use super::prelude::*;
+use std::fmt::{Debug, Display};
 
 /// A data structure that keeps track of a staker's staked coins and the epochs for different
 /// capabilities.
@@ -23,7 +24,7 @@ where
 
 impl<Address, Coins, Epoch, Power> Stake<Address, Coins, Epoch, Power>
 where
-    Address: Default,
+    Address: Default + Debug + Display + Sync + Send,
     Coins: Copy
         + From<u64>
         + PartialOrd
@@ -31,8 +32,20 @@ where
         + Add<Output = Coins>
         + Sub<Output = Coins>
         + Mul
-        + Mul<Epoch, Output = Power>,
-    Epoch: Copy + Default + num_traits::Saturating + Sub<Output = Epoch> + From<u32>,
+        + Mul<Epoch, Output = Power>
+        + Debug
+        + Display
+        + Send
+        + Sync,
+    Epoch: Copy
+        + Default
+        + num_traits::Saturating
+        + Sub<Output = Epoch>
+        + From<u32>
+        + Debug
+        + Display
+        + Sync
+        + Send,
     Power: Add<Output = Power> + Div<Output = Power>,
     u64: From<Coins> + From<Power>,
 {

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -290,6 +290,11 @@ pub fn exec_cmd(
         Command::AuthorizeStake { node, withdrawer } => {
             rpc::authorize_st(node.unwrap_or(default_jsonrpc), withdrawer)
         }
+        Command::QueryStakes {
+            node,
+            withdrawer,
+            validator,
+        } => rpc::query_stakes(node.unwrap_or(default_jsonrpc), withdrawer, validator),
     }
 }
 
@@ -783,6 +788,15 @@ pub enum Command {
         node: Option<SocketAddr>,
         /// Withdrawer address
         #[structopt(long = "withdrawer")]
+        withdrawer: Option<String>,
+    },
+    QueryStakes {
+        /// Socket address of the Witnet node to query
+        #[structopt(short = "n", long = "node")]
+        node: Option<SocketAddr>,
+        #[structopt(short = "v", long = "validator")]
+        validator: Option<String>,
+        #[structopt(short = "w", long = "withdrawer")]
         withdrawer: Option<String>,
     },
 }


### PR DESCRIPTION
Implement JSON-RPC and CLI methods that allow querying the stakes of the specified address/addresses argument.
The argument can contain:
- A validator and a withdrawer
- A validator
- A withdrawer
- Empty argument, uses the node's address as validator.

close #2424
close #2423 