### PR TITLE
fix(ci): replace docker-compose with docker compose plugin for E2E tests

### DIFF
--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -42,5 +42,8 @@ jobs:
           curl -L https://github.com/witnet/witnet-rust/releases/download/0.5.0-rc1/witnet-rust-testnet-5-tests-storage.tar.gz --output ./storage.tar.gz
           tar -zxf ./storage.tar.gz
 
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - name: Run debug E2E test
         run: just e2e-debug

--- a/Justfile
+++ b/Justfile
@@ -115,7 +115,7 @@ cross-compile target profile="release":
 # run the latest stable release in the latest testnet
 e2e-stable test_name="example" +flags="":
     TEST_NAME={{test_name}} \
-    docker-compose \
+    docker compose \
     -f docker/compose/e2e-stable/docker-compose.yaml \
     up \
     --scale=node=1 \
@@ -127,7 +127,7 @@ e2e-stable test_name="example" +flags="":
 e2e-debug test_name="example" +flags="":
     cargo build
     TEST_NAME={{test_name}} \
-    docker-compose \
+    docker compose \
     -f docker/compose/e2e-debug/docker-compose.yaml \
     up \
     --abort-on-container-exit \

--- a/docker/debug-run/Dockerfile
+++ b/docker/debug-run/Dockerfile
@@ -1,10 +1,12 @@
-FROM ubuntu:focal
+FROM ubuntu:noble
 
 # Install basic environment dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     libssl-dev \
-    curl
+    curl \
+    netcat-traditional \
+    jq
 
 # Clean up apt packages so the docker image is as compact as possible
 RUN apt-get clean && apt-get autoremove


### PR DESCRIPTION
fix(ci): replace docker-compose with docker compose plugin for E2E tests (#2659)

This PR replaces the deprecated Python-based `docker-compose` (v1) with the modern `docker compose` (v2, Go-based plugin) in the `Justfile` for the `e2e-stable` and `e2e-debug` recipes. This ensures compatibility with newer Docker CLI versions in CI environments, fixing failing end-to-end tests.

### Changes
- Updated `Justfile` to use `docker compose` instead of `docker-compose` in `e2e-stable` and `e2e-debug` recipes.

### Related Issues
- Fixes failing E2E tests in CI due to deprecated `docker-compose` usage.