### PR TITLE
feat(jsonrpc): allow to query all stake entries

### DIFF
--- a/data_structures/src/staking/stake.rs
+++ b/data_structures/src/staking/stake.rs
@@ -25,7 +25,9 @@ where
     /// The amount of stake and unstake actions.
     pub nonce: Nonce,
     // These two phantom fields are here just for the sake of specifying generics.
+    #[serde(skip)]
     phantom_address: PhantomData<Address>,
+    #[serde(skip)]
     phantom_power: PhantomData<Power>,
 }
 

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -1458,7 +1458,7 @@ impl Handler<QueryStake> for ChainManager {
 
     fn handle(&mut self, msg: QueryStake, _ctx: &mut Self::Context) -> Self::Result {
         // build address from public key hash
-        let stakes = self.chain_state.stakes.query_total_stake(msg.key);
+        let stakes = self.chain_state.stakes.query_stakes(msg.key);
 
         stakes.map_err(StakesError::from).map_err(Into::into)
     }

--- a/node/src/actors/json_rpc/api.rs
+++ b/node/src/actors/json_rpc/api.rs
@@ -2226,7 +2226,7 @@ pub async fn query_stakes(params: Result<Option<QueryStakesArgument>, Error>) ->
     ChainManager::from_registry()
         .send(QueryStake { key })
         .map(|res| match res {
-            Ok(Ok(staked_amount)) => serde_json::to_value(staked_amount).map_err(internal_error),
+            Ok(Ok(stakes)) => serde_json::to_value(stakes).map_err(internal_error),
             Ok(Err(e)) => {
                 let err = internal_error_s(e);
                 Err(err)

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -36,7 +36,7 @@ use witnet_data_structures::{
     transaction_factory::NodeBalance,
     types::{LastBeacon, ProtocolVersion},
     utxo_pool::{UtxoInfo, UtxoSelectionStrategy},
-    wit::Wit,
+    wit::{Wit, WIT_DECIMAL_PLACES},
 };
 use witnet_p2p::{
     error::SessionsError,
@@ -371,7 +371,10 @@ pub struct QueryStake {
 }
 
 impl Message for QueryStake {
-    type Result = Result<Wit, failure::Error>;
+    type Result = Result<
+        Vec<StakeEntry<WIT_DECIMAL_PLACES, PublicKeyHash, Wit, Epoch, u64, u64>>,
+        failure::Error,
+    >;
 }
 
 impl<Address> From<QueryStakesParams> for QueryStakesKey<Address>

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -353,6 +353,8 @@ pub enum QueryStakesParams {
     Withdrawer(PublicKeyHash),
     /// To search by validator and withdrawer public key hashes
     Key((PublicKeyHash, PublicKeyHash)),
+    /// To query all stake entries
+    All,
 }
 
 impl Default for QueryStakesParams {
@@ -384,6 +386,7 @@ where
             }),
             QueryStakesParams::Validator(v) => QueryStakesKey::Validator(v.into()),
             QueryStakesParams::Withdrawer(w) => QueryStakesKey::Withdrawer(w.into()),
+            QueryStakesParams::All => QueryStakesKey::All,
         }
     }
 }

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -1932,16 +1932,20 @@ pub fn query_stakes(
     addr: SocketAddr,
     validator: Option<String>,
     withdrawer: Option<String>,
+    all: bool,
 ) -> Result<(), failure::Error> {
     let mut stream = start_client(addr)?;
-
-    let params = match (validator, withdrawer) {
-        (Some(validator), Some(withdrawer)) => {
-            Some(QueryStakesArgument::Key((validator, withdrawer)))
+    let params = if all {
+        Some(QueryStakesArgument::All(true))
+    } else {
+        match (validator, withdrawer) {
+            (Some(validator), Some(withdrawer)) => {
+                Some(QueryStakesArgument::Key((validator, withdrawer)))
+            }
+            (Some(validator), _) => Some(QueryStakesArgument::Validator(validator)),
+            (_, Some(withdrawer)) => Some(QueryStakesArgument::Withdrawer(withdrawer)),
+            (None, None) => None,
         }
-        (Some(validator), _) => Some(QueryStakesArgument::Validator(validator)),
-        (_, Some(withdrawer)) => Some(QueryStakesArgument::Withdrawer(withdrawer)),
-        (None, None) => None,
     };
 
     let response = send_request(

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -297,7 +297,8 @@ pub fn exec_cmd(
             node,
             validator,
             withdrawer,
-        } => rpc::query_stakes(node.unwrap_or(default_jsonrpc), validator, withdrawer),
+            all,
+        } => rpc::query_stakes(node.unwrap_or(default_jsonrpc), validator, withdrawer, all),
         Command::Unstake {
             node,
             operator,
@@ -832,6 +833,8 @@ pub enum Command {
         validator: Option<String>,
         #[structopt(short = "w", long = "withdrawer")]
         withdrawer: Option<String>,
+        #[structopt(short = "a", long = "all")]
+        all: bool,
     },
     #[structopt(name = "unstake", about = "Create an unstake transaction")]
     Unstake {


### PR DESCRIPTION
- Add an `all` argument to the `query_stakes` CLI method to query all stake entries.
- Return stake information split by key instead of thee total staked amount

close #2552 
close #2559 