### PR TITLE
fix(chain_manager): fix some synchronization issues

### DIFF
--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -71,7 +71,7 @@ use witnet_data_structures::{
     },
     data_request::DataRequestPool,
     get_environment, get_protocol_version, get_protocol_version_activation_epoch,
-    proto::versioning::ProtocolVersion,
+    proto::versioning::{ProtocolVersion, VersionedHashable},
     radon_error::RadonError,
     radon_report::{RadonReport, ReportContext},
     register_protocol_version,
@@ -705,7 +705,7 @@ impl ChainManager {
 
             let mut transaction_visitor = PriorityVisitor::default();
 
-            let protocol_version = get_protocol_version(self.current_epoch);
+            let protocol_version = get_protocol_version(Some(block.block_header.beacon.checkpoint));
             let utxo_diff = process_validations(
                 &block,
                 self.current_epoch.unwrap_or_default(),
@@ -978,8 +978,8 @@ impl ChainManager {
                 ref mut stakes,
                 ..
             } => {
-                let block_hash = block.hash();
                 let block_epoch = block.block_header.beacon.checkpoint;
+                let block_hash = block.versioned_hash(get_protocol_version(Some(block_epoch)));
                 let block_signals = block.block_header.signals;
                 let validator_count = stakes.validator_count();
 

--- a/node/src/actors/inventory_manager/handlers.rs
+++ b/node/src/actors/inventory_manager/handlers.rs
@@ -4,6 +4,8 @@ use witnet_data_structures::{
     chain::{
         Block, Epoch, Hash, Hashable, InventoryEntry, InventoryItem, PointerToBlock, SuperBlock,
     },
+    get_protocol_version,
+    proto::versioning::VersionedHashable,
     transaction::Transaction,
 };
 
@@ -42,7 +44,9 @@ impl InventoryManager {
 
             match item {
                 StoreInventoryItem::Block(block) => {
-                    let block_hash = block.hash();
+                    let block_hash = block.versioned_hash(get_protocol_version(Some(
+                        block.block_header.beacon.checkpoint,
+                    )));
                     let key = match block_hash {
                         Hash::SHA256(h) => h.to_vec(),
                     };

--- a/node/src/storage_mngr/node_migrations.rs
+++ b/node/src/storage_mngr/node_migrations.rs
@@ -62,27 +62,20 @@ fn migrate_chain_state_v3_to_v4(old_chain_state_bytes: &[u8]) -> Vec<u8> {
     let db_version: u32 = 4;
     let db_version_bytes = db_version.to_le_bytes();
 
-    // This little trick makes sure that we don't run a migration on a v4 chain state that was
-    // incorrectly tagged as v3 in the context of a development release, by checking if the bytes
-    // match a pattern where the environment enum is stored at a certain position
-    if old_chain_state_bytes[5..9] == [0x02, 0x00, 0x00, 0x00] {
-        // Extra fields in ChainState v4:
-        let protocol_info = ProtocolInfo::default();
-        let protocol_info_bytes = serialize(&protocol_info).unwrap();
-        let stakes = StakesTracker::default();
-        let stakes_bytes = serialize(&stakes).unwrap();
+    // Extra fields in ChainState v4:
+    let protocol_info = ProtocolInfo::default();
+    let protocol_info_bytes = serialize(&protocol_info).unwrap();
+    let stakes = StakesTracker::default();
+    let stakes_bytes = serialize(&stakes).unwrap();
 
-        [
-            &db_version_bytes,
-            &old_chain_state_bytes[4..5],
-            &protocol_info_bytes,
-            &old_chain_state_bytes[5..],
-            &stakes_bytes,
-        ]
-        .concat()
-    } else {
-        [&db_version_bytes, &old_chain_state_bytes[4..]].concat()
-    }
+    [
+        &db_version_bytes,
+        &old_chain_state_bytes[4..5],
+        &protocol_info_bytes,
+        &old_chain_state_bytes[5..],
+        &stakes_bytes,
+    ]
+    .concat()
 }
 
 fn migrate_chain_state(mut bytes: Vec<u8>) -> Result<ChainState, failure::Error> {


### PR DESCRIPTION
This PR contains two distinct patches that solve some synchronization issues.

```
-          let protocol_version = get_protocol_version(self.current_epoch);
+          let protocol_version = get_protocol_version(Some(block.block_header.beacon.checkpoint));
```

Pretty self-explanatory. Don't use the current epoch for validating block transactions when synchronizing blocks that may be older than the current protocol version.

```
-               let block_hash = block.hash();
                let block_epoch = block.block_header.beacon.checkpoint;
+               let block_hash = block.versioned_hash(get_protocol_version(Some(block_epoch)));
```

Somewhat more involved. When I restart a node that is already in V1.8, I noticed it failed to synchronize. It received new blocks, but did not want to add them properly. I added some debug info and found that the block hashes it receives are non-versioned block hashes while it expects versioned ones.

I logged the `InventoryAnnouncement` message it receives here (for a block starting at epoch 1010): https://github.com/witnet/witnet-rust/blob/da223feb3c39f949a7077042844ba9908be139c9/node/src/actors/session/handlers.rs#L770

```
[
    8fd76b5064d45b205dce9d8e29a388ab2af1db388c906614f213badd4c831009,
    8e70c676d64059076f9295732a94bb164589313433f07965e408116e77de8992,
    0ff6ba671f52c0994bce24d2cb7d61c545451fbcc58c4a8b4fc7ac98e9115330,
    ...
]
```
And the expected hashes when it receives block messages for epoch 1010:
```
[<] Received BLOCK #1010: 0e474e3fe73f47689c8bbb7dcd60ec50085d0c88abda5e54e34a48e7ad08cb47 message (699 bytes)
[<] Received BLOCK #1011: 8f39bb88f28eec113368c836f0ee62afd653b85008c42efa7350618e633a92eb message (699 bytes)
[<] Received BLOCK #1012: ac31e5b56174b3961f44c1228f694bd40703913aa58c56774bfdf2ea18898a85 message (699 bytes)
```
Note the different hashes. The reason for this is because the second hash for block 1010 is a versioned hash with protocol version V1.8 while the former is not. 

This results in the following line not evaluating to true:
https://github.com/witnet/witnet-rust/blob/da223feb3c39f949a7077042844ba9908be139c9/node/src/actors/session/handlers.rs#L679

After which we call `AddCandidates` which drops the block because of this condition:
https://github.com/witnet/witnet-rust/blob/da223feb3c39f949a7077042844ba9908be139c9/node/src/actors/chain_manager/mod.rs#L750

However, if we use the versioned hash as proposed in the patch, you can see that the `block_chain` structure will insert the correctly versioned hash here:
https://github.com/witnet/witnet-rust/blob/da223feb3c39f949a7077042844ba9908be139c9/node/src/actors/chain_manager/mod.rs#L1322

After which the `InventoryAnnouncement` which uses `GetBlocksEpochRange` which reads the `block_chain` structure should return the correct, expected versioned hash.

Just to confirm, I printed out the non-versioned and versioned hash for epoch 1010:
```
Consolidating block hash (old: 8fd76b5064d45b205dce9d8e29a388ab2af1db388c906614f213badd4c831009, new: 0e474e3fe73f47689c8bbb7dcd60ec50085d0c88abda5e54e34a48e7ad08cb47) for epoch 1010
```
As you can see, the old hash matches the hash we receive in the `InventoryAnnouncement` message block hash array while the new hash matches the expected versioned hash in the received block message which will eventually be processed.

I cannot fully test this works because we'd need a testnet reset since we are essentially forking the chain, but it looks reasonable.