### PR TITLE
TooManyWitnesses RAD error tally

### DIFF
--- a/data_structures/src/chain/mod.rs
+++ b/data_structures/src/chain/mod.rs
@@ -3589,6 +3589,8 @@ pub struct DataRequestInfo {
     pub current_reveal_round: u16,
     /// Current stage, or None if finished
     pub current_stage: Option<DataRequestStage>,
+    /// Too many witnesses requested
+    pub too_many_witnesses: bool,
 }
 
 impl Default for DataRequestInfo {
@@ -3602,6 +3604,7 @@ impl Default for DataRequestInfo {
             current_commit_round: 0,
             current_reveal_round: 0,
             current_stage: Some(DataRequestStage::COMMIT),
+            too_many_witnesses: false,
         }
     }
 }
@@ -3693,14 +3696,20 @@ impl DataRequestState {
         }
     }
 
+    pub fn set_too_many_witnesses(&mut self) {
+        self.info.too_many_witnesses = true;
+    }
+
     /// Advance to the next stage.
     /// Since the data requests are updated by looking at the transactions from a valid block,
     /// the only issue would be that there were no commits in that block.
-    pub fn update_stage(&mut self, extra_rounds: u16) {
+    pub fn update_stage(&mut self, extra_rounds: u16, too_many_witnesses: bool) {
         self.stage = match self.stage {
             DataRequestStage::COMMIT => {
                 if self.info.commits.is_empty() {
-                    if self.info.current_commit_round <= extra_rounds {
+                    if too_many_witnesses {
+                        DataRequestStage::TALLY
+                    } else if self.info.current_commit_round <= extra_rounds {
                         self.info.current_commit_round += 1;
                         DataRequestStage::COMMIT
                     } else {

--- a/data_structures/src/data_request.rs
+++ b/data_structures/src/data_request.rs
@@ -242,7 +242,7 @@ impl DataRequestPool {
     /// for reveal (the node should send a reveal transaction).
     /// This function must be called after `add_data_requests_from_block`, in order to update
     /// the stage of all the data requests.
-    pub fn update_data_request_stages(&mut self) -> Vec<RevealTransaction> {
+    pub fn update_data_request_stages(&mut self, validator_count: usize) -> Vec<RevealTransaction> {
         let waiting_for_reveal = &mut self.waiting_for_reveal;
         let data_requests_by_epoch = &mut self.data_requests_by_epoch;
         let extra_rounds = self.extra_rounds;
@@ -252,7 +252,9 @@ impl DataRequestPool {
             .filter_map(|(dr_pointer, dr_state)| {
                 // We can notify the user that a data request from "my_claims" is available
                 // for reveal.
-                dr_state.update_stage(extra_rounds);
+                let too_many_witnesses =
+                    data_request_has_too_many_witnesses(&dr_state.data_request, validator_count);
+                dr_state.update_stage(extra_rounds, too_many_witnesses);
                 match dr_state.stage {
                     DataRequestStage::REVEAL => {
                         // When a data request changes from commit stage to reveal stage, it should
@@ -366,6 +368,14 @@ impl DataRequestPool {
     /// Get the detailed state of a data request.
     pub fn data_request_state(&self, dr_pointer: &Hash) -> Option<&DataRequestState> {
         self.data_request_pool.get(dr_pointer)
+    }
+
+    /// Get the detailed state of a data request.
+    pub fn data_request_state_mutable(
+        &mut self,
+        dr_pointer: &Hash,
+    ) -> Option<&mut DataRequestState> {
+        self.data_request_pool.get_mut(dr_pointer)
     }
 
     /// Get the data request info of the finished data requests, to be persisted to the storage
@@ -523,6 +533,14 @@ pub fn calculate_reward_collateral_ratio(
     };
 
     saturating_div_ceil(dr_collateral, witness_reward)
+}
+
+/// Function to check if a data request requires too many witnesses
+pub fn data_request_has_too_many_witnesses(
+    dr_output: &DataRequestOutput,
+    validator_count: usize,
+) -> bool {
+    usize::from(dr_output.witnesses) > validator_count / 4
 }
 
 /// Saturating version of `u64::div_ceil`.

--- a/data_structures/src/radon_error.rs
+++ b/data_structures/src/radon_error.rs
@@ -50,6 +50,8 @@ pub enum RadonErrors {
     InsufficientCommits = 0x52,
     /// Generic error during tally execution
     TallyExecution = 0x53,
+    /// Insufficient stakers to resolve the data request
+    TooManyWitnesses = 0x54,
     /// Invalid reveal serialization (malformed reveals are converted to this value)
     MalformedReveal = 0x60,
     /// Failed to encode reveal

--- a/data_structures/src/staking/stakes.rs
+++ b/data_structures/src/staking/stakes.rs
@@ -311,6 +311,11 @@ where
         }
     }
 
+    /// Return the total number of validators.
+    pub fn validator_count(&self) -> usize {
+        self.by_validator.len()
+    }
+
     /// Query stakes by stake key.
     #[inline(always)]
     fn query_by_key(&self, key: StakeKey<Address>) -> StakingResult<Coins, Address, Coins, Epoch> {

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -1022,6 +1022,8 @@ pub struct RunTally {
     /// Active Witnet protocol improvements as of the block that will include this tally.
     /// Used to select the correct version of the validation logic.
     pub active_wips: ActiveWips,
+    /// Variable indicating if the amount of requested witnesses exceeds a certain fraction of the amount of stakers
+    pub too_many_witnesses: bool,
 }
 
 impl Message for ResolveRA {

--- a/node/src/actors/rad_manager/handlers.rs
+++ b/node/src/actors/rad_manager/handlers.rs
@@ -84,8 +84,13 @@ impl Handler<ResolveRA> for RadManager {
 
             // Evaluate tally precondition to ensure that at least 20% of the data sources are not errors.
             // This stage does not need to evaluate the postcondition.
-            let clause_result =
-                evaluate_tally_precondition_clause(retrieve_responses, 0.2, 1, &msg.active_wips);
+            let clause_result = evaluate_tally_precondition_clause(
+                retrieve_responses,
+                0.2,
+                1,
+                &msg.active_wips,
+                false,
+            );
             match clause_result {
                 Ok(TallyPreconditionClauseResult::MajorityOfValues {
                     values,
@@ -135,6 +140,7 @@ impl Handler<RunTally> for RadManager {
                 msg.min_consensus_ratio,
                 msg.commits_count,
                 &msg.active_wips,
+                msg.too_many_witnesses,
             )
         };
 
@@ -273,6 +279,7 @@ mod tests {
                     rad_request,
                     timeout: None,
                     active_wips,
+                    too_many_witnesses: false,
                 })
                 .await
                 .unwrap()
@@ -312,6 +319,7 @@ mod tests {
                     rad_request,
                     timeout: None,
                     active_wips,
+                    too_many_witnesses: false,
                 })
                 .await
                 .unwrap()

--- a/rad/src/conditions.rs
+++ b/rad/src/conditions.rs
@@ -44,7 +44,12 @@ pub fn evaluate_tally_precondition_clause(
     minimum_consensus: f64,
     num_commits: usize,
     active_wips: &ActiveWips,
+    too_many_witnesses: bool,
 ) -> Result<TallyPreconditionClauseResult, RadError> {
+    // Short-circuit if there are not enough stakers
+    if too_many_witnesses {
+        return Err(RadError::TooManyWitnesses);
+    }
     // Short-circuit if there were no commits
     if num_commits == 0 {
         return Err(RadError::InsufficientCommits);

--- a/rad/src/error.rs
+++ b/rad/src/error.rs
@@ -293,6 +293,9 @@ pub enum RadError {
     /// No commits received
     #[fail(display = "Insufficient commits received")]
     InsufficientCommits,
+    /// No commits received
+    #[fail(display = "Too many witnesses request for the amount of stakers")]
+    TooManyWitnesses,
     /// No reveals received
     #[fail(display = "No reveals received")]
     NoReveals,
@@ -435,6 +438,7 @@ impl RadError {
             RadonErrors::ScriptTooManyCalls => RadError::ScriptTooManyCalls,
             RadonErrors::Overflow => RadError::Overflow,
             RadonErrors::InsufficientCommits => RadError::InsufficientCommits,
+            RadonErrors::TooManyWitnesses => RadError::TooManyWitnesses,
             RadonErrors::NoReveals => RadError::NoReveals,
             RadonErrors::SourceScriptNotCBOR => RadError::SourceScriptNotCBOR,
             RadonErrors::SourceScriptNotArray => RadError::SourceScriptNotArray,
@@ -585,6 +589,7 @@ impl RadError {
             RadError::Overflow => RadonErrors::Overflow,
             RadError::DivisionByZero => RadonErrors::DivisionByZero,
             RadError::InsufficientCommits => RadonErrors::InsufficientCommits,
+            RadError::TooManyWitnesses => RadonErrors::TooManyWitnesses,
             RadError::NoReveals => RadonErrors::NoReveals,
             RadError::RetrieveTimeout => RadonErrors::RetrieveTimeout,
             RadError::InsufficientConsensus { .. } => RadonErrors::InsufficientConsensus,

--- a/rad/src/lib.rs
+++ b/rad/src/lib.rs
@@ -63,6 +63,7 @@ pub fn try_data_request(
     settings: RadonScriptExecutionSettings,
     inputs_injection: Option<&[&str]>,
     witnessing: Option<WitnessingConfig<witnet_net::Uri>>,
+    too_many_witnesses: bool,
 ) -> RADRequestExecutionReport {
     #[cfg(not(test))]
     let active_wips = current_active_wips();
@@ -115,6 +116,7 @@ pub fn try_data_request(
         0.2,
         1,
         &current_active_wips(),
+        too_many_witnesses,
     );
 
     let aggregation_report = match clause_result {
@@ -1516,6 +1518,7 @@ mod tests {
             RadonScriptExecutionSettings::enable_all(),
             None,
             None,
+            false,
         );
         let tally_result = report.tally.into_inner();
 
@@ -1559,6 +1562,7 @@ mod tests {
             RadonScriptExecutionSettings::enable_all(),
             None,
             None,
+            false,
         );
         let tally_result = report.tally.into_inner();
 
@@ -1611,6 +1615,7 @@ mod tests {
             RadonScriptExecutionSettings::enable_all(),
             None,
             None,
+            false,
         );
         let tally_result = report.tally.into_inner();
 
@@ -1663,6 +1668,7 @@ mod tests {
             RadonScriptExecutionSettings::enable_all(),
             None,
             None,
+            false,
         );
         let tally_result = report.tally.into_inner();
 
@@ -1715,6 +1721,7 @@ mod tests {
             RadonScriptExecutionSettings::enable_all(),
             None,
             None,
+            false,
         );
         let tally_result = report.tally.into_inner();
 
@@ -1780,6 +1787,7 @@ mod tests {
             RadonScriptExecutionSettings::enable_all(),
             Some(&["1", "1", "error"]),
             None,
+            false,
         );
         let tally_result = report.tally.into_inner();
 

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -1373,6 +1373,7 @@ pub fn data_request_report(
                     non_error_min,
                     commits_count,
                     &active_wips,
+                    false,
                 );
 
                 local_tally = Some(report.into_inner());

--- a/toolkit/src/data_requests.rs
+++ b/toolkit/src/data_requests.rs
@@ -52,7 +52,7 @@ pub fn try_data_request(
     } else {
         RadonScriptExecutionSettings::disable_all()
     };
-    let report = witnet_rad::try_data_request(request, settings, None, None);
+    let report = witnet_rad::try_data_request(request, settings, None, None, false);
 
     Ok(report)
 }

--- a/wallet/src/actors/worker/methods.rs
+++ b/wallet/src/actors/worker/methods.rs
@@ -55,6 +55,7 @@ impl Worker {
             RadonScriptExecutionSettings::enable_all(),
             None,
             Some(self.params.witnessing.clone()),
+            false,
         )
     }
 

--- a/wallet/tests/data_requests.rs
+++ b/wallet/tests/data_requests.rs
@@ -109,6 +109,7 @@ fn test_data_request_report_json_serialization() {
         RadonScriptExecutionSettings::enable_all(),
         Some(&inputs),
         None,
+        false,
     );
 
     // Number of retrieval reports should match number of sources


### PR DESCRIPTION
This is an alternative implemenation to #2444 where instead of refusing to build a block with a data request requiring too many witnesses, the data request is included by a miner together with a tally. The tally has a TooManyWitnesses Radon error as result.

This is potentially more robust because of two reasons:
1) It won't keep invalid data requests in the transaction pool
2) By creating a tally the (decentralized) bridge can report an actual tally result rather than make something up