### PR TITLE
(fix): switch query-stakes arguments

### DIFF
--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -292,9 +292,9 @@ pub fn exec_cmd(
         }
         Command::QueryStakes {
             node,
-            withdrawer,
             validator,
-        } => rpc::query_stakes(node.unwrap_or(default_jsonrpc), withdrawer, validator),
+            withdrawer,
+        } => rpc::query_stakes(node.unwrap_or(default_jsonrpc), validator, withdrawer),
     }
 }
 


### PR DESCRIPTION
The arguments to the `query_stakes` function in `with_node.rs` were in the incorrect order which resulted in querying the withdrawer when a validator was requested and vice versa.