### PR TITLE
fix(stakes): fix mining by a validator with a different withdrawer address

### DIFF
--- a/bridges/centralized-ethereum/src/actors/dr_sender/tests.rs
+++ b/bridges/centralized-ethereum/src/actors/dr_sender/tests.rs
@@ -4,14 +4,14 @@ use witnet_data_structures::chain::{RADAggregate, RADRequest, RADRetrieve, RADTa
 #[test]
 fn deserialize_empty_dr() {
     // An empty data request is invalid with error 0xE0: BridgeMalformedRequest
-    let err = deserialize_and_validate_dr_bytes(&[], 1).unwrap_err();
+    let err = deserialize_and_validate_dr_bytes(&[], 0, 1).unwrap_err();
     assert_eq!(err.encode_cbor(), vec![216, 39, 129, 24, 224]);
 }
 
 #[test]
 fn deserialize_dr_not_protobuf() {
     // A malformed data request is invalid with error 0xE0: BridgeMalformedRequest
-    let err = deserialize_and_validate_dr_bytes(&[1, 2, 3, 4], 1).unwrap_err();
+    let err = deserialize_and_validate_dr_bytes(&[1, 2, 3, 4], 0, 1).unwrap_err();
     assert_eq!(err.encode_cbor(), vec![216, 39, 129, 24, 224]);
 }
 
@@ -55,7 +55,8 @@ fn deserialize_dr_high_value() {
     let dro_bytes = dro.to_pb_bytes().unwrap();
     // Setting the maximum allowed value to 1 nanowit below that will result in an error 0xE1:
     // BridgePoorIncentives
-    let err = deserialize_and_validate_dr_bytes(&dro_bytes, total_value - 1).unwrap_err();
+    let err =
+        deserialize_and_validate_dr_bytes(&dro_bytes, 1_000_000_000, total_value - 1).unwrap_err();
     assert_eq!(err.encode_cbor(), vec![216, 39, 129, 24, 225]);
 }
 
@@ -78,7 +79,7 @@ fn deserialize_dr_collateral_one_nanowit() {
     assert_eq!(total_value, 20_000_000);
 
     let dro_bytes = dro.to_pb_bytes().unwrap();
-    let err = deserialize_and_validate_dr_bytes(&dro_bytes, total_value).unwrap_err();
+    let err = deserialize_and_validate_dr_bytes(&dro_bytes, 1, total_value).unwrap_err();
     assert_eq!(err.encode_cbor(), vec![216, 39, 129, 24, 224]);
 }
 
@@ -95,7 +96,7 @@ fn deserialize_dr_value_overflow() {
     };
 
     let dro_bytes = dro.to_pb_bytes().unwrap();
-    let err = deserialize_and_validate_dr_bytes(&dro_bytes, 1).unwrap_err();
+    let err = deserialize_and_validate_dr_bytes(&dro_bytes, 0, 1).unwrap_err();
     assert_eq!(err.encode_cbor(), vec![216, 39, 129, 24, 224]);
 }
 
@@ -115,6 +116,7 @@ fn deserialize_and_validate_dr_bytes_wip_0022() {
     let dro_bytes = dro.to_pb_bytes().unwrap();
     let witnet_dr_max_value_nanowits = 100_000_000_000;
     let err =
-        deserialize_and_validate_dr_bytes(&dro_bytes, witnet_dr_max_value_nanowits).unwrap_err();
+        deserialize_and_validate_dr_bytes(&dro_bytes, 1_000_000_000, witnet_dr_max_value_nanowits)
+            .unwrap_err();
     assert_eq!(err.encode_cbor(), vec![216, 39, 129, 24, 224]);
 }

--- a/bridges/centralized-ethereum/src/main.rs
+++ b/bridges/centralized-ethereum/src/main.rs
@@ -119,7 +119,10 @@ fn run(callback: fn()) -> Result<(), String> {
 
         // Initialize Storage Manager
         let mut node_config = NodeConfig::default();
-        node_config.storage.db_path = config.storage.db_path.clone();
+        node_config
+            .storage
+            .db_path
+            .clone_from(&config.storage.db_path);
         storage_mngr::start_from_config(node_config);
     });
 

