### PR TITLE
Implement proper mechanism for sampling superblock signing committees in V2_0

### DIFF
--- a/data_structures/src/chain/mod.rs
+++ b/data_structures/src/chain/mod.rs
@@ -4888,7 +4888,7 @@ mod tests {
 
     use crate::{
         proto::versioning::{ProtocolVersion, VersionedHashable},
-        superblock::{mining_build_superblock, ARSIdentities},
+        superblock::{mining_build_superblock, Census},
         transaction::{CommitTransactionBody, RevealTransactionBody, VTTransactionBody},
     };
 
@@ -6829,7 +6829,7 @@ mod tests {
 
         let expected_order = vec![p1_bls, p2_bls, p3_bls];
         let ordered_identities = rep_engine.get_rep_ordered_ars_list();
-        let ars_identities = ARSIdentities::new(ordered_identities);
+        let ars_identities = Census::new(ordered_identities);
 
         assert_eq!(
             expected_order,
@@ -6871,7 +6871,7 @@ mod tests {
 
         let expected_order = vec![p1_bls, p2_bls, p3_bls];
         let ordered_identities = rep_engine.get_rep_ordered_ars_list();
-        let ars_identities = ARSIdentities::new(ordered_identities);
+        let ars_identities = Census::new(ordered_identities);
 
         assert_eq!(
             expected_order,
@@ -6929,7 +6929,7 @@ mod tests {
 
         let expected_order = vec![p1_bls, p2_bls, p4_bls, p5_bls, p3_bls];
         let ordered_identities = rep_engine.get_rep_ordered_ars_list();
-        let ars_identities = ARSIdentities::new(ordered_identities);
+        let ars_identities = Census::new(ordered_identities);
 
         assert_eq!(
             expected_order,

--- a/data_structures/src/staking/helpers.rs
+++ b/data_structures/src/staking/helpers.rs
@@ -287,22 +287,6 @@ pub struct CoinsAndAddresses<Coins, Address> {
     pub addresses: StakeKey<Address>,
 }
 
-/// Allows telling the `census` method in `Stakes` to source addresses from its internal `by_coins`
-/// following different strategies.
-#[repr(u8)]
-#[derive(Clone, Copy, Debug)]
-pub enum CensusStrategy {
-    /// Retrieve all addresses, ordered by decreasing power.
-    All = 0,
-    /// Retrieve every Nth address, ordered by decreasing power.
-    StepBy(usize) = 1,
-    /// Retrieve the most powerful N addresses, ordered by decreasing power.
-    Take(usize) = 2,
-    /// Retrieve a total of N addresses, evenly distributed from the index, ordered by decreasing
-    /// power.
-    Evenly(usize) = 3,
-}
-
 impl<const UNIT: u8, Address, Coins, Epoch, Nonce, Power> Serialize
     for Stakes<UNIT, Address, Coins, Epoch, Nonce, Power>
 where

--- a/data_structures/src/staking/stakes.rs
+++ b/data_structures/src/staking/stakes.rs
@@ -265,6 +265,20 @@ where
         self.by_validator.len()
     }
 
+    /// Retrieve all validators, ordered by the total amount of stake that they operate.
+    pub fn validators_by_stake(&self) -> impl Iterator<Item = (Address, Coins)> + Clone + '_ {
+        self.by_validator
+            .iter()
+            .map(|(address, entries)| {
+                let coins = entries.iter().fold(Coins::zero(), |acc, entry| {
+                    acc + entry.value.read().unwrap().coins
+                });
+
+                (address.clone(), coins)
+            })
+            .sorted_by_key(|(_, coins)| *coins)
+    }
+
     /// Tells what is the power of an identity in the network on a certain epoch.
     pub fn query_power<ISK>(
         &self,

--- a/data_structures/src/staking/stakes.rs
+++ b/data_structures/src/staking/stakes.rs
@@ -260,6 +260,9 @@ where
         self.by_key.len()
     }
 
+    /// Quickly count how many different validators are recorded into this data structure.
+    pub fn validators_count(&self) -> usize {
+        self.by_validator.len()
     }
 
     /// Tells what is the power of an identity in the network on a certain epoch.

--- a/data_structures/src/staking/stakes.rs
+++ b/data_structures/src/staking/stakes.rs
@@ -260,34 +260,6 @@ where
         self.by_key.len()
     }
 
-    /// Obtain a list of stakers, conveniently ordered by one of several strategies.
-    ///
-    /// ## Strategies
-    ///
-    /// - `All`: retrieve all addresses, ordered by decreasing power.
-    /// - `StepBy`: retrieve every Nth address, ordered by decreasing power.
-    /// - `Take`: retrieve the most powerful N addresses, ordered by decreasing power.
-    /// - `Evenly`: retrieve a total of N addresses, evenly distributed from the index, ordered by
-    ///   decreasing power.
-    pub fn census(
-        &self,
-        capability: Capability,
-        epoch: Epoch,
-        strategy: CensusStrategy,
-    ) -> Box<dyn Iterator<Item = StakeKey<Address>> + '_> {
-        let iterator = self.by_rank(capability, epoch).map(|(address, _)| address);
-
-        match strategy {
-            CensusStrategy::All => Box::new(iterator),
-            CensusStrategy::StepBy(step) => Box::new(iterator.step_by(step)),
-            CensusStrategy::Take(head) => Box::new(iterator.take(head)),
-            CensusStrategy::Evenly(count) => {
-                let collected = iterator.collect::<Vec<_>>();
-                let step = collected.len() / count;
-
-                Box::new(collected.into_iter().step_by(step).take(count))
-            }
-        }
     }
 
     /// Tells what is the power of an identity in the network on a certain epoch.

--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -68,7 +68,7 @@ pub enum SuperBlockConsensus {
 ///
 /// Different protocol versions populate this data differently:
 /// - In V1_X, this contained a complete list of all ARS identities.
-/// - In V2_X, it is expected to contain all validators instead.
+/// - In V2_X, it is expected to contain a list of validators instead.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Census {
     // HashSet containing the identities

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -72,7 +72,7 @@ use witnet_data_structures::{
     radon_report::{RadonReport, ReportContext},
     register_protocol_version,
     staking::prelude::*,
-    superblock::{ARSIdentities, AddSuperBlockVote, SuperBlockConsensus},
+    superblock::{Census, AddSuperBlockVote, SuperBlockConsensus},
     transaction::{RevealTransaction, TallyTransaction, Transaction},
     types::{
         visitor::{StatefulVisitor, Visitor},
@@ -2042,7 +2042,7 @@ impl ChainManager {
 
                 // Get the list of members of the ARS with reputation greater than 0
                 // the list itself is ordered by decreasing reputation
-                let ars_identities = ARSIdentities::new(ars_members);
+                let ars_identities = Census::new(ars_members);
 
                 // After the second hard fork, the superblock committee size must be at least 50
                 let min_committee_size = if after_second_hard_fork(block_epoch, get_environment()) {

--- a/node/src/actors/chain_manager/mod.rs
+++ b/node/src/actors/chain_manager/mod.rs
@@ -2043,17 +2043,17 @@ impl ChainManager {
                 // - In V1_X protocols, the census was sourced from the ARS. Namely, it contains
                 //   all identities with non-zero reputation, ordered by decreasing reputation.
                 // - In V2_x protocols, the census is instead sourced from the stakes tracker.
-                //   Namely, it contains the two top quartiles of the most powerful validators,
-                //   ordered by power.
+                //   Namely, it contains the two top quartiles of the validators that operate the
+                //   most stake.
                 // Exceptionally, if a base census has been constructed above, all of this logic is
                 // skipped, and the base census is used.
                 let census = Census::new(base_census.unwrap_or(
                     if ProtocolVersion::from_epoch(block_epoch) < ProtocolVersion::V2_0 {
                         reputation_engine.get_rep_ordered_ars_list()
                     } else {
-                        let all_validators = act.chain_state.stakes.by_rank(Capability::Mining, block_epoch);
+                        let all_validators = act.chain_state.stakes.validators_by_stake();
                         let half_count = act.chain_state.stakes.validators_count() / 2;
-                        let top_validators = all_validators.map(|(StakeKey { validator, .. }, _)| validator).take(half_count).collect();
+                        let top_validators = all_validators.map(|(validator, _)| validator).take(half_count).collect();
 
                         top_validators
                     }));


### PR DESCRIPTION
A very simple approach to implementing decentralized selection of superblock signing committees in protocol V2_0.

IMO, sampling the committee from the top 50% validators that operate the most stake should be more than enough to prevent attackers from spamming—or potentially overtaking—the committee with sock puppet identities.

solve #2501 