### PR TITLE
feat(json_rpc): return extra fields in getTransactions

### DIFF
--- a/data_structures/src/superblock.rs
+++ b/data_structures/src/superblock.rs
@@ -490,7 +490,7 @@ impl SuperBlockState {
                 // (assume this takes a week).
                 // Add 7 x 1_920 epochs to take into account the activation delay for V2_0:
                 // 3_048_960 + 7 x 1_920 + 7 x 1_920 = 3_075_840
-                // 
+                //
                 // After that, wit/2.0 should be activated with a fixed superblock bootstrap
                 // committee.
                 //

--- a/node/src/actors/json_rpc/api.rs
+++ b/node/src/actors/json_rpc/api.rs
@@ -1023,18 +1023,18 @@ pub struct GetTransactionOutput {
     pub transaction: Transaction,
     /// Weight of the transaction
     pub weight: u32,
-    /// Hash of the block that contains this transaction in hex format,
-    /// or "pending" if the transaction has not been included in any block yet
-    pub block_hash: String,
     /// Epoch of the block that contains this transaction, or None if the transaction has not been
     /// included in any block yet
     pub block_epoch: Option<Epoch>,
+    /// Hash of the block that contains this transaction in hex format,
+    /// or "pending" if the transaction has not been included in any block yet
+    pub block_hash: String,
+    /// Timestamp of the block that contains this transaction, or None not included yet
+    pub block_timestamp: Option<i64>,
     /// True if the block that includes this transaction has been confirmed by a superblock
     pub confirmed: bool,
     /// Number of epochs since this transaction got included in a block
     pub confirmations: Option<u32>,
-    /// Timestamp of the block that contains this transaction, or None not included yet
-    pub block_timestamp: Option<i64>,
 }
 
 /// Get transaction by hash


### PR DESCRIPTION
- [Inlcude extra fields in `getTransactions` JSON-RPC call](https://github.com/witnet/witnet-rust/pull/2619/commits/90de74c94ba469ea0c9304008ff03c8674f7cc7f):
  - `block_timestamp`: Timestamp of the block that contains this transaction, or None not included yet.
  - `confirmations`: Number of epochs since this transaction got included in a block.
 - [Sort GetTransactionOutput fields in alphabetical order](https://github.com/witnet/witnet-rust/pull/2619/commits/bf83a311788733e94fcb09d69c5bfad30e9cf455)
  