### PR TITLE
fix(ci): update Rust toolchain to 1.89.0 for edition 2024 compatibility

### DIFF
--- a/.github/workflows/midnight.yml
+++ b/.github/workflows/midnight.yml
@@ -42,5 +42,8 @@ jobs:
           curl -L https://github.com/witnet/witnet-rust/releases/download/0.5.0-rc1/witnet-rust-testnet-5-tests-storage.tar.gz --output ./storage.tar.gz
           tar -zxf ./storage.tar.gz
 
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - name: Run debug E2E test
         run: just e2e-debug

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.88.0
+          toolchain: 1.89.0
           components: rustfmt,clippy
 
       - name: Show Rust toolchain

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.80.0
+          toolchain: 1.85.0
           components: rustfmt
 
       - name: Show Rust toolchain

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           subcrate: bridges/centralized-ethereum
 
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.65.0
+
       - name: Show Rust toolchain
         run: rustup show
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -63,7 +63,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.85.0
-          components: rustfmt
+          components: rustfmt,clippy
 
       - name: Show Rust toolchain
         run: rustup show

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.86.0
           components: rustfmt,clippy
 
       - name: Show Rust toolchain

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.86.0
+          toolchain: 1.88.0
           components: rustfmt,clippy
 
       - name: Show Rust toolchain

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -63,6 +63,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.65.0
+          components: rustfmt
 
       - name: Show Rust toolchain
         run: rustup show

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.65.0
+          toolchain: 1.80.0
           components: rustfmt
 
       - name: Show Rust toolchain

--- a/Justfile
+++ b/Justfile
@@ -115,7 +115,7 @@ cross-compile target profile="release":
 # run the latest stable release in the latest testnet
 e2e-stable test_name="example" +flags="":
     TEST_NAME={{test_name}} \
-    docker-compose \
+    docker compose \
     -f docker/compose/e2e-stable/docker-compose.yaml \
     up \
     --scale=node=1 \
@@ -127,7 +127,7 @@ e2e-stable test_name="example" +flags="":
 e2e-debug test_name="example" +flags="":
     cargo build
     TEST_NAME={{test_name}} \
-    docker-compose \
+    docker compose \
     -f docker/compose/e2e-debug/docker-compose.yaml \
     up \
     --abort-on-container-exit \


### PR DESCRIPTION
fix(ci): update Rust toolchain to 1.89.0 for edition 2024 compatibility (#2660)

This PR updates the Rust toolchain to version 1.89.0 in the CI workflow to support
`edition = "2024"` in `Cargo.toml` and resolve compatibility issues with newer Rust
features and lints, including `mismatched_lifetime_syntaxes`. It also ensures
`rustfmt` and `clippy` are available for `just fmt` and `just clippy` steps.

### Changes
- Added `dtolnay/rust-toolchain@stable` with `toolchain: 1.89.0` and
  `components: rustfmt,clippy` in `.github/workflows/pull_request.yml`.

### Related Issues
- Fixes failing CI in PRs due to `edition = "2024"` incompatibility with older Rust
  versions.