### PR TITLE
feat(json_rpc): accept reading bigints from strings when parsing raw transactions

### DIFF
--- a/data_structures/src/chain/mod.rs
+++ b/data_structures/src/chain/mod.rs
@@ -11,12 +11,12 @@ use std::{
 
 use bech32::{FromBase32, ToBase32};
 use bls_signatures_rs::{bn256, bn256::Bn256, MultiSignature};
+use core::fmt::Display;
 use ethereum_types::U256;
 use failure::Fail;
 use futures::future::BoxFuture;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Deserializer, Serialize};
-use core::fmt::Display;
 
 use partial_struct::PartialStruct;
 use witnet_crypto::{
@@ -1605,26 +1605,12 @@ pub struct ValueTransferOutput {
     /// Address that will receive the value
     pub pkh: PublicKeyHash,
     /// Transferred value in nanowits
-    #[serde(
-        serialize_with = "u64_to_string",
-        deserialize_with = "number_from_string"
-    )]
+    #[serde(deserialize_with = "number_from_string")]
     pub value: u64,
     /// The value attached to a time-locked output cannot be spent before the specified
     /// timestamp. That is, they cannot be used as an input in any transaction of a
     /// subsequent block proposed for an epoch whose opening timestamp predates the time lock.
     pub time_lock: u64,
-}
-
-pub fn u64_to_string<S>(val: &u64, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    if serializer.is_human_readable() {
-        serializer.serialize_str(&val.to_string())
-    } else {
-        serializer.serialize_u64(*val)
-    }
 }
 
 pub fn number_from_string<'de, T, D>(deserializer: D) -> Result<T, D::Error>
@@ -1668,10 +1654,12 @@ pub struct DataRequestOutput {
     /// Data request structure
     pub data_request: RADRequest,
     /// Reward in nanowits that will be earned by honest witnesses
+    #[serde(deserialize_with = "number_from_string")]
     pub witness_reward: u64,
     /// Number of witnesses that will resolve this data request
     pub witnesses: u16,
     /// This fee will be earn by the miner when include commits and/or reveals in the block
+    #[serde(deserialize_with = "number_from_string")]
     pub commit_and_reveal_fee: u64,
     /// The minimum percentage of non-error reveals required to consider this data request as
     /// "resolved" instead of as "error".
@@ -1683,6 +1671,7 @@ pub struct DataRequestOutput {
     /// this data request.
     /// This field must be >= collateral_minimum, or zero.
     /// If zero, it will be treated as collateral_minimum.
+    #[serde(deserialize_with = "number_from_string")]
     pub collateral: u64,
 }
 
@@ -1732,6 +1721,7 @@ impl DataRequestOutput {
 pub struct StakeOutput {
     pub authorization: KeyedSignature,
     pub key: StakeKey<PublicKeyHash>,
+    #[serde(deserialize_with = "number_from_string")]
     pub value: u64,
 }
 

--- a/data_structures/src/transaction.rs
+++ b/data_structures/src/transaction.rs
@@ -1,8 +1,9 @@
 use std::convert::TryFrom;
+use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 
 use protobuf::Message;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use witnet_crypto::{
     hash::calculate_sha256, merkle::FullMerkleTree, secp256k1::Message as Secp256k1Message,
@@ -863,12 +864,36 @@ impl UnstakeTransaction {
 pub struct UnstakeTransactionBody {
     pub operator: PublicKeyHash,
     pub withdrawal: ValueTransferOutput,
+    #[serde(deserialize_with = "number_from_string")]
     pub fee: u64,
+    #[serde(deserialize_with = "number_from_string")]
     pub nonce: u64,
 
     #[protobuf_convert(skip)]
     #[serde(skip)]
     hash: MemoHash,
+}
+
+pub fn number_from_string<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr + serde::Deserialize<'de>,
+    <T as FromStr>::Err: std::fmt::Display,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrInt<T> {
+        String(String),
+        Number(T),
+    }
+    if deserializer.is_human_readable() {
+        match StringOrInt::<T>::deserialize(deserializer)? {
+            StringOrInt::String(s) => s.parse::<T>().map_err(serde::de::Error::custom),
+            StringOrInt::Number(i) => Ok(i),
+        }
+    } else {
+        T::deserialize(deserializer)
+    }
 }
 
 impl UnstakeTransactionBody {


### PR DESCRIPTION
As to cope with Javascript RPC clients.

(Supersedes #2620)