### PR TITLE
feat(json_rpc): multiple improvements: get_balance_2, query_stakes and query_powers

### DIFF
--- a/data_structures/src/capabilities.rs
+++ b/data_structures/src/capabilities.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use strum_macros::{EnumString, IntoStaticStr};
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 #[repr(u8)]
 #[derive(
@@ -7,8 +7,10 @@ use strum_macros::{EnumString, IntoStaticStr};
     Copy,
     Debug,
     Default,
+    EnumIter,
     EnumString,
     Eq,
+    Hash,
     IntoStaticStr,
     PartialEq,
     serde::Deserialize,

--- a/data_structures/src/transaction_factory.rs
+++ b/data_structures/src/transaction_factory.rs
@@ -97,7 +97,8 @@ impl NodeBalance2 {
     pub fn add_utxo_value(&mut self, utxo_value: u64, utxo_locked: bool) {
         if let NodeBalance2::One {
                 unlocked, locked, ..
-            } = self {
+            } = self 
+        {
             if utxo_locked {
                 locked.add_assign(utxo_value);
             } else {

--- a/data_structures/src/transaction_factory.rs
+++ b/data_structures/src/transaction_factory.rs
@@ -96,8 +96,8 @@ pub enum NodeBalance2 {
 impl NodeBalance2 {
     pub fn add_utxo_value(&mut self, utxo_value: u64, utxo_locked: bool) {
         if let NodeBalance2::One {
-                unlocked, locked, ..
-            } = self 
+            unlocked, locked, ..
+        } = self
         {
             if utxo_locked {
                 locked.add_assign(utxo_value);

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -1564,13 +1564,6 @@ impl Handler<QueryStakes> for ChainManager {
             stakes
         };
 
-        log::info!(
-            "queryStakes => found {} entries after filter {:?} w/ params {:?}",
-            stakes.len(),
-            filter,
-            params,
-        );
-
         // applies `offset`, if any, and limits number of returned records to `limit``
         Ok(stakes.into_iter().skip(offset).take(limit).collect())
     }
@@ -1601,10 +1594,9 @@ impl Handler<QueryStakingPowers> for ChainManager {
                 .unique_by(|(_, key, _)| key.validator)
                 .skip(offset)
                 .take(limit)
-                .into_iter()
                 .collect()
         } else {
-            powers.skip(offset).take(limit).into_iter().collect()
+            powers.skip(offset).take(limit).collect()
         };
 
         powers

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -1692,7 +1692,7 @@ impl Handler<GetBalance2> for ChainManager {
                 let stakes = self
                     .chain_state
                     .stakes
-                    .query_stakes(QueryStakesKey::Validator(pkh));
+                    .query_stakes(QueryStakesKey::Withdrawer(pkh));
                 if let Ok(stakes) = stakes {
                     balance.add_staked(stakes.iter().fold(0u64, |staked: u64, entry| {
                         staked.saturating_add(entry.value.coins.nanowits())

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -23,9 +23,10 @@ use witnet_data_structures::{
     transaction::{
         DRTransaction, StakeTransaction, Transaction, UnstakeTransaction, VTTransaction,
     },
-    transaction_factory::{self, NodeBalance},
+    transaction_factory::{self, NodeBalance, NodeBalance2},
     types::LastBeacon,
     utxo_pool::{get_utxo_info, UtxoInfo},
+    wit::Wit,
 };
 use witnet_util::timestamp::get_timestamp;
 use witnet_validations::validations::{block_reward, total_block_reward, validate_rad_request};
@@ -34,15 +35,16 @@ use crate::{
     actors::{
         chain_manager::{handlers::BlockBatches::*, BlockCandidate},
         messages::{
-            AddBlocks, AddCandidates, AddCommitReveal, AddSuperBlock, AddSuperBlockVote,
-            AddTransaction, Broadcast, BuildDrt, BuildStake, BuildUnstake, BuildVtt,
-            EpochNotification, EstimatePriority, GetBalance, GetBalanceTarget, GetBlocksEpochRange,
-            GetDataRequestInfo, GetHighestCheckpointBeacon, GetMemoryTransaction, GetMempool,
-            GetMempoolResult, GetNodeStats, GetProtocolInfo, GetReputation, GetReputationResult,
-            GetSignalingInfo, GetState, GetSuperBlockVotes, GetSupplyInfo, GetSupplyInfo2,
-            GetUtxoInfo, IsConfirmedBlock, PeersBeacons, QueryStakePowers, QueryStakes,
-            ReputationStats, Rewind, SendLastBeacon, SessionUnitResult, SetLastBeacon,
-            SetPeersLimits, SignalingInfo, SnapshotExport, SnapshotImport, TryMineBlock,
+            try_do_magic_into_pkh, AddBlocks, AddCandidates, AddCommitReveal, AddSuperBlock,
+            AddSuperBlockVote, AddTransaction, Broadcast, BuildDrt, BuildStake, BuildUnstake,
+            BuildVtt, EpochNotification, EstimatePriority, GetBalance, GetBalance2,
+            GetBalanceTarget, GetBlocksEpochRange, GetDataRequestInfo, GetHighestCheckpointBeacon,
+            GetMemoryTransaction, GetMempool, GetMempoolResult, GetNodeStats, GetProtocolInfo,
+            GetReputation, GetReputationResult, GetSignalingInfo, GetState, GetSuperBlockVotes,
+            GetSupplyInfo, GetSupplyInfo2, GetUtxoInfo, IsConfirmedBlock, PeersBeacons,
+            QueryStakePowers, QueryStakes, QueryStakesFilter, ReputationStats, Rewind,
+            SendLastBeacon, SessionUnitResult, SetLastBeacon, SetPeersLimits, SignalingInfo,
+            SnapshotExport, SnapshotImport, TryMineBlock,
         },
         sessions_manager::SessionsManager,
     },
@@ -1595,6 +1597,82 @@ impl Handler<GetDataRequestInfo> for ChainManager {
 
             Box::pin(fut)
         }
+    }
+}
+
+impl Handler<GetBalance2> for ChainManager {
+    type Result = Result<NodeBalance2, failure::Error>;
+
+    fn handle(&mut self, msg: GetBalance2, _ctx: &mut Self::Context) -> Self::Result {
+        if self.sm_state != StateMachine::Synced {
+            return Err(ChainManagerError::NotSynced {
+                current_state: self.sm_state,
+            }
+            .into());
+        }
+        let now = get_timestamp();
+        let balance = match msg {
+            GetBalance2::All(limits) => {
+                let mut balances: HashMap<PublicKeyHash, NodeBalance2> = HashMap::new();
+                for (_output_pointer, (vto, _)) in self.chain_state.unspent_outputs_pool.iter() {
+                    balances
+                        .entry(vto.pkh)
+                        .or_insert(NodeBalance2::One {
+                            locked: 0,
+                            staked: 0,
+                            unlocked: 0,
+                        })
+                        .add_utxo_value(vto.value, vto.time_lock as i64 > now);
+                }
+                let stakes = self.chain_state.stakes.query_stakes(QueryStakesFilter::All);
+                if let Ok(stakes) = stakes {
+                    stakes.iter().for_each(|entry| {
+                        balances
+                            .entry(entry.key.withdrawer)
+                            .or_insert(NodeBalance2::One {
+                                locked: 0,
+                                staked: 0,
+                                unlocked: 0,
+                            })
+                            .add_staked(entry.value.coins.into())
+                    });
+                }
+                balances.retain(|_pkh, balance| {
+                    balance.get_total().unwrap_or_default()
+                        >= Wit::from_nanowits(limits.min_balance)
+                        && balance.get_total().unwrap_or_default()
+                            <= Wit::from_nanowits(limits.max_balance.unwrap_or(u64::MAX))
+                });
+
+                NodeBalance2::Many(balances)
+            }
+            GetBalance2::Address(pkh) => {
+                let mut balance = transaction_factory::get_utxos_balance(
+                    &self.chain_state.unspent_outputs_pool,
+                    try_do_magic_into_pkh(pkh.clone()).map_err(|e| {
+                        log::warn!(
+                            "Failed to convert {:?} into a valid public key hash: {e}",
+                            pkh
+                        );
+                        e
+                    })?,
+                    now,
+                );
+                let stakes = self
+                    .chain_state
+                    .stakes
+                    .query_stakes(QueryStakesFilter::Withdrawer(pkh));
+                if let Ok(stakes) = stakes {
+                    balance.add_staked(stakes.iter().fold(0u64, |staked: u64, entry| {
+                        staked.saturating_add(entry.value.coins.nanowits())
+                    }));
+                }
+
+                balance
+            }
+        };
+
+        Ok(balance)
     }
 }
 

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -1584,7 +1584,7 @@ impl Handler<QueryStakingPowers> for ChainManager {
             .stakes
             .by_rank(msg.order_by, current_epoch)
             .enumerate()
-            .map(|(index, record)| (index, record.0, record.1));
+            .map(|(index, record)| (index + 1, record.0, record.1));
 
         // Skip first `offset` entries and take next `limit`.
         // If distinct is specified, retain just first appearance per validator.

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -20,7 +20,7 @@ use witnet_data_structures::{
     get_protocol_version,
     proto::versioning::ProtocolVersion,
     refresh_protocol_version,
-    staking::{errors::StakesError, prelude::StakeKey},
+    staking::{errors::StakesError, prelude::StakeKey, stakes::QueryStakesKey},
     transaction::{
         DRTransaction, StakeTransaction, Transaction, UnstakeTransaction, VTTransaction,
     },
@@ -1654,7 +1654,7 @@ impl Handler<GetBalance2> for ChainManager {
                         })
                         .add_utxo_value(vto.value, vto.time_lock as i64 > now);
                 }
-                let stakes = self.chain_state.stakes.query_stakes(QueryStakesFilter::All);
+                let stakes = self.chain_state.stakes.query_stakes(QueryStakesKey::All);
                 if let Ok(stakes) = stakes {
                     stakes.iter().for_each(|entry| {
                         balances
@@ -1677,21 +1677,22 @@ impl Handler<GetBalance2> for ChainManager {
                 NodeBalance2::Many(balances)
             }
             GetBalance2::Address(pkh) => {
+                let pkh = try_do_magic_into_pkh(pkh.clone()).map_err(|e| {
+                    log::warn!(
+                        "Failed to convert {:?} into a valid public key hash: {e}",
+                        pkh
+                    );
+                    e
+                })?;
                 let mut balance = transaction_factory::get_utxos_balance(
                     &self.chain_state.unspent_outputs_pool,
-                    try_do_magic_into_pkh(pkh.clone()).map_err(|e| {
-                        log::warn!(
-                            "Failed to convert {:?} into a valid public key hash: {e}",
-                            pkh
-                        );
-                        e
-                    })?,
+                    pkh,
                     now,
                 );
                 let stakes = self
                     .chain_state
                     .stakes
-                    .query_stakes(QueryStakesFilter::Withdrawer(pkh));
+                    .query_stakes(QueryStakesKey::Validator(pkh));
                 if let Ok(stakes) = stakes {
                     balance.add_staked(stakes.iter().fold(0u64, |staked: u64, entry| {
                         staked.saturating_add(entry.value.coins.nanowits())

--- a/node/src/actors/chain_manager/handlers.rs
+++ b/node/src/actors/chain_manager/handlers.rs
@@ -9,6 +9,7 @@ use std::{
 use actix::{prelude::*, ActorFutureExt, WrapFuture};
 use futures::future::Either;
 
+use itertools::Itertools;
 use witnet_data_structures::{
     chain::{
         tapi::ActiveWips, Block, ChainInfo, ChainState, CheckpointBeacon, ConsensusConstantsWit2,
@@ -1462,10 +1463,39 @@ impl Handler<QueryStakes> for ChainManager {
     type Result = <QueryStakes as Message>::Result;
 
     fn handle(&mut self, msg: QueryStakes, _ctx: &mut Self::Context) -> Self::Result {
-        // build address from public key hash
-        let stakes = self.chain_state.stakes.query_stakes(msg.filter);
+        // query stakes from current chain state
+        let mut stakes = self
+            .chain_state
+            .stakes
+            .query_stakes(msg.filter)
+            .map_err(StakesError::from)?;
+        // filter out stake entries whose last mining and witnessing epochs are previous to `epoch`
+        let epoch: u32 = if msg.limits.since >= 0 {
+            msg.limits.since.try_into().inspect_err(|&e| {
+                log::warn!("Invalid 'since' limit on QueryStakes: {}", e);
+            })?
+        } else {
+            (self.current_epoch.unwrap() as i64 + msg.limits.since)
+                .try_into()
+                .unwrap_or_default()
+        };
+        stakes.retain(|stake| {
+            let nonce: u32 = stake.value.nonce.try_into().unwrap_or_default();
+            stake.value.epochs.mining >= epoch && stake.value.epochs.mining != nonce
+                || (stake.value.epochs.witnessing >= epoch
+                    && stake.value.epochs.witnessing != nonce)
+        });
+        if msg.limits.distinct {
+            // if only distinct validators are required, retain only first appearence in the stakes array:
+            let stakes = stakes
+                .into_iter()
+                .unique_by(|stake| stake.key.validator)
+                .collect();
 
-        stakes.map_err(StakesError::from).map_err(Into::into)
+            Ok(stakes)
+        } else {
+            Ok(stakes)
+        }
     }
 }
 

--- a/node/src/actors/json_rpc/api.rs
+++ b/node/src/actors/json_rpc/api.rs
@@ -2239,22 +2239,8 @@ pub async fn authorize_stake(params: Result<AuthorizeStake, Error>) -> JsonRpcRe
         .await
 }
 
-/// Param for query_stakes
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum QueryStakesParams {
-    /// To query by stake validator
-    Validator(String),
-    /// To query by stake withdrawer
-    Withdrawer(String),
-    /// To query by stake validator and withdrawer
-    Key((String, String)),
-    /// To query all stake entries
-    All(bool),
-}
-
 /// Query the amount of nanowits staked by an address.
-pub async fn query_stakes(params: Result<Option<QueryStakesParams>, Error>) -> JsonRpcResult {
+pub async fn query_stakes(params: Result<Option<QueryStakes>, Error>) -> JsonRpcResult {
     // Short-circuit if parameters are wrong
     let params = params?;
     // If a withdrawer address is not specified, default to local node address

--- a/node/src/actors/json_rpc/api.rs
+++ b/node/src/actors/json_rpc/api.rs
@@ -1466,8 +1466,11 @@ pub async fn get_balance(params: Params) -> JsonRpcResult {
         target = params.into();
     };
 
-    let chain_manager_addr = ChainManager::from_registry();
+    if target == GetBalanceTarget::Own {
+        return Err(Error::invalid_params("Providing server's balance is not allowed"));
+    };
 
+    let chain_manager_addr = ChainManager::from_registry();
     chain_manager_addr
         .send(GetBalance { target, simple })
         .map(|res| {

--- a/node/src/actors/json_rpc/api.rs
+++ b/node/src/actors/json_rpc/api.rs
@@ -1467,7 +1467,9 @@ pub async fn get_balance(params: Params) -> JsonRpcResult {
     };
 
     if target == GetBalanceTarget::Own {
-        return Err(Error::invalid_params("Providing server's balance is not allowed"));
+        return Err(Error::invalid_params(
+            "Providing server's balance is not allowed",
+        ));
     };
 
     let chain_manager_addr = ChainManager::from_registry();

--- a/node/src/actors/messages.rs
+++ b/node/src/actors/messages.rs
@@ -346,14 +346,32 @@ impl Message for StakeAuthorization {
 }
 
 /// Message for querying stakes
-#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
-pub struct QueryStakePowers {
-    /// capabilities being searched for
-    pub capabilities: Vec<Capability>,
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryStakingPowers {
+    /// Retrieve only first appearence for every distinct validator (default: false)
+    pub distinct: Option<bool>,
+    /// Limits max number of entries to return (default: 0 == u16::MAX)
+    pub limit: Option<u16>,
+    /// Skips first found entries (default: 0)
+    pub offset: Option<usize>,
+    /// Order by specified capability (default: reverse order by coins)
+    pub order_by: Capability,
 }
 
-impl Message for QueryStakePowers {
-    type Result = Vec<(StakeKey<PublicKeyHash>, Vec<Power>)>;
+impl Default for QueryStakingPowers {
+    fn default() -> Self {
+        QueryStakingPowers {
+            distinct: Some(false),
+            limit: Some(u16::MAX),
+            offset: Some(0),
+            order_by: Capability::Mining,
+        }
+    }
+}
+
+impl Message for QueryStakingPowers {
+    type Result = Vec<(usize, StakeKey<PublicKeyHash>, Power)>;
 }
 
 /// Stake key for quering stakes

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -2022,14 +2022,16 @@ pub fn query_powers(
 ) -> Result<(), failure::Error> {
     let mut stream = start_client(addr)?;
 
-    let mut params = QueryStakingPowers::default();
-    params.distinct = Some(distinct);
-    params.order_by = match capability {
-        Some(c) => match Capability::from_str(&c) {
-            Ok(c) => c,
-            Err(_) => Capability::Mining,
+    let params = QueryStakingPowers {
+        distinct: Some(distinct),
+        order_by: match capability {
+            Some(c) => match Capability::from_str(&c) {
+                Ok(c) => c,
+                Err(_) => Capability::Mining,
+            },
+            None => Capability::Mining,
         },
-        None => Capability::Mining,
+        ..Default::default()
     };
 
     let response = send_request(

--- a/src/cli/node/json_rpc_client.rs
+++ b/src/cli/node/json_rpc_client.rs
@@ -56,7 +56,7 @@ use witnet_node::actors::{
     messages::{
         AuthorizeStake, BuildDrt, BuildStakeParams, BuildStakeResponse, BuildUnstakeParams,
         BuildVtt, GetBalanceTarget, GetReputationResult, MagicEither, QueryStakes,
-        QueryStakesFilter, QueryStakesLimits, SignalingInfo, StakeAuthorization,
+        QueryStakesFilter, SignalingInfo, StakeAuthorization,
     },
 };
 use witnet_rad::types::RadonTypes;
@@ -1957,26 +1957,23 @@ pub fn query_stakes(
     let mut stream = start_client(addr)?;
     let params = QueryStakes {
         filter: match (validator, withdrawer) {
-            (Some(validator), Some(withdrawer)) => QueryStakesFilter {
+            (Some(validator), Some(withdrawer)) => Some(QueryStakesFilter {
                 validator: Some(MagicEither::Left(validator)),
                 withdrawer: Some(MagicEither::Left(withdrawer)),
-            },
-            (Some(validator), None) => QueryStakesFilter {
+            }),
+            (Some(validator), None) => Some(QueryStakesFilter {
                 validator: Some(MagicEither::Left(validator)),
                 withdrawer: None,
-            },
-            (None, Some(withdrawer)) => QueryStakesFilter {
+            }),
+            (None, Some(withdrawer)) => Some(QueryStakesFilter {
                 validator: None,
                 withdrawer: Some(MagicEither::Left(withdrawer)),
-            },
-            (None, None) => QueryStakesFilter {
-                validator: None,
-                withdrawer: None,
-            },
+            }),
+            (None, None) => None,
         },
-        limits: QueryStakesLimits::default(),
+        params: None,
     };
-    
+
     let response = send_request(
         &mut stream,
         &format!(

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -295,15 +295,8 @@ pub fn exec_cmd(
             node,
             validator,
             withdrawer,
-            all,
             long,
-        } => rpc::query_stakes(
-            node.unwrap_or(default_jsonrpc),
-            validator,
-            withdrawer,
-            all,
-            long,
-        ),
+        } => rpc::query_stakes(node.unwrap_or(default_jsonrpc), validator, withdrawer, long),
         Command::QueryPowers {
             node,
             capability,
@@ -840,8 +833,6 @@ pub enum Command {
         validator: Option<String>,
         #[structopt(short = "w", long = "withdrawer")]
         withdrawer: Option<String>,
-        #[structopt(short = "a", long = "all")]
-        all: bool,
         #[structopt(short = "l", long = "long")]
         long: bool,
     },

--- a/src/cli/node/with_node.rs
+++ b/src/cli/node/with_node.rs
@@ -300,8 +300,8 @@ pub fn exec_cmd(
         Command::QueryPowers {
             node,
             capability,
-            all,
-        } => rpc::query_powers(node.unwrap_or(default_jsonrpc), capability, all),
+            distinct,
+        } => rpc::query_powers(node.unwrap_or(default_jsonrpc), capability, distinct),
         Command::Unstake {
             node,
             operator,
@@ -848,8 +848,8 @@ pub enum Command {
         node: Option<SocketAddr>,
         #[structopt(short = "c", long = "capability")]
         capability: Option<String>,
-        #[structopt(short = "a", long = "all")]
-        all: bool,
+        #[structopt(short = "d", long = "distinct")]
+        distinct: bool,
     },
     #[structopt(name = "unstake", about = "Create an unstake transaction")]
     Unstake {


### PR DESCRIPTION
Provides Wit/2 relevant information at the toolkit's CLI and Typescript library level:
  - **`npx witnet network`** ...
    - `holders`: get locked, unlocked and staked balances for specified min/max balance range.
    - `powers`: get current staking powers for specified limit/offset range, supporting distinct.
    - `senate`: get distinct validators having validated at least one block during previous number of epochs.
    - `stakers`: get stake entries for specified limit/offset range, supporting optional distinct and since parameters.

  - **`npx witnet farm`** ...
    - `rankings`: Sort identities by their highest staking power ranking at present time for specified capability.
    - `withdrawers`: get identities currently delegating stake in farm nodes.
  - **`npx witnet inspect`** ...
    - `validators`: show validators treasuring delegated stake from specified address.
    - `withdrawers`: show withdrawers currently delegating stake to specified address.
  