### PR TITLE
fix(mining): abort trying to mine a block when the node is not eligible

### DIFF
--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -111,7 +111,8 @@ impl ChainManager {
                     log::info!("Hurray! Found eligibility for proposing a block candidate!");
                 }
                 Eligible::No(_) => {
-                    log::debug!("No eligibility for proposing a block candidate.")
+                    log::debug!("No eligibility for proposing a block candidate.");
+                    return Ok(());
                 }
             }
         }


### PR DESCRIPTION
Adds a single return statement in `mining.rs` to prevent the validator still proposing a block even when he's not eligible.