### PR TITLE
feat(validations): raise a transaction error when too many witnesses are requested

### DIFF
--- a/data_structures/src/error.rs
+++ b/data_structures/src/error.rs
@@ -74,6 +74,14 @@ pub enum TransactionError {
     #[fail(display = "Data Request witnesses number must be greater than zero")]
     InsufficientWitnesses,
     #[fail(
+        display = "Number of data Request witnesses must be at most one fourth of the number of validators: {} > {}",
+        witnesses, one_fourth_of_validators
+    )]
+    TooManyWitnesses {
+        witnesses: u16,
+        one_fourth_of_validators: usize,
+    },
+    #[fail(
         display = "Mismatch between expected tally ({:?}) and miner tally ({:?})",
         expected_tally, miner_tally
     )]

--- a/data_structures/src/staking/stakes.rs
+++ b/data_structures/src/staking/stakes.rs
@@ -311,6 +311,11 @@ where
         }
     }
 
+    /// Return the total number of validators.
+    pub fn validator_count(&self) -> usize {
+        self.by_validator.len()
+    }
+
     /// Query stakes by stake key.
     #[inline(always)]
     fn query_by_key(&self, key: StakeKey<Address>) -> StakingResult<Coins, Address, Coins, Epoch> {

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -80,6 +80,7 @@ use witnet_data_structures::{
     },
     utxo_pool::{Diff, OwnUnspentOutputsPool, UnspentOutputsPool, UtxoWriteBatch},
     vrf::VrfCtx,
+    wit::Wit,
 };
 use witnet_rad::types::RadonTypes;
 use witnet_util::timestamp::seconds_to_human_string;
@@ -699,6 +700,7 @@ impl ChainManager {
                 &chain_info.consensus_constants,
                 resynchronizing,
                 &active_wips,
+                &self.chain_state.stakes,
                 Some(&mut transaction_visitor),
             )?;
 
@@ -840,6 +842,7 @@ impl ChainManager {
                     &chain_info.consensus_constants,
                     false,
                     &active_wips,
+                    &self.chain_state.stakes,
                     Some(&mut transaction_visitor),
                 ) {
                     Ok(utxo_diff) => {
@@ -1438,6 +1441,7 @@ impl ChainManager {
                 // than or equal to the current epoch
                 block_epoch: current_epoch,
             };
+            let stakes = &self.chain_state.stakes;
             let collateral_age = if active_wips.wip0027() {
                 PSEUDO_CONSENSUS_CONSTANTS_WIP0027_COLLATERAL_AGE
             } else {
@@ -1464,6 +1468,7 @@ impl ChainManager {
                 chain_info.consensus_constants.minimum_difficulty,
                 required_reward_collateral_ratio,
                 &active_wips,
+                &stakes,
                 chain_info.consensus_constants.superblock_period,
             ))
             .into_actor(self)
@@ -2011,6 +2016,7 @@ impl ChainManager {
                 block_number,
                 &consensus_constants,
                 &active_wips,
+                &act.chain_state.stakes,
                 None,
             );
             async {
@@ -2786,6 +2792,7 @@ pub fn process_validations(
     consensus_constants: &ConsensusConstants,
     resynchronizing: bool,
     active_wips: &ActiveWips,
+    stakes: &Stakes<PublicKeyHash, Wit, u32, u64>,
     transaction_visitor: Option<&mut dyn Visitor<Visitable = (Transaction, u64, u32)>>,
 ) -> Result<Diff, failure::Error> {
     if !resynchronizing {
@@ -2815,6 +2822,7 @@ pub fn process_validations(
         block_number,
         consensus_constants,
         active_wips,
+        stakes,
         transaction_visitor,
     )?;
 

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -732,6 +732,7 @@ fn deserialize_and_validate_hex_dr(
         collateral_minimum,
         required_reward_collateral_ratio,
         &current_active_wips(),
+        None,
     )?;
     validate_rad_request(&dr.data_request, &current_active_wips())?;
 

--- a/wallet/src/actors/app/handlers/create_data_req.rs
+++ b/wallet/src/actors/app/handlers/create_data_req.rs
@@ -136,6 +136,7 @@ fn validate(
         minimum_collateral,
         required_reward_collateral_ratio,
         &current_active_wips(),
+        None,
     )
     .map_err(|err| app::field_error("request", format!("{}", err)));
 


### PR DESCRIPTION
This PR serves as a proof-of-concept of how we could validate that a data request does not request too many witnesses. The threshold is hard-coded to 1/4th of the amount of validators.

It is probably more convenient to just pass the validator count rather than the full Stakes Tracker. However, I wanted to have this PR serve as a test on how to pass the Stakes Tracker as an argument since that will be required for other validation functions.

The JSON-RPC CLI and wallet cannot really access the Stakes Tracker, so they pass it a None value. If the implementation were to be simplified to pass the validator count as a single number, they could presumably query it from the node before validating the data request.