--- a/data_structures/src/chain/mod.rs
+++ b/data_structures/src/chain/mod.rs
@@ -1642,7 +1642,7 @@ impl KeyedSignature {
         compact: &[u8],
         message: &[u8],
     ) -> Result<Self, Secp256k1ConversionError> {
-        let recid = RecoveryId::from_i32(compact[0] as i32)
+        let recid = RecoveryId::from_i32(i32::from(compact[0]))
             .map_err(|e| Secp256k1ConversionError::Secp256k1 { inner: e })?;
         let recoverable = RecoverableSignature::from_compact(&compact[1..], recid)
             .map_err(|e| Secp256k1ConversionError::Secp256k1 { inner: e })?;

--- a/data_structures/src/staking/errors.rs
+++ b/data_structures/src/staking/errors.rs
@@ -1,4 +1,4 @@
-use crate::staking::aux::StakeKey;
+use crate::staking::helpers::StakeKey;
 use failure::Fail;
 use std::{
     convert::From,

--- a/data_structures/src/staking/mod.rs
+++ b/data_structures/src/staking/mod.rs
@@ -1,11 +1,11 @@
 #![deny(missing_docs)]
 
-/// Auxiliary convenience types and data structures.
-pub mod helpers;
 /// Constants related to the staking functionality.
 pub mod constants;
 /// Errors related to the staking functionality.
 pub mod errors;
+/// Auxiliary convenience types and data structures.
+pub mod helpers;
 /// The data structure and related logic for stake entries.
 pub mod stake;
 /// The data structure and related logic for keeping track of multiple stake entries.
@@ -16,9 +16,9 @@ pub mod stakes;
 pub mod prelude {
     pub use crate::capabilities::*;
 
-    pub use super::helpers::*;
     pub use super::constants::*;
     pub use super::errors::*;
+    pub use super::helpers::*;
     pub use super::stake::*;
     pub use super::stakes::*;
 }

--- a/data_structures/src/staking/stake.rs
+++ b/data_structures/src/staking/stake.rs
@@ -79,6 +79,7 @@ where
         let product_added = coins * epoch;
 
         let coins_after = coins_before + coins;
+        #[allow(clippy::cast_possible_truncation)]
         let epoch_after = Epoch::from(
             (u64::from(product_before + product_added) / u64::from(coins_after)) as u32,
         );

--- a/data_structures/src/utxo_pool.rs
+++ b/data_structures/src/utxo_pool.rs
@@ -311,26 +311,23 @@ impl OwnUnspentOutputsPool {
             map: HashMap::default(),
         }
     }
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&u64>
+    pub fn get<Q: ?Sized + std::hash::Hash + Eq>(&self, k: &Q) -> Option<&u64>
     where
         OutputPointer: std::borrow::Borrow<Q>,
-        Q: std::hash::Hash + Eq,
     {
         self.map.get(k)
     }
 
-    pub fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut u64>
+    pub fn get_mut<Q: ?Sized + std::hash::Hash + Eq>(&mut self, k: &Q) -> Option<&mut u64>
     where
         OutputPointer: std::borrow::Borrow<Q>,
-        Q: std::hash::Hash + Eq,
     {
         self.map.get_mut(k)
     }
 
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn contains_key<Q: ?Sized + std::hash::Hash + Eq>(&self, k: &Q) -> bool
     where
         OutputPointer: std::borrow::Borrow<Q>,
-        Q: std::hash::Hash + Eq,
     {
         self.map.contains_key(k)
     }

--- a/data_structures/src/wit.rs
+++ b/data_structures/src/wit.rs
@@ -1,8 +1,8 @@
-use std::{fmt, ops::*};
+use std::{fmt, iter::Sum, ops::*};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{chain::Epoch, staking::aux::Power};
+use crate::{chain::Epoch, staking::helpers::Power};
 
 /// 1 nanowit is the minimal unit of value
 /// 1 wit = 10^9 nanowits
@@ -135,6 +135,19 @@ impl From<u64> for Wit {
 impl From<Wit> for u64 {
     fn from(value: Wit) -> Self {
         value.0
+    }
+}
+
+impl Sum for Wit {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = Wit>,
+    {
+        let mut total = Wit::from_nanowits(0);
+        for w in iter {
+            total = total + w;
+        }
+        total
     }
 }
 

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -917,7 +917,7 @@ impl Handler<PeersBeacons> for ChainManager {
         let beacon_consensus = peers_beacons.superblock_consensus(consensus_threshold);
         let outbound_limit = peers_beacons.outbound_limit;
         let pb_len = peers_beacons.pb.len();
-        self.last_received_beacons = peers_beacons.pb.clone();
+        self.last_received_beacons.clone_from(&peers_beacons.pb);
         let peers_needed_for_consensus = outbound_limit
             .map(|x| {
                 // ceil(x * consensus_threshold / 100)

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -36,7 +36,6 @@ use witnet_data_structures::{
     proto::versioning::{ProtocolVersion, VersionedHashable},
     radon_error::RadonError,
     radon_report::{RadonReport, ReportContext, TypeLike},
-    staking::prelude::*,
     transaction::{
         CommitTransaction, CommitTransactionBody, DRTransactionBody, MintTransaction,
         RevealTransaction, RevealTransactionBody, StakeTransactionBody, TallyTransaction,
@@ -113,11 +112,10 @@ impl ChainManager {
         let mut vrf_input = chain_info.highest_vrf_output;
 
         if get_protocol_version(self.current_epoch) == ProtocolVersion::V2_0 {
-            let key = StakeKey::from((own_pkh, own_pkh));
             let eligibility = self
                 .chain_state
                 .stakes
-                .mining_eligibility(key, current_epoch)
+                .mining_eligibility(own_pkh, current_epoch)
                 .map_err(ChainManagerError::Staking)?;
 
             match eligibility {

--- a/node/src/actors/chain_manager/mining.rs
+++ b/node/src/actors/chain_manager/mining.rs
@@ -1190,6 +1190,7 @@ mod tests {
         // Set `max_vt_weight` and `max_dr_weight` to zero (no transaction should be included)
         let max_vt_weight = 0;
         let max_dr_weight = 0;
+        let max_st_weight = 0;
 
         // Fields required to mine a block
         let block_beacon = CheckpointBeacon::default();
@@ -1219,6 +1220,7 @@ mod tests {
             (&mut transaction_pool, &unspent_outputs_pool, &dr_pool),
             max_vt_weight,
             max_dr_weight,
+            max_st_weight,
             block_beacon,
             block_proof,
             &[],

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -4042,6 +4042,7 @@ mod tests {
                     vrf_hash_2,
                     false,
                     &VrfSlots::new(vec![Hash::default()]),
+                    ProtocolVersion::V1_7,
                 ),
                 Ordering::Greater
             );

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -1012,8 +1012,7 @@ impl ChainManager {
                 let miner_pkh = block.block_header.proof.proof.pkh();
 
                 // Reset the coin age of the miner for all staked coins
-                let key = StakeKey::from((miner_pkh, miner_pkh));
-                let _ = stakes.reset_age(key, Capability::Mining, current_epoch);
+                let _ = stakes.reset_age(miner_pkh, Capability::Mining, current_epoch);
 
                 // Do not update reputation or stakes when consolidating genesis block
                 if block_hash != chain_info.consensus_constants.genesis_hash {

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -27,7 +27,7 @@ use witnet_data_structures::{
     },
     fee::{deserialize_fee_backwards_compatible, Fee},
     radon_report::RadonReport,
-    staking::{aux::StakeKey, stakes::QueryStakesKey},
+    staking::{helpers::StakeKey, stakes::QueryStakesKey},
     transaction::{
         CommitTransaction, DRTransaction, RevealTransaction, StakeTransaction, Transaction,
         VTTransaction,

--- a/node/src/actors/session/handlers.rs
+++ b/node/src/actors/session/handlers.rs
@@ -81,6 +81,7 @@ enum HandshakeError {
 impl WriteHandler<Error> for Session {}
 
 /// Payload for the notification for a specific epoch
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct EpochPayload;
 

--- a/p2p/tests/sessions.rs
+++ b/p2p/tests/sessions.rs
@@ -375,15 +375,13 @@ fn p2p_sessions_consolidate() {
     assert!(sessions
         .outbound_unconsolidated
         .collection
-        .get(&outbound_address)
-        .is_some());
+        .contains_key(&outbound_address));
     assert_eq!(sessions.outbound_consolidated.collection.len(), 0);
     assert_eq!(sessions.inbound_consolidated.collection.len(), 0);
     assert!(sessions
         .inbound_unconsolidated
         .collection
-        .get(&inbound_address)
-        .is_some());
+        .contains_key(&inbound_address));
 
     // Consolidate session
     assert!(sessions
@@ -397,14 +395,12 @@ fn p2p_sessions_consolidate() {
     assert!(sessions
         .outbound_consolidated
         .collection
-        .get(&outbound_address)
-        .is_some());
+        .contains_key(&outbound_address));
     assert_eq!(sessions.outbound_unconsolidated.collection.len(), 0);
     assert!(sessions
         .inbound_consolidated
         .collection
-        .get(&inbound_address)
-        .is_some());
+        .contains_key(&inbound_address));
 }
 
 /// Check the consensus of outbound consolidated sessions
@@ -434,8 +430,7 @@ fn p2p_sessions_consensus() {
     assert!(sessions
         .outbound_consolidated
         .collection
-        .get(&outbound_address)
-        .is_some());
+        .contains_key(&outbound_address));
 
     assert_eq!(sessions.outbound_unconsolidated.collection.len(), 0);
     assert_eq!(sessions.outbound_consolidated.collection.len(), 1);

--- a/partial_struct/tests/partial_struct_derive.rs
+++ b/partial_struct/tests/partial_struct_derive.rs
@@ -5,6 +5,7 @@ use partial_struct::PartialStruct;
 fn test_partial_derive() {
     #[derive(PartialStruct, Debug, Clone, PartialEq)]
     #[partial_struct(derive(Debug, Clone, PartialEq))]
+    #[allow(dead_code)]
     struct Obj;
 
     let p = PartialObj;

--- a/rad/src/reducers/mod.rs
+++ b/rad/src/reducers/mod.rs
@@ -161,9 +161,7 @@ mod tests {
         assert_eq!(output, expected);
 
         // Deactivate WIP-0017
-        active_wips
-            .active_wips
-            .remove(&"WIP0017-0018-0019".to_string());
+        active_wips.active_wips.remove("WIP0017-0018-0019");
         context.active_wips = Some(active_wips);
 
         let expected_err = RadError::UnsupportedReducer {

--- a/validations/benches/reppoe.rs
+++ b/validations/benches/reppoe.rs
@@ -7,8 +7,6 @@ use witnet_data_structures::chain::{
     Alpha, Environment, PublicKeyHash, Reputation, ReputationEngine,
 };
 
-// To benchmark the old algorithm, comment out this import:
-use witnet_validations::validations;
 // To benchmark the old algorithm, comment out the line that says cfg any:
 #[cfg(any())]
 mod validations {
@@ -87,7 +85,7 @@ fn be<I>(
     }
     // Initialize cache
     rep_eng.total_active_reputation();
-    validations::calculate_reppoe_threshold(
+    witnet_validations::eligibility::legacy::calculate_reppoe_threshold(
         &rep_eng,
         &my_pkh,
         num_witnesses,
@@ -101,7 +99,7 @@ fn be<I>(
         if invalidate_threshold_cache {
             rep_eng.clear_threshold_cache();
         }
-        validations::calculate_reppoe_threshold(
+        witnet_validations::eligibility::legacy::calculate_reppoe_threshold(
             &rep_eng,
             &my_pkh,
             num_witnesses,

--- a/validations/src/eligibility/current.rs
+++ b/validations/src/eligibility/current.rs
@@ -202,7 +202,7 @@ where
         };
 
         let mut rank = self.rank(Capability::Mining, epoch);
-        let rf = 2usize.pow(round as u32) * witnesses as usize;
+        let rf = 2usize.pow(u32::from(round)) * witnesses as usize;
 
         // Requirement no. 2 from the WIP:
         //  "the witnessing power of the block proposer is in the `rf / stakers`th quantile among the witnessing powers
@@ -251,13 +251,13 @@ mod tests {
             stakes.mining_eligibility(isk, 0),
             Ok(Eligible::No(IneligibilityReason::NotStaking))
         );
-        assert_eq!(stakes.mining_eligibility_bool(isk, 0), false);
+        assert!(!stakes.mining_eligibility_bool(isk, 0));
 
         assert_eq!(
             stakes.mining_eligibility(isk, 100),
             Ok(Eligible::No(IneligibilityReason::NotStaking))
         );
-        assert_eq!(stakes.mining_eligibility_bool(isk, 100), false);
+        assert!(!stakes.mining_eligibility_bool(isk, 100));
     }
 
     #[test]
@@ -271,10 +271,10 @@ mod tests {
             stakes.mining_eligibility(isk, 0),
             Ok(Eligible::No(IneligibilityReason::InsufficientPower))
         );
-        assert_eq!(stakes.mining_eligibility_bool(isk, 0), false);
+        assert!(!stakes.mining_eligibility_bool(isk, 0));
 
         assert_eq!(stakes.mining_eligibility(isk, 100), Ok(Eligible::Yes));
-        assert_eq!(stakes.mining_eligibility_bool(isk, 100), true);
+        assert!(stakes.mining_eligibility_bool(isk, 100));
     }
 
     #[test]
@@ -286,13 +286,13 @@ mod tests {
             stakes.witnessing_eligibility(isk, 0, 10, 0),
             Ok(Eligible::No(IneligibilityReason::NotStaking))
         );
-        assert_eq!(stakes.witnessing_eligibility_bool(isk, 0, 10, 0), false);
+        assert!(!stakes.witnessing_eligibility_bool(isk, 0, 10, 0));
 
         assert_eq!(
             stakes.witnessing_eligibility(isk, 100, 10, 0),
             Ok(Eligible::No(IneligibilityReason::NotStaking))
         );
-        assert_eq!(stakes.witnessing_eligibility_bool(isk, 100, 10, 0), false);
+        assert!(!stakes.witnessing_eligibility_bool(isk, 100, 10, 0));
     }
 
     #[test]
@@ -306,12 +306,12 @@ mod tests {
             stakes.witnessing_eligibility(isk, 0, 10, 0),
             Ok(Eligible::No(IneligibilityReason::InsufficientPower))
         );
-        assert_eq!(stakes.witnessing_eligibility_bool(isk, 0, 10, 0), false);
+        assert!(!stakes.witnessing_eligibility_bool(isk, 0, 10, 0));
 
         assert_eq!(
             stakes.witnessing_eligibility(isk, 100, 10, 0),
             Ok(Eligible::Yes)
         );
-        assert_eq!(stakes.witnessing_eligibility_bool(isk, 100, 10, 0), true);
+        assert!(stakes.witnessing_eligibility_bool(isk, 100, 10, 0));
     }
 }

--- a/validations/src/tests/compare_block_candidates.rs
+++ b/validations/src/tests/compare_block_candidates.rs
@@ -1,4 +1,7 @@
-use witnet_data_structures::chain::{tapi::current_active_wips, Hash, Reputation};
+use witnet_data_structures::{
+    chain::{tapi::current_active_wips, Hash, Reputation},
+    proto::versioning::ProtocolVersion,
+};
 
 use std::cmp::Ordering;
 
@@ -33,6 +36,7 @@ fn test_compare_candidate_same_section() {
                                     vrf_j,
                                     act_j,
                                     &vrf_sections,
+                                    ProtocolVersion::V1_7,
                                 ),
                                 Ordering::Less
                             );
@@ -47,6 +51,7 @@ fn test_compare_candidate_same_section() {
                                     vrf_j,
                                     act_j,
                                     &vrf_sections,
+                                    ProtocolVersion::V1_7,
                                 ),
                                 Ordering::Greater
                             );
@@ -73,6 +78,7 @@ fn test_compare_candidate_same_section() {
                             vrf_j,
                             false,
                             &vrf_sections,
+                            ProtocolVersion::V1_7,
                         ),
                         Ordering::Greater
                     );
@@ -87,6 +93,7 @@ fn test_compare_candidate_same_section() {
                             vrf_j,
                             true,
                             &vrf_sections,
+                            ProtocolVersion::V1_7,
                         ),
                         Ordering::Less
                     );
@@ -109,6 +116,7 @@ fn test_compare_candidate_same_section() {
                     vrf_2,
                     true,
                     &vrf_sections,
+                    ProtocolVersion::V1_7,
                 ),
                 Ordering::Greater
             );
@@ -123,6 +131,7 @@ fn test_compare_candidate_same_section() {
                     vrf_1,
                     true,
                     &vrf_sections,
+                    ProtocolVersion::V1_7,
                 ),
                 Ordering::Less
             );
@@ -141,6 +150,7 @@ fn test_compare_candidate_same_section() {
             vrf_1,
             true,
             &vrf_sections,
+            ProtocolVersion::V1_7,
         ),
         Ordering::Greater
     );
@@ -155,6 +165,7 @@ fn test_compare_candidate_same_section() {
             vrf_1,
             true,
             &vrf_sections,
+            ProtocolVersion::V1_7,
         ),
         Ordering::Less
     );
@@ -171,6 +182,7 @@ fn test_compare_candidate_same_section() {
             vrf_1,
             true,
             &vrf_sections,
+            ProtocolVersion::V1_7,
         ),
         Ordering::Equal
     );
@@ -207,6 +219,7 @@ fn test_compare_candidate_different_section() {
                                     vrf_2,
                                     act_j,
                                     &vrf_sections,
+                                    ProtocolVersion::V1_7,
                                 ),
                                 Ordering::Greater
                             );
@@ -221,6 +234,7 @@ fn test_compare_candidate_different_section() {
                                     vrf_1,
                                     act_j,
                                     &vrf_sections,
+                                    ProtocolVersion::V1_7,
                                 ),
                                 Ordering::Less
                             );
@@ -255,6 +269,7 @@ fn test_compare_candidate_different_reputation_bigger_than_zero() {
             vrf_2,
             true,
             &vrf_sections,
+            ProtocolVersion::V1_7,
         ),
         Ordering::Greater
     );
@@ -270,6 +285,7 @@ fn test_compare_candidate_different_reputation_bigger_than_zero() {
             vrf_1,
             true,
             &vrf_sections,
+            ProtocolVersion::V1_7,
         ),
         Ordering::Less
     );

--- a/validations/src/tests/mod.rs
+++ b/validations/src/tests/mod.rs
@@ -23,12 +23,15 @@ use witnet_data_structures::{
         calculate_tally_change, calculate_witness_reward, create_tally, DataRequestPool,
     },
     error::{BlockError, DataRequestError, Secp256k1ConversionError, TransactionError},
+    proto::versioning::ProtocolVersion,
     radon_error::RadonError,
     radon_report::{RadonReport, ReportContext, TypeLike},
+    staking::prelude::Stakes,
     transaction::*,
     transaction_factory::transaction_outputs_sum,
     utxo_pool::{UnspentOutputsPool, UtxoDiff},
     vrf::{BlockEligibilityClaim, DataRequestEligibilityClaim, VrfCtx},
+    wit::Wit,
 };
 use witnet_protected::Protected;
 use witnet_rad::{
@@ -8808,6 +8811,8 @@ fn test_block_with_drpool_and_utxo_set<F: FnMut(&mut Block) -> bool>(
         &rep_eng,
         &consensus_constants,
         &active_wips,
+        ProtocolVersion::V1_7,
+        &Stakes::<PublicKeyHash, Wit, u32, u64>::default(),
     )?;
     verify_signatures_test(signatures_to_verify)?;
     let mut signatures_to_verify = vec![];
@@ -9083,6 +9088,8 @@ fn block_difficult_proof() {
                 &rep_eng,
                 &consensus_constants,
                 &current_active_wips(),
+                ProtocolVersion::V1_7,
+                &Stakes::<PublicKeyHash, Wit, u32, u64>::default(),
             )?;
             verify_signatures_test(signatures_to_verify)?;
             let mut signatures_to_verify = vec![];
@@ -9790,6 +9797,8 @@ fn test_blocks_with_limits(
             &rep_eng,
             &consensus_constants,
             &current_active_wips(),
+            ProtocolVersion::V1_7,
+            &Stakes::<PublicKeyHash, Wit, u32, u64>::default(),
         )?;
         verify_signatures_test(signatures_to_verify)?;
         let mut signatures_to_verify = vec![];
@@ -10300,6 +10309,8 @@ fn genesis_block_after_not_bootstrap_hash() {
         &rep_eng,
         &consensus_constants,
         &current_active_wips(),
+        ProtocolVersion::V1_7,
+        &Stakes::<PublicKeyHash, Wit, u32, u64>::default(),
     );
     assert_eq!(signatures_to_verify, vec![]);
 
@@ -10380,6 +10391,8 @@ fn genesis_block_value_overflow() {
         &rep_eng,
         &consensus_constants,
         &current_active_wips(),
+        ProtocolVersion::V1_7,
+        &Stakes::<PublicKeyHash, Wit, u32, u64>::default(),
     )
     .unwrap();
     assert_eq!(signatures_to_verify, vec![]);
@@ -10465,6 +10478,8 @@ fn genesis_block_full_validate() {
         &rep_eng,
         &consensus_constants,
         &current_active_wips(),
+        ProtocolVersion::V1_7,
+        &Stakes::<PublicKeyHash, Wit, u32, u64>::default(),
     )
     .unwrap();
     assert_eq!(signatures_to_verify, vec![]);

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -1056,7 +1056,7 @@ pub fn validate_tally_transaction<'a>(
             if is_after_second_hard_fork {
                 if honests_count > 0 {
                     // Make sure every rewarded address is a revealer
-                    if dr_state.info.reveals.get(&output.pkh).is_none() {
+                    if !dr_state.info.reveals.contains_key(&output.pkh) {
                         return Err(TransactionError::RevealNotFound.into());
                     }
                     // Make sure every rewarded address passed the tally function, a.k.a. "is honest" / "is not a liar"
@@ -1086,7 +1086,7 @@ pub fn validate_tally_transaction<'a>(
                     }
                 } else {
                     // Make sure every rewarded address is a committer
-                    if dr_state.info.commits.get(&output.pkh).is_none() {
+                    if !dr_state.info.commits.contains_key(&output.pkh) {
                         return Err(TransactionError::CommitNotFound.into());
                     }
                     // Validation of the reward, must be equal to the collateral
@@ -1102,7 +1102,7 @@ pub fn validate_tally_transaction<'a>(
                 // Old logic used before second hard fork
                 if reveals_count > 0 {
                     // Make sure every rewarded address is a revealer
-                    if dr_state.info.reveals.get(&output.pkh).is_none() {
+                    if !dr_state.info.reveals.contains_key(&output.pkh) {
                         return Err(TransactionError::RevealNotFound.into());
                     }
                     // Make sure every rewarded address passed the tally function, a.k.a. "is honest" / "is not a liar"
@@ -2314,7 +2314,7 @@ pub fn compare_block_candidates(
     s: &VrfSlots,
     version: ProtocolVersion,
 ) -> Ordering {
-    let ordering = if version == ProtocolVersion::V2_0 {
+    if version == ProtocolVersion::V2_0 {
         // Bigger vrf hash implies worse block candidate
         b1_vrf_hash
             .cmp(&b2_vrf_hash)
@@ -2348,9 +2348,7 @@ pub fn compare_block_candidates(
             .then(b1_vrf_hash.cmp(&b2_vrf_hash).reverse())
             // Bigger block implies worse block candidate
             .then(b1_hash.cmp(&b2_hash).reverse())
-    };
-
-    ordering
+    }
 }
 
 /// Blocking process to verify signatures

--- a/validations/src/validations.rs
+++ b/validations/src/validations.rs
@@ -34,7 +34,7 @@ use witnet_data_structures::{
     get_protocol_version,
     proto::versioning::{ProtocolVersion, VersionedHashable},
     radon_report::{RadonReport, ReportContext},
-    staking::{prelude::StakeKey, stakes::Stakes},
+    staking::stakes::Stakes,
     transaction::{
         CommitTransaction, DRTransaction, MintTransaction, RevealTransaction, StakeTransaction,
         TallyTransaction, Transaction, UnstakeTransaction, VTTransaction,
@@ -2071,8 +2071,7 @@ pub fn validate_block(
     } else {
         let target_hash = if protocol_version == ProtocolVersion::V2_0 {
             let validator = block.block_sig.public_key.pkh();
-            let validator_key = StakeKey::from((validator, validator));
-            let eligibility = stakes.mining_eligibility(validator_key, block_epoch);
+            let eligibility = stakes.mining_eligibility(validator, block_epoch);
             if eligibility == Ok(Eligible::No(InsufficientPower))
                 || eligibility == Ok(Eligible::No(NotStaking))
             {

--- a/wallet/src/db/mod.rs
+++ b/wallet/src/db/mod.rs
@@ -47,6 +47,7 @@ pub trait Database {
         K: AsRef<[u8]>,
         V: serde::de::DeserializeOwned;
 
+    #[allow(dead_code)]
     fn contains<K, V>(&self, key: &Key<K, V>) -> Result<bool>
     where
         K: AsRef<[u8]>;

--- a/wallet/src/repository/wallet/mod.rs
+++ b/wallet/src/repository/wallet/mod.rs
@@ -819,7 +819,7 @@ where
             // Check if any input or output is from the wallet (input is an UTXO or output points to any wallet's pkh)
             if inputs
                 .iter()
-                .any(|input| state.utxo_set.get(&input.output_pointer().into()).is_some())
+                .any(|input| state.utxo_set.contains_key(&input.output_pointer().into()))
                 || outputs.iter().any(check_db_and_transient)
             {
                 filtered_txns.push(txn.clone());


### PR DESCRIPTION
This fixes #2466, #2467 and tackles the `by_validator` issue mentioned in #2464.