### PR TITLE
feat(mining): reset collateral age of the validator which mined the latest block

### DIFF
--- a/data_structures/src/error.rs
+++ b/data_structures/src/error.rs
@@ -472,10 +472,7 @@ pub enum BlockError {
     )]
     MissingExpectedTallies { count: usize, block_hash: Hash },
     /// Missing expected tallies
-    #[fail(
-        display = "Validator {} is not eligible to propose a block",
-        validator,
-    )]
+    #[fail(display = "Validator {} is not eligible to propose a block", validator)]
     ValidatorNotEligible { validator: PublicKeyHash },
 }
 

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -806,7 +806,8 @@ impl ChainManager {
                         return;
                     }
                 };
-                let protocol_version = get_protocol_version(Some(block.block_header.beacon.checkpoint));
+                let protocol_version =
+                    get_protocol_version(Some(block.block_header.beacon.checkpoint));
 
                 if let Some(best_candidate) = &self.best_candidate {
                     let best_hash = best_candidate.block.hash();

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -924,6 +924,13 @@ impl ChainManager {
             }
         };
 
+        let current_epoch = if let Some(epoch) = self.current_epoch {
+            epoch
+        } else {
+            log::error!("Current epoch not loaded in ChainManager");
+            return;
+        };
+
         match self.chain_state {
             ChainState {
                 chain_info: Some(ref mut chain_info),
@@ -992,6 +999,10 @@ impl ChainManager {
                 );
 
                 let miner_pkh = block.block_header.proof.proof.pkh();
+
+                // Reset the coin age of the miner for all staked coins
+                let key = StakeKey::from((miner_pkh, miner_pkh));
+                let _ = stakes.reset_age(key, Capability::Mining, current_epoch);
 
                 // Do not update reputation or stakes when consolidating genesis block
                 if block_hash != chain_info.consensus_constants.genesis_hash {

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -34,10 +34,7 @@ use witnet_data_structures::{
     get_protocol_version,
     proto::versioning::{ProtocolVersion, VersionedHashable},
     radon_report::{RadonReport, ReportContext},
-    staking::{
-        prelude::StakeKey,
-        stakes::Stakes,
-    },
+    staking::{prelude::StakeKey, stakes::Stakes},
     transaction::{
         CommitTransaction, DRTransaction, MintTransaction, RevealTransaction, StakeTransaction,
         TallyTransaction, Transaction, UnstakeTransaction, VTTransaction,
@@ -46,7 +43,7 @@ use witnet_data_structures::{
     types::visitor::Visitor,
     utxo_pool::{Diff, UnspentOutputsPool, UtxoDiff},
     vrf::{BlockEligibilityClaim, DataRequestEligibilityClaim, VrfCtx},
-    wit::{NANOWITS_PER_WIT, Wit},
+    wit::{Wit, NANOWITS_PER_WIT},
 };
 use witnet_rad::{
     conditions::{
@@ -61,7 +58,7 @@ use witnet_rad::{
 
 use crate::eligibility::{
     current::{
-        Eligible, Eligibility,
+        Eligibility, Eligible,
         IneligibilityReason::{InsufficientPower, NotStaking},
     },
     legacy::*,
@@ -2076,8 +2073,10 @@ pub fn validate_block(
             let validator = block.block_sig.public_key.pkh();
             let validator_key = StakeKey::from((validator, validator));
             let eligibility = stakes.mining_eligibility(validator_key, block_epoch);
-            if eligibility == Ok(Eligible::No(InsufficientPower)) || eligibility == Ok(Eligible::No(NotStaking)) {
-                return Err(BlockError::ValidatorNotEligible{ validator }.into());
+            if eligibility == Ok(Eligible::No(InsufficientPower))
+                || eligibility == Ok(Eligible::No(NotStaking))
+            {
+                return Err(BlockError::ValidatorNotEligible { validator }.into());
             }
 
             Hash::max()
@@ -2322,9 +2321,7 @@ pub fn compare_block_candidates(
             .cmp(&b2_vrf_hash)
             .reverse()
             // Bigger block implies worse block candidate
-            .then(
-                b1_hash.cmp(&b2_hash).reverse()
-            )
+            .then(b1_hash.cmp(&b2_hash).reverse())
     } else {
         let section1 = s.slot(&b1_vrf_hash);
         let section2 = s.slot(&b2_vrf_hash);


### PR DESCRIPTION
I think this is the only spot where we need to reset the collateral age of the validator which mined a block. I am not entirely happy with using `self.current_epoch.unwrap_or_default()`, but it should be safe since we would not get here if `current_epoch` was `None`